### PR TITLE
FIX: Improve release workflow performance and publish behavior

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,4 +1,4 @@
-name: Create Release Plugin from main
+name: Create Release Plugin
 
 on:
   workflow_run:
@@ -11,7 +11,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: plugin-prerelease-${{ github.event.workflow_run.head_branch || github.ref_name }}
+  group: plugin-release-${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref_name }}
   cancel-in-progress: true
 
 env:
@@ -19,11 +19,9 @@ env:
   CARGO_TARGET_DIR: ${{ github.workspace }}/target
   NO_INSTALL: "1"
 
-
 jobs:
   build:
-    # workflow_run の場合は CI 成功時のみ続行
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push') || (github.event_name == 'workflow_dispatch' && (github.ref_name == 'main' || github.ref_name == 'dev')) }}
     strategy:
       fail-fast: false
       matrix:
@@ -36,7 +34,6 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-          # workflow_run では GITHUB_SHA が「この workflow の実体」の SHA になるため、CI が走った SHA を明示して checkout
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
           submodules: recursive
 
@@ -63,8 +60,8 @@ jobs:
           which awk
           awk --version | head -n 1 || true
 
-      - name: Build (release)
-        run: just release
+      - name: Build and package (release-ci)
+        run: just release-ci
 
       - name: Package (macOS)
         if: runner.os == 'macOS'
@@ -79,7 +76,6 @@ jobs:
             SUFFIX="$(git rev-parse --short=12 HEAD)"
           fi
 
-          # zip ファイル名として危険な文字を潰す
           SUFFIX_SAFE="$(echo "$SUFFIX" | sed -E 's/[^A-Za-z0-9._-]+/_/g')"
           ZIP_NAME="aod-AE-plugins_macos_${SUFFIX_SAFE}.zip"
 
@@ -107,15 +103,12 @@ jobs:
           $tag = (git tag --points-at HEAD | Select-Object -First 1)
           if ($tag) { $suffix = $tag.Trim() } else { $suffix = (git rev-parse --short=12 HEAD).Trim() }
 
-          # Windows ファイル名として危険な文字を潰す
           $suffixSafe = ($suffix -replace '[^A-Za-z0-9._-]', '_')
           $zipName = "aod-AE-plugins_windows_$suffixSafe.zip"
 
           $releaseDir = Join-Path $env:CARGO_TARGET_DIR "release"
 
           New-Item -ItemType Directory -Force -Path dist\windows | Out-Null
-
-          # 念のため -File を付けて、見つからない場合はディレクトリ一覧を出して落とす
           $plugins = Get-ChildItem -Path $releaseDir -Filter *.aex -File -ErrorAction SilentlyContinue
           if (-not $plugins) {
             Write-Host "No .aex found in $releaseDir"
@@ -137,28 +130,85 @@ jobs:
             aod-AE-plugins_windows_*.zip
           if-no-files-found: error
 
-
-
   publish:
     needs: build
-    if: ${{ github.event_name != 'pull_request' && (github.event_name == 'workflow_run' || github.ref_name == 'main' || github.ref_name == 'dev') }}
+    if: ${{ needs.build.result == 'success' }}
     permissions:
       contents: write
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout source revision
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
           path: artifacts
           merge-multiple: true
 
+      - name: Resolve source branch
+        id: source_meta
+        env:
+          TARGET_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+          EVENT_BRANCH: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main dev
+
+          SHA="$TARGET_SHA"
+          if [ -z "$SHA" ]; then
+            SHA="$(git rev-parse HEAD)"
+          fi
+
+          branch=""
+          if [ "$EVENT_BRANCH" = "main" ] || [ "$EVENT_BRANCH" = "dev" ]; then
+            if git merge-base --is-ancestor "$SHA" "origin/$EVENT_BRANCH"; then
+              branch="$EVENT_BRANCH"
+            fi
+          fi
+
+          if [ -z "$branch" ]; then
+            in_main=0
+            in_dev=0
+            if git merge-base --is-ancestor "$SHA" origin/main; then in_main=1; fi
+            if git merge-base --is-ancestor "$SHA" origin/dev; then in_dev=1; fi
+
+            if [ "$in_main" -eq 1 ] && [ "$in_dev" -eq 0 ]; then
+              branch="main"
+            elif [ "$in_main" -eq 0 ] && [ "$in_dev" -eq 1 ]; then
+              branch="dev"
+            elif [ "$in_main" -eq 1 ] && [ "$in_dev" -eq 1 ]; then
+              if [ "$EVENT_BRANCH" = "main" ] || [ "$EVENT_BRANCH" = "dev" ]; then
+                branch="$EVENT_BRANCH"
+              elif [ "$SHA" = "$(git rev-parse origin/main)" ]; then
+                branch="main"
+              elif [ "$SHA" = "$(git rev-parse origin/dev)" ]; then
+                branch="dev"
+              else
+                echo "Unable to resolve source branch for $SHA (contained in both main and dev)." >&2
+                exit 1
+              fi
+            else
+              echo "Unsupported source SHA: $SHA" >&2
+              exit 1
+            fi
+          fi
+
+          echo "target_sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "source_branch=$branch" >> "$GITHUB_OUTPUT"
+
       - name: Prepare release tag
         id: draft_release
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          TARGET_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
-          SOURCE_BRANCH: ${{ github.event.workflow_run.head_branch || github.ref_name }}
+          TARGET_SHA: ${{ steps.source_meta.outputs.target_sha }}
+          SOURCE_BRANCH: ${{ steps.source_meta.outputs.source_branch }}
         shell: bash
         run: |
           set -euo pipefail
@@ -167,12 +217,12 @@ jobs:
           case "$BRANCH" in
             main)
               TAG_PREFIX="main-release"
