### PR TITLE
FIX: Repair cargo-generate template for empty feature sets

### DIFF
--- a/templates/plugin/cargo-generate.toml
+++ b/templates/plugin/cargo-generate.toml
@@ -1,6 +1,6 @@
 [placeholders]
 description = { prompt = "Short description of the plugin", type = "string" }
-features = { prompt = "Select features", type = "array", choices = [
+features = { prompt = "Select features", type = "array", default = [], choices = [
     "imageproc",
     "rustfft",
     "nalgebra",

--- a/templates/plugin/post-script.rhai
+++ b/templates/plugin/post-script.rhai
@@ -2,5 +2,5 @@ let features = variable::get("features").to_string();
 let has_wgpu = features.contains("wgpu");
 
 if !has_wgpu {
-    fs::remove_dir_all("src/gpu");
+    file::delete("src/gpu");
 }


### PR DESCRIPTION
## Summary
- Fix Rhai post hook to use ile::delete instead of missing s module
- Add default = [] for eatures placeholder to support non-interactive empty selections

## Validation
- Reproduced template generation with eatures=[] via --template-values-file
- Confirmed generation succeeds without src/gpu
