### PR TITLE
FIX: Add alpha-only color space to color-quantize

### DIFF
--- a/plugins/color-quantize/src/gpu/wgpu/shaders/compute.wgsl
+++ b/plugins/color-quantize/src/gpu/wgpu/shaders/compute.wgsl
@@ -205,6 +205,11 @@ fn decode_feature_to_rgb(feature: vec3<f32>, color_space: u32) -> vec3<f32> {
         return clamp(vec3<f32>(r, g, b), vec3<f32>(0.0), vec3<f32>(1.0));
     }
 
+    if color_space == 5u {
+        let v = clamp01(feature.x);
+        return vec3<f32>(v, v, v);
+    }
+
     return clamp(linear_to_srgb(feature), vec3<f32>(0.0), vec3<f32>(1.0));
 }
 


### PR DESCRIPTION
## Summary
- Add Alpha Only to Color Space options in color-quantize
- Disable RGB Only parameter when Alpha Only is selected (dynamic UI)
- Ensure processing path uses alpha-only feature encoding and GPU decode path supports alpha-only grayscale output

## Validation
- cargo fmt --all -- --check
- cargo clippy -p color_quantize
- cargo test -p color_quantize