-              IS_DRAFT="true"
+              IS_DRAFT="false"
               IS_PRERELEASE="false"
               ;;
             dev)
               TAG_PREFIX="dev-prerelease"
-              IS_DRAFT="false"
+              IS_DRAFT="true"
               IS_PRERELEASE="true"
               ;;
             *)
@@ -184,7 +234,6 @@ jobs:
           RELEASE_DATE="$(date -u +%Y%m%d)"
           BASE_TAG="${TAG_PREFIX}-${RELEASE_DATE}"
 
-          # 同日再実行で衝突する場合は連番 suffix を付与
           TAG="$BASE_TAG"
           if gh release view "$TAG" >/dev/null 2>&1; then
             found="false"
@@ -207,14 +256,16 @@ jobs:
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
           echo "is_draft=$IS_DRAFT" >> "$GITHUB_OUTPUT"
           echo "is_prerelease=$IS_PRERELEASE" >> "$GITHUB_OUTPUT"
+          echo "tag_prefix=$TAG_PREFIX" >> "$GITHUB_OUTPUT"
 
       - name: Create draft prerelease and upload assets
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          TARGET_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+          TARGET_SHA: ${{ steps.source_meta.outputs.target_sha }}
         shell: bash
         run: |
+          set -euo pipefail
           ls -la artifacts
           RELEASE_DATE="$(date -u +%Y-%m-%d)"
           TITLE_PREFIX="Release"
@@ -238,3 +289,33 @@ jobs:
             $DRAFT_FLAG \
             $PRERELEASE_FLAG \
             --generate-notes
