### PR TITLE
FIX: Correct workflow_run branch detection in release workflow

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -158,11 +158,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           TARGET_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+          SOURCE_BRANCH: ${{ github.event.workflow_run.head_branch || github.ref_name }}
         shell: bash
         run: |
           set -euo pipefail
 
-          BRANCH="${GITHUB_EVENT_WORKFLOW_RUN_HEAD_BRANCH:-${GITHUB_REF_NAME}}"
+          BRANCH="${SOURCE_BRANCH}"
           case "$BRANCH" in
             main)
               TAG_PREFIX="main-release"


### PR DESCRIPTION
## Summary
- Fix branch resolution in create_release workflow for workflow_run triggers
- Pass \\github.event.workflow_run.head_branch\\ into an explicit env var and use it in the script
- Keep existing behavior: main -> draft release, dev -> prerelease (not draft)

## Why
- The previous script read a non-existent shell env variable and could fall back to \\GITHUB_REF_NAME\\, causing dev-origin runs to be treated as main.
