### PR TITLE
FIX: Add channel and color space controls to ImageCalculate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1202,6 +1202,8 @@ version = "0.1.0"
 dependencies = [
  "after-effects",
  "chrono",
+ "color-art",
+ "palette",
  "pipl",
  "utils",
 ]

--- a/plugins/image-calculate/Cargo.toml
+++ b/plugins/image-calculate/Cargo.toml
@@ -13,6 +13,8 @@ catch-panics = []
 
 [dependencies]
 after-effects = { workspace = true }
+color-art = "0.3"
+palette = "0.7.6"
 utils = { path = "../../crates/utils" }
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary
- Add channel selection for operation (RGBA, RGB, R, G, B, A, Luminance)
- Add calculation color space selection (RGB/OKLAB/OKLCH/LAB/YIQ/YUV/YCbCr/HSL/HSV/CMYK)
- Apply math in selected channel/color space while keeping existing clamp and alpha options

## Verification
- cargo fmt --all -- --check
- cargo clippy --workspace
- cargo test