+
+      - name: Delete stale draft releases
+        if: ${{ steps.draft_release.outputs.is_draft == 'true' && steps.draft_release.outputs.is_prerelease == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          CURRENT_TAG: ${{ steps.draft_release.outputs.tag }}
+          TAG_PREFIX: ${{ steps.draft_release.outputs.tag_prefix }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          stale_tags="$(gh api "repos/${GH_REPO}/releases?per_page=100" | jq -r --arg current "$CURRENT_TAG" --arg prefix "${TAG_PREFIX}-" '
+            .[]
+            | select(.draft == true)
+            | select(.tag_name != $current)
+            | select(.tag_name | startswith($prefix))
+            | .tag_name
+          ')"
+
+          if [ -z "$stale_tags" ]; then
+            echo "No stale draft releases to delete."
+            exit 0
+          fi
+
+          while IFS= read -r tag; do
+            [ -z "$tag" ] && continue
+            echo "Deleting stale draft: $tag"
+            gh release delete "$tag" --cleanup-tag --yes
+          done <<< "$stale_tags"

--- a/AdobePlugin.just
+++ b/AdobePlugin.just
@@ -5,14 +5,14 @@ TargetDir := env_var_or_default("CARGO_TARGET_DIR", WorkspaceRoot + "/target")
 
 [windows]
 build:
-    cargo build -p {{CrateName}}
+    if (-not $env:NO_CARGO_BUILD) { cargo build -p {{CrateName}} }
     if (-not $env:NO_INSTALL) { \
         Start-Process PowerShell -Verb runAs -ArgumentList "-command Set-Location '{{source_directory()}}'; Copy-Item -Force '{{TargetDir}}\debug\{{BinaryName}}.dll' 'C:\Program Files\Adobe\Common\Plug-ins\7.0\MediaCore\{{PluginName}}.aex'" \
     }
 
 [windows]
 release:
-    cargo build -p {{CrateName}} --release
+    if (-not $env:NO_CARGO_BUILD) { cargo build -p {{CrateName}} --release }
     Copy-Item -Force '{{TargetDir}}\release\{{BinaryName}}.dll' '{{TargetDir}}\release\{{PluginName}}.aex'
     if (-not $env:NO_INSTALL) { \
         Start-Process PowerShell -Verb runAs -ArgumentList "-command Set-Location '{{source_directory()}}'; Copy-Item -Force '{{TargetDir}}\release\{{BinaryName}}.dll' 'C:\Program Files\Adobe\Common\Plug-ins\7.0\MediaCore\{{PluginName}}.aex'" \
@@ -20,12 +20,12 @@ release:
 
 [macos]
 build:
-    cargo build -p {{CrateName}}
+    if [ -z "${NO_CARGO_BUILD:-}" ]; then cargo build -p {{CrateName}}; fi
     just -f {{justfile()}} create_bundle debug {{TargetDir}}
 
 [macos]
 release:
-    cargo build -p {{CrateName}} --release
+    if [ -z "${NO_CARGO_BUILD:-}" ]; then cargo build -p {{CrateName}} --release; fi
     just -f {{justfile()}} create_bundle release {{TargetDir}}
 
 [macos]
@@ -40,12 +40,14 @@ create_bundle profile TargetDir:
     mkdir -p {{TargetDir}}/{{profile}}/{{PluginName}}.plugin/Contents/MacOS
 
     if [ "{{profile}}" == "release" ]; then
-        # Build universal binary
-        rustup target add aarch64-apple-darwin
-        rustup target add x86_64-apple-darwin
+        if [ -z "${NO_CARGO_BUILD:-}" ]; then
+            # Build universal binary
+            rustup target add aarch64-apple-darwin
+            rustup target add x86_64-apple-darwin
 
-        cargo build -p {{CrateName}} --release --target x86_64-apple-darwin
-        cargo build -p {{CrateName}} --release --target aarch64-apple-darwin
+            cargo build -p {{CrateName}} --release --target x86_64-apple-darwin
+            cargo build -p {{CrateName}} --release --target aarch64-apple-darwin
+        fi
 
         cp {{TargetDir}}/x86_64-apple-darwin/release/{{BinaryName}}.rsrc {{TargetDir}}/{{profile}}/{{PluginName}}.plugin/Contents/Resources/{{PluginName}}.rsrc
         cp {{TargetDir}}/x86_64-apple-darwin/release/{{BinaryName}}_PkgInfo {{TargetDir}}/{{profile}}/{{PluginName}}.plugin/Contents/PkgInfo

--- a/Justfile
+++ b/Justfile
@@ -21,3 +21,29 @@ release:
 	set -euo pipefail
 	root="{{justfile_directory()}}"
 	find "$root/plugins" -name Justfile -type f -print0 | xargs -0 -I {} just -f "{}" release
+
+[windows]
+release-ci:
+	$ErrorActionPreference = "Stop"
+	cargo build --workspace --release
+	$root = "{{justfile_directory()}}"
+	$justfiles = Get-ChildItem -Path (Join-Path $root "plugins") -Filter Justfile -Recurse
+	$env:NO_CARGO_BUILD = "1"
+	try { \
+		$justfiles | ForEach-Object { just -f $_.FullName release } \
+	} finally { \
+		Remove-Item Env:NO_CARGO_BUILD -ErrorAction SilentlyContinue \
+	}
+
+[macos]
+release-ci:
+	#!/bin/bash
+	set -euo pipefail
+	root="{{justfile_directory()}}"
+	rustup target add x86_64-apple-darwin
+	rustup target add aarch64-apple-darwin
+	cargo build --workspace --release --target x86_64-apple-darwin
+	cargo build --workspace --release --target aarch64-apple-darwin
+	find "$root/plugins" -name Justfile -type f -print0 | while IFS= read -r -d '' justfile; do \
+		NO_CARGO_BUILD=1 just -f "$justfile" release; \
+	done


### PR DESCRIPTION
## Summary
- add elease-ci to root Justfile to compile workspace once and reuse artifacts for per-plugin packaging
- support NO_CARGO_BUILD in AdobePlugin.just to skip redundant cargo build in CI packaging phase
- update create_release workflow to use just release-ci and only run on CI push completions for main/dev
- resolve source branch from target SHA to avoid wrong Release (main) labeling on dev builds
- publish main releases directly (non-draft)
- keep dev prereleases as draft and delete stale dev draft releases automatically

## Validation
- just --list
- just --dry-run release-ci
