### PR TITLE
REFACTOR: Improve RegionColorize UI and Opacity-path performance

### DIFF
--- a/plugins/region-colorize/build.rs
+++ b/plugins/region-colorize/build.rs
@@ -62,6 +62,7 @@ fn main() {
             | OutFlags::UseOutputExtent
             | OutFlags::DeepColorAware
             | OutFlags::WideTimeInput
+            | OutFlags::SendUpdateParamsUI
             ,
         ),
         Property::AE_Effect_Global_OutFlags_2( 

--- a/plugins/region-colorize/src/lib.rs
+++ b/plugins/region-colorize/src/lib.rs
@@ -1,8 +1,8 @@
 #![allow(clippy::drop_non_drop, clippy::question_mark)]
 
 use after_effects as ae;
-use std::collections::VecDeque;
 use std::env;
+use std::time::{Duration, Instant};
 
 use ae::pf::*;
 use utils::ToPixel;
@@ -14,17 +14,22 @@ enum Params {
     Mode,
     Seed,
     UseOriginalAlpha,
+    GradientPoint,
+    ModeRandomness,
+    PositionCenterX,
+    PositionCenterY,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 enum Mode {
     RandomColor,
     PositionColor,
     IndexMaskSequential,
     IndexMaskRandom,
+    IndexMaskPointDistance,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 enum RegionSource {
     Opacity,
     Color,
@@ -38,7 +43,9 @@ struct RegionInfo {
 }
 
 #[derive(Default)]
-struct Plugin {}
+struct Plugin {
+    aegp_id: Option<ae::aegp::PluginId>,
+}
 
 ae::define_effect!(Plugin, (), Params);
 
@@ -74,7 +81,7 @@ impl AdobePluginGlobal for Plugin {
             }),
         )?;
 
-        params.add(
+        params.add_with_flags(
             Params::Mode,
             "Mode",
             PopupDef::setup(|d| {
@@ -83,9 +90,12 @@ impl AdobePluginGlobal for Plugin {
                     "Position Color",
                     "Index Gradient (Sequential)",
                     "Index Gradient (Random)",
+                    "Index Gradient (Point Distance)",
                 ]);
                 d.set_default(1);
             }),
+            ae::ParamFlag::SUPERVISE,
+            ae::ParamUIFlags::empty(),
         )?;
 
         params.add(
@@ -106,6 +116,59 @@ impl AdobePluginGlobal for Plugin {
             CheckBoxDef::setup(|d| {
                 d.set_default(false);
             }),
+        )?;
+
+        params.add_with_flags(
+            Params::GradientPoint,
+            "Gradient Point",
+            PointDef::setup(|p| {
+                p.set_default((0.0, 0.0));
+            }),
+            ae::ParamFlag::empty(),
+            ae::ParamUIFlags::INVISIBLE,
+        )?;
+
+        params.add(
+            Params::ModeRandomness,
+            "Randomness (Position/Index)",
+            FloatSliderDef::setup(|d| {
+                d.set_valid_min(0.0);
+                d.set_valid_max(1.0);
+                d.set_slider_min(0.0);
+                d.set_slider_max(1.0);
+                d.set_default(0.0);
+                d.set_precision(3);
+            }),
+        )?;
+
+        params.add_with_flags(
+            Params::PositionCenterX,
+            "Position Center X",
+            FloatSliderDef::setup(|d| {
+                d.set_valid_min(0.0);
+                d.set_valid_max(1.0);
+                d.set_slider_min(0.0);
+                d.set_slider_max(1.0);
+                d.set_default(0.5);
+                d.set_precision(3);
+            }),
+            ae::ParamFlag::empty(),
+            ae::ParamUIFlags::INVISIBLE,
+        )?;
+
+        params.add_with_flags(
+            Params::PositionCenterY,
+            "Position Center Y",
+            FloatSliderDef::setup(|d| {
+                d.set_valid_min(0.0);
+                d.set_valid_max(1.0);
+                d.set_slider_min(0.0);
+                d.set_slider_max(1.0);
+                d.set_default(0.5);
+                d.set_precision(3);
+            }),
+            ae::ParamFlag::empty(),
+            ae::ParamUIFlags::INVISIBLE,
         )?;
 
         Ok(())
@@ -130,7 +193,13 @@ impl AdobePluginGlobal for Plugin {
                 );
             }
             ae::Command::GlobalSetup => {
+                out_data.set_out_flag(OutFlags::SendUpdateParamsUi, true);
                 out_data.set_out_flag2(OutFlags2::SupportsSmartRender, true);
+                if let Ok(suite) = ae::aegp::suites::Utility::new()
+                    && let Ok(plugin_id) = suite.register_with_aegp("AOD_RegionColorize")
+                {
+                    self.aegp_id = Some(plugin_id);
+                }
             }
             ae::Command::Render {
                 in_layer,
@@ -168,6 +237,15 @@ impl AdobePluginGlobal for Plugin {
 
                 cb.checkin_layer_pixels(0)?;
             }
+            ae::Command::UserChangedParam { param_index } => {
+                if params.type_at(param_index) == Params::Mode {
+                    out_data.set_out_flag(OutFlags::RefreshUi, true);
+                }
+            }
+            ae::Command::UpdateParamsUi => {
+                let mut params_copy = params.cloned();
+                self.update_params_ui(in_data, &mut params_copy)?;
+            }
             _ => {}
         }
         Ok(())
@@ -175,6 +253,84 @@ impl AdobePluginGlobal for Plugin {
 }
 
 impl Plugin {
+    fn update_params_ui(
+        &self,
+        in_data: InData,
+        params: &mut Parameters<Params>,
+    ) -> Result<(), Error> {
+        let mode = mode_from_popup(params.get(Params::Mode)?.as_popup()?.value());
+        let show_gradient_point = matches!(mode, Mode::IndexMaskPointDistance);
+        let show_position_center = matches!(mode, Mode::PositionColor);
+        let show_mode_randomness = !matches!(mode, Mode::RandomColor);
+
+        self.set_param_visible(in_data, params, Params::GradientPoint, show_gradient_point)?;
+        self.set_param_visible(
+            in_data,
+            params,
+            Params::ModeRandomness,
+            show_mode_randomness,
+        )?;
+        self.set_param_visible(
+            in_data,
+            params,
+            Params::PositionCenterX,
+            show_position_center,
+        )?;
+        self.set_param_visible(
+            in_data,
+            params,
+            Params::PositionCenterY,
+            show_position_center,
+        )?;
+        Ok(())
+    }
+
+    fn set_param_visible(
+        &self,
+        in_data: InData,
+        params: &mut Parameters<Params>,
+        id: Params,
+        visible: bool,
+    ) -> Result<(), Error> {
+        if in_data.is_premiere() {
+            return Self::set_param_ui_flag(params, id, ae::pf::ParamUIFlags::INVISIBLE, !visible);
+        }
+
+        if let Some(plugin_id) = self.aegp_id {
+            let effect = in_data.effect();
+            if let Some(index) = params.index(id)
+                && let Ok(effect_ref) = effect.aegp_effect(plugin_id)
+                && let Ok(stream) = effect_ref.new_stream_by_index(plugin_id, index as i32)
+            {
+                return stream.set_dynamic_stream_flag(
+                    ae::aegp::DynamicStreamFlags::Hidden,
+                    false,
+                    !visible,
+                );
+            }
+        }
+
+        Self::set_param_ui_flag(params, id, ae::pf::ParamUIFlags::INVISIBLE, !visible)
+    }
+
+    fn set_param_ui_flag(
+        params: &mut Parameters<Params>,
+        id: Params,
+        flag: ae::pf::ParamUIFlags,
+        status: bool,
+    ) -> Result<(), Error> {
+        let flag_bits = flag.bits();
+        let current_status = (params.get(id)?.ui_flags().bits() & flag_bits) != 0;
+        if current_status == status {
+            return Ok(());
+        }
+
+        let mut p = params.get_mut(id)?;
+        p.set_ui_flag(flag, status);
+        p.update_param_ui()?;
+        Ok(())
+    }
+
     fn do_render(
         &self,
         _in_data: InData,
@@ -183,22 +339,48 @@ impl Plugin {
         mut out_layer: Layer,
         params: &mut Parameters<Params>,
     ) -> Result<(), Error> {
+        let profile_enabled = profiling_enabled();
+        let profile_total_start = Instant::now();
+
         let w = in_layer.width();
         let h = in_layer.height();
         let n = w * h;
         let progress_final = out_layer.height() as i32;
         let out_world_type = out_layer.world_type();
 
-        let mode = match params.get(Params::Mode)?.as_popup()?.value() {
-            2 => Mode::PositionColor,
-            3 => Mode::IndexMaskSequential,
-            4 => Mode::IndexMaskRandom,
-            _ => Mode::RandomColor,
-        };
+        let mode = mode_from_popup(params.get(Params::Mode)?.as_popup()?.value());
 
         let region_source = match params.get(Params::RegionSource)?.as_popup()?.value() {
             2 => RegionSource::Color,
             _ => RegionSource::Opacity,
+        };
+
+        let mode_randomness = params
+            .get(Params::ModeRandomness)?
+            .as_float_slider()?
+            .value() as f32;
+        let mode_randomness = mode_randomness.clamp(0.0, 1.0);
+
+        let gradient_point = if matches!(mode, Mode::IndexMaskPointDistance) {
+            let point_param = params.get(Params::GradientPoint)?;
+            let point = point_param.as_point()?;
+            point_value_f32(&point)
+        } else {
+            (0.0, 0.0)
+        };
+
+        let position_center = if matches!(mode, Mode::PositionColor) {
+            let x = params
+                .get(Params::PositionCenterX)?
+                .as_float_slider()?
+                .value() as f32;
+            let y = params
+                .get(Params::PositionCenterY)?
+                .as_float_slider()?
+                .value() as f32;
+            (x.clamp(0.0, 1.0), y.clamp(0.0, 1.0))
+        } else {
+            (0.5, 0.5)
         };
 
         let seed = params.get(Params::Seed)?.as_slider()?.value().max(0) as u32;
@@ -210,13 +392,20 @@ impl Plugin {
 
         let in_world_type = in_layer.world_type();
         let mut base_label: Vec<u32> = vec![0; n];
-        let mut alpha_map: Vec<f32> = vec![1.0; n];
+        let mut alpha_map: Option<Vec<f32>> = if use_original_alpha {
+            Some(vec![1.0; n])
+        } else {
+            None
+        };
 
+        let read_start = Instant::now();
         for y in 0..h {
             for x in 0..w {
                 let idx = y * w + x;
                 let px = read_pixel_f32(&in_layer, in_world_type, x, y);
-                alpha_map[idx] = px.alpha;
+                if let Some(alpha_map) = alpha_map.as_mut() {
+                    alpha_map[idx] = px.alpha;
+                }
                 if px.alpha < alpha_thr {
                     base_label[idx] = 0;
                     continue;
@@ -227,11 +416,14 @@ impl Plugin {
                 };
             }
         }
+        let read_elapsed = read_start.elapsed();
 
         let mut region_id: Vec<u32> = vec![0; n];
-        let mut regions: Vec<RegionInfo> = vec![RegionInfo::default()];
-        let mut queue: VecDeque<usize> = VecDeque::new();
+        let mut regions: Vec<RegionInfo> = Vec::with_capacity((n / 64).max(2));
+        regions.push(RegionInfo::default());
+        let mut queue: Vec<usize> = Vec::with_capacity((w.max(h)).max(64));
 
+        let ccl_start = Instant::now();
         for y in 0..h {
             for x in 0..w {
                 let i = y * w + x;
@@ -243,9 +435,13 @@ impl Plugin {
                 let new_id = regions.len() as u32;
                 regions.push(RegionInfo::default());
                 region_id[i] = new_id;
-                queue.push_back(i);
+                queue.clear();
+                queue.push(i);
+                let mut head = 0usize;
 
-                while let Some(idx) = queue.pop_front() {
+                while head < queue.len() {
+                    let idx = queue[head];
+                    head += 1;
                     let px = idx % w;
                     let py = idx / w;
 
@@ -258,36 +454,38 @@ impl Plugin {
                         let j = idx - 1;
                         if region_id[j] == 0 && base_label[j] == lbl {
                             region_id[j] = new_id;
-                            queue.push_back(j);
+                            queue.push(j);
                         }
                     }
                     if px + 1 < w {
                         let j = idx + 1;
                         if region_id[j] == 0 && base_label[j] == lbl {
                             region_id[j] = new_id;
-                            queue.push_back(j);
+                            queue.push(j);
                         }
                     }
                     if py > 0 {
                         let j = idx - w;
                         if region_id[j] == 0 && base_label[j] == lbl {
                             region_id[j] = new_id;
-                            queue.push_back(j);
+                            queue.push(j);
                         }
                     }
                     if py + 1 < h {
                         let j = idx + w;
                         if region_id[j] == 0 && base_label[j] == lbl {
                             region_id[j] = new_id;
-                            queue.push_back(j);
+                            queue.push(j);
                         }
                     }
                 }
             }
         }
+        let ccl_elapsed = ccl_start.elapsed();
 
         let region_count = regions.len().saturating_sub(1);
         let mut region_color: Vec<[f32; 3]> = vec![[0.0, 0.0, 0.0]; regions.len()];
+        let color_start = Instant::now();
 
         match mode {
             Mode::RandomColor => {
@@ -303,33 +501,74 @@ impl Plugin {
                     }
                     let cx = info.sum_x as f32 / info.count as f32;
                     let cy = info.sum_y as f32 / info.count as f32;
-                    *color = position_color(cx, cy, w, h);
+                    let base = position_color(cx, cy, w, h, position_center);
+                    let random = random_color(id as u32, seed ^ 0xD1B5_4A32);
+                    *color = [
+                        lerp(base[0], random[0], mode_randomness),
+                        lerp(base[1], random[1], mode_randomness),
+                        lerp(base[2], random[2], mode_randomness),
+                    ];
                 }
             }
-            Mode::IndexMaskSequential | Mode::IndexMaskRandom => {
+            Mode::IndexMaskSequential | Mode::IndexMaskRandom | Mode::IndexMaskPointDistance => {
                 if region_count == 0 {
                     // no regions
-                } else if matches!(mode, Mode::IndexMaskSequential) {
-                    for (id, color) in region_color.iter_mut().enumerate().skip(1) {
-                        let t = grayscale_for_rank(id - 1, region_count);
-                        *color = [t, t, t];
-                    }
                 } else {
-                    let mut order: Vec<(u32, usize)> = Vec::with_capacity(region_count);
-                    for id in 1..=region_count {
-                        let key = hash_u32(id as u32 ^ seed ^ 0x9e3779b9);
-                        order.push((key, id));
-                    }
-                    order.sort_by_key(|(key, _)| *key);
+                    let mut base_rank: Vec<usize> = vec![0; regions.len()];
+                    match mode {
+                        Mode::IndexMaskSequential => {
+                            for (id, rank) in base_rank.iter_mut().enumerate().skip(1) {
+                                *rank = id - 1;
+                            }
+                        }
+                        Mode::IndexMaskRandom => {
+                            let mut order: Vec<(u32, usize)> = Vec::with_capacity(region_count);
+                            for id in 1..=region_count {
+                                let key = hash_u32(id as u32 ^ seed ^ 0x9E37_79B9);
+                                order.push((key, id));
+                            }
+                            order.sort_by_key(|(key, _)| *key);
+                            for (rank, (_, id)) in order.iter().enumerate() {
+                                base_rank[*id] = rank;
+                            }
+                        }
+                        Mode::IndexMaskPointDistance => {
+                            let mut order: Vec<(f32, usize)> = Vec::with_capacity(region_count);
+                            for (id, info) in
+                                regions.iter().enumerate().take(region_count + 1).skip(1)
+                            {
+                                if info.count == 0 {
+                                    continue;
+                                }
+                                let cx = info.sum_x as f32 / info.count as f32 + 0.5;
+                                let cy = info.sum_y as f32 / info.count as f32 + 0.5;
+                                let dx = cx - gradient_point.0;
+                                let dy = cy - gradient_point.1;
+                                let dist2 = dx * dx + dy * dy;
+                                order.push((dist2, id));
+                            }
 
-                    for (rank, (_, id)) in order.iter().enumerate() {
-                        let t = grayscale_for_rank(rank, region_count);
-                        region_color[*id] = [t, t, t];
+                            order.sort_by(|a, b| a.0.total_cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+
+                            for (rank, (_, id)) in order.iter().enumerate() {
+                                base_rank[*id] = rank;
+                            }
+                        }
+                        Mode::RandomColor | Mode::PositionColor => {}
+                    }
+
+                    for id in 1..=region_count {
+                        let base_t = grayscale_for_rank(base_rank[id], region_count);
+                        let random_t = random01(hash_u32(id as u32 ^ seed ^ 0xA361_95A7));
+                        let t = lerp(base_t, random_t, mode_randomness);
+                        region_color[id] = [t, t, t];
                     }
                 }
             }
         }
+        let color_elapsed = color_start.elapsed();
 
+        let write_start = Instant::now();
         out_layer.iterate(0, progress_final, None, |x, y, mut dst| {
             let idx = y as usize * w + x as usize;
             let id = region_id[idx] as usize;
@@ -340,7 +579,7 @@ impl Plugin {
                 blue: region_color[id][2],
             };
 
-            if use_original_alpha {
+            if let Some(alpha_map) = alpha_map.as_ref() {
                 let mut out_alpha = alpha_map[idx];
                 if !out_alpha.is_finite() {
                     out_alpha = 0.0;
@@ -362,8 +601,43 @@ impl Plugin {
 
             Ok(())
         })?;
+        let write_elapsed = write_start.elapsed();
+
+        if profile_enabled {
+            let total_elapsed = profile_total_start.elapsed();
+            debugview_log(&format!(
+                "[AOD_RegionColorize][PROFILE] {}x{} mode={:?} source={:?} regions={} read={:.3}ms ccl={:.3}ms color={:.3}ms write={:.3}ms total={:.3}ms",
+                w,
+                h,
+                mode,
+                region_source,
+                region_count,
+                duration_ms(read_elapsed),
+                duration_ms(ccl_elapsed),
+                duration_ms(color_elapsed),
+                duration_ms(write_elapsed),
+                duration_ms(total_elapsed),
+            ));
+        }
 
         Ok(())
+    }
+}
+
+fn mode_from_popup(value: i32) -> Mode {
+    match value {
+        2 => Mode::PositionColor,
+        3 => Mode::IndexMaskSequential,
+        4 => Mode::IndexMaskRandom,
+        5 => Mode::IndexMaskPointDistance,
+        _ => Mode::RandomColor,
+    }
+}
+
+fn point_value_f32(point: &PointDef<'_>) -> (f32, f32) {
+    match point.float_value() {
+        Ok(p) => (p.x as f32, p.y as f32),
+        Err(_) => point.value(),
     }
 }
 
@@ -406,10 +680,12 @@ fn random_color(id: u32, seed: u32) -> [f32; 3] {
     [r, g, b]
 }
 
-fn position_color(x: f32, y: f32, w: usize, h: usize) -> [f32; 3] {
+fn position_color(x: f32, y: f32, w: usize, h: usize, center: (f32, f32)) -> [f32; 3] {
     let nx = if w > 1 { (x + 0.5) / w as f32 } else { 0.0 };
     let ny = if h > 1 { (y + 0.5) / h as f32 } else { 0.0 };
-    [nx, ny, 0.0]
+    let sx = (nx - center.0 + 0.5).clamp(0.0, 1.0);
+    let sy = (ny - center.1 + 0.5).clamp(0.0, 1.0);
+    [sx, sy, 0.0]
 }
 
 fn grayscale_for_rank(rank: usize, count: usize) -> f32 {
@@ -419,6 +695,46 @@ fn grayscale_for_rank(rank: usize, count: usize) -> f32 {
         (rank as f32) / (count.saturating_sub(1) as f32)
     }
 }
+
+fn lerp(a: f32, b: f32, t: f32) -> f32 {
+    a + (b - a) * t
+}
+
+fn random01(h: u32) -> f32 {
+    h as f32 / u32::MAX as f32
+}
+
+fn duration_ms(d: Duration) -> f64 {
+    d.as_secs_f64() * 1000.0
+}
+
+fn profiling_enabled() -> bool {
+    cfg!(debug_assertions)
+}
+
+#[cfg(target_os = "windows")]
+fn debugview_log(message: &str) {
+    use std::ffi::CString;
+    use std::os::raw::c_char;
+
+    #[link(name = "Kernel32")]
+    unsafe extern "system" {
+        fn OutputDebugStringA(lp_output_string: *const c_char);
+    }
+
+    let mut line = String::with_capacity(message.len() + 1);
+    line.push_str(message);
+    line.push('\n');
+    if let Ok(c) = CString::new(line) {
+        // SAFETY: CString guarantees a valid, null-terminated pointer.
+        unsafe {
+            OutputDebugStringA(c.as_ptr());
+        }
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn debugview_log(_message: &str) {}
 
 fn hash_u32(mut x: u32) -> u32 {
     x ^= x >> 16;


### PR DESCRIPTION
## Summary
- Add dynamic UI and profiling for RegionColorize.
- Add Index Gradient (Point Distance) mode and point parameter.
- Add Position Color center parameters shown only in Position mode.
- Optimize Opacity path using union-find CCL and alpha-only read.
- Reduce output conversion overhead by caching per-region output colors when possible.

## Validation
- cargo fmt --all
- cargo check -p region_colorize
- cargo clippy -p region_colorize
- cargo test -p region_colorize