### PR TITLE
FIX: Correct reciprocal scaling in non-linear modes

### DIFF
--- a/plugins/image-scaler/src/lib.rs
+++ b/plugins/image-scaler/src/lib.rs
@@ -508,14 +508,14 @@ impl Plugin {
         )?;
 
         let exp_name = if use_reciprocal {
-            "Scale (Log e)"
+            "Scale (1/Exp)"
         } else {
             "Scale (Exp)"
         };
         Self::set_param_name(params, Params::ScaleExp, exp_name)?;
 
         let power2_name = if use_reciprocal {
-            "Scale (Log 2)"
+            "Scale (1/Power2)"
         } else {
             "Scale (Power2)"
         };
@@ -629,19 +629,21 @@ fn read_settings(params: &mut Parameters<Params>) -> Result<Settings, Error> {
         ScaleMode::Exp => {
             let scale_percent = params.get(Params::ScaleExp)?.as_float_slider()?.value() as f32;
             let base_scale = (scale_percent / 100.0).max(MIN_SCALE_FACTOR);
+            let exp_scale = base_scale.exp();
             if use_reciprocal {
-                base_scale.ln()
+                1.0 / exp_scale
             } else {
-                base_scale.exp()
+                exp_scale
             }
         }
         ScaleMode::Power2 => {
             let scale_percent = params.get(Params::ScalePower2)?.as_float_slider()?.value() as f32;
             let base_scale = (scale_percent / 100.0).max(MIN_SCALE_FACTOR);
+            let power2_scale = 2.0_f32.powf(base_scale);
             if use_reciprocal {
-                base_scale.log2()
+                1.0 / power2_scale
             } else {
-                2.0_f32.powf(base_scale)
+                power2_scale
             }
         }
     };


### PR DESCRIPTION
## Summary
- fix Use Reciprocal behavior for non-linear scale modes in AOD_ImageScaler
- change Exp reciprocal from ln(x) to 1/exp(x)
- change Power2 reciprocal from log2(x) to 1/(2^x)
- update UI labels from Log wording to 1/Exp and 1/Power2

## Verification
- cargo check -p image_scaler
- cargo fmt --all -- --check
- cargo clippy -p image_scaler
- just -f .\plugins\image-scaler\Justfile release
