### PR TITLE
ADD: Add GPU-accelerated pixel extend effect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2010,6 +2010,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pixel_extend"
+version = "0.1.0"
+dependencies = [
+ "after-effects",
+ "chrono",
+ "pipl",
+ "utils",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2014,9 +2014,13 @@ name = "pixel_extend"
 version = "0.1.0"
 dependencies = [
  "after-effects",
+ "bytemuck",
  "chrono",
+ "futures-intrusive",
  "pipl",
+ "pollster",
  "utils",
+ "wgpu",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ template.
   - レイヤーにメビウス変換を適用します / Applies Mobius transformation to layers
 - AOD_NormalGenerate
   - 色領域から法線マップを生成します / Generate a normal map from the color region.
+- AOD_PixelExtend
+  - 指定条件のピクセルを方向・減衰・補間指定で伸ばします / Extends pixels in adjustable directions with selectable source masks and interpolation.
 - AOD_RegionColorize
   - 不透明または色領域をランダム・位置・インデックスで色分けします / Colors connected regions with random, positional, or index-based schemes.
 - AOD_SingularValueDecompose

--- a/plugins/pixel-extend/Cargo.toml
+++ b/plugins/pixel-extend/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "pixel_extend"
+description = "Extends pixels in adjustable directions with selectable source masks and interpolation."
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib"]
+
+[features]
+default = []
+catch-panics = []
+
+[dependencies]
+after-effects = { workspace = true }
+utils = { path = "../../crates/utils" }
+
+
+[dev-dependencies]
+pipl = { workspace = true }
+
+[build-dependencies]
+chrono.workspace = true
+pipl.workspace = true
+
+[lints]
+workspace = true

--- a/plugins/pixel-extend/Cargo.toml
+++ b/plugins/pixel-extend/Cargo.toml
@@ -13,7 +13,11 @@ catch-panics = []
 
 [dependencies]
 after-effects = { workspace = true }
+bytemuck = { workspace = true }
+futures-intrusive = { workspace = true }
+pollster = { workspace = true }
 utils = { path = "../../crates/utils" }
+wgpu = { workspace = true }
 
 
 [dev-dependencies]

--- a/plugins/pixel-extend/Justfile
+++ b/plugins/pixel-extend/Justfile
@@ -1,0 +1,12 @@
+# Read package.name from Cargo.toml for build naming.
+CrateName := if os() == "windows" {
+    `$inPackage = $false; foreach ($line in Get-Content -Path Cargo.toml) { if ($line -match '^\s*\[package\]\s*$') { $inPackage = $true; continue }; if ($line -match '^\s*\[.+\]\s*$') { if ($inPackage) { break } }; if ($inPackage -and $line -match '^\s*name\s*=\s*"([^"]+)"') { $matches[1]; break } }`
+} else {
+    `awk -F'"' 'BEGIN{in_pkg=0} /^[[:space:]]*\[package\][[:space:]]*$/{in_pkg=1;next} /^[[:space:]]*\[/{if(in_pkg)exit} in_pkg && /^[[:space:]]*name[[:space:]]*=/ {print $2; exit}' Cargo.toml`
+}
+
+PluginName       := "AOD_PixelExtend"
+BundleIdentifier := "com.aodaruma." + PluginName
+BinaryName       := snakecase(CrateName)
+
+import "../../AdobePlugin.just"

--- a/plugins/pixel-extend/README.md
+++ b/plugins/pixel-extend/README.md
@@ -1,0 +1,9 @@
+# pixel-extend ( AOD_PixelExtend )
+
+Extends pixels in adjustable directions with selectable source masks and interpolation.
+
+This is the After Effects plugin **AOD_PixelExtend**, which provides the **PixelExtend.aex** plugin file for Adobe After Effects.
+
+## Building the Plugin
+
+See the [main README](../../README.md) for instructions on how to build the plugin.

--- a/plugins/pixel-extend/build.rs
+++ b/plugins/pixel-extend/build.rs
@@ -1,0 +1,83 @@
+use chrono::Datelike;
+use pipl::*;
+
+const PF_PLUG_IN_VERSION: u16 = 13;
+const PF_PLUG_IN_SUBVERS: u16 = 28;
+
+#[rustfmt::skip]
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(does_dialog)");
+    println!("cargo::rustc-check-cfg=cfg(threaded_rendering)");
+
+    let current_year = chrono::Local::now().year();
+    println!("cargo:rustc-env=BUILD_YEAR={}", current_year);
+
+    let pkg_version = env!("CARGO_PKG_VERSION");
+    let version_parts: Vec<&str> = pkg_version.split('.').collect();
+    if version_parts.len() != 3 {
+        panic!("CARGO_PKG_VERSION must be in the format 'major.minor.patch'");
+    }
+    let major: u32 = version_parts[0].parse().expect("Invalid major version");
+    let minor: u32 = version_parts[1].parse().expect("Invalid minor version");
+    let patch: u32 = version_parts[2].parse().expect("Invalid patch version");
+
+    // Determine the stage based on building whether debug or release
+    /*
+    // pipl load error occured when stage = Stage::Release in pipl == v0.1.1, so temporarily fixed to Develop
+    let stage = if cfg!(debug_assertions) {
+        Stage::Develop
+    } else {
+        Stage::Release
+    };
+    */
+    let stage = Stage::Develop;
+
+    // --------------------------------------------------
+    // Build the plugin with PiPL
+    pipl::plugin_build(vec![
+        Property::Kind(PIPLType::AEEffect),
+        Property::Name("AOD_PixelExtend"),
+        Property::Category("Aodaruma"),
+
+        #[cfg(target_os = "windows")]
+        Property::CodeWin64X86("EffectMain"),
+        #[cfg(target_os = "macos")]
+        Property::CodeMacIntel64("EffectMain"),
+        #[cfg(target_os = "macos")]
+        Property::CodeMacARM64("EffectMain"),
+
+        Property::AE_PiPL_Version { major: 2, minor: 0 },
+        Property::AE_Effect_Spec_Version { major: PF_PLUG_IN_VERSION, minor: PF_PLUG_IN_SUBVERS },
+        Property::AE_Effect_Version {
+            version: major,
+            subversion: minor,
+            bugversion: patch,
+            stage,
+            build: 1,
+        },
+        Property::AE_Effect_Info_Flags(0),
+        Property::AE_Effect_Global_OutFlags(
+            // set up from https://docs.rs/pipl/latest/pipl/struct.OutFlags.html
+            OutFlags::PixIndependent
+            | OutFlags::UseOutputExtent
+            | OutFlags::DeepColorAware
+            | OutFlags::WideTimeInput
+            | OutFlags::SendUpdateParamsUI
+            ,
+        ),
+        Property::AE_Effect_Global_OutFlags_2(
+            // set up from https://docs.rs/pipl/latest/pipl/struct.OutFlags2.html
+            OutFlags2::FloatColorAware
+            | OutFlags2::SupportsThreadedRendering
+            // | OutFlags2::SupportsGetFlattenedSequenceData // error occured in pipl == v0.1.1, so temporarily commented out
+            | OutFlags2::AutomaticWideTimeInput
+            | OutFlags2::SupportsSmartRender
+            | OutFlags2::ParamGroupStartCollapsedFlag
+            // | OutFlags2::SupportsGpuRenderF32
+            ,
+        ),
+        Property::AE_Effect_Match_Name("PixelExtend"),
+        Property::AE_Reserved_Info(8),
+        Property::AE_Effect_Support_URL("https://github.com/Aodaruma/aodaruma-ae-plugin"),
+    ])
+}

--- a/plugins/pixel-extend/src/gpu/mod.rs
+++ b/plugins/pixel-extend/src/gpu/mod.rs
@@ -1,0 +1,602 @@
+use super::{
+    BlendMode, DirectionField, ExpansionSample, InterpolationMode, PixelF32, RenderContext,
+    Settings,
+};
+use ::wgpu::*;
+use bytemuck::{Pod, Zeroable};
+use futures_intrusive::channel::shared::oneshot_channel;
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
+
+const WORKGROUP_SIZE: u32 = 16;
+const AUTO_GPU_WORK_THRESHOLD: usize = 250_000;
+
+static WGPU_CONTEXT: OnceLock<Result<Arc<WgpuContext>, String>> = OnceLock::new();
+
+pub(super) fn should_render(context: &RenderContext) -> bool {
+    match std::env::var("AOD_PIXEL_EXTEND_GPU").as_deref() {
+        Ok("0") | Ok("false") | Ok("off") => return false,
+        Ok("1") | Ok("true") | Ok("on") => return true,
+        _ => {}
+    }
+
+    let samples_per_pixel = context.plan.paths.iter().fold(0usize, |total, path| {
+        total.saturating_add(path.steps.iter().fold(0usize, |path_total, step| {
+            path_total.saturating_add(
+                if step.expansion_radius > super::EPSILON
+                    && context.plan.expansion_samples.len() > 1
+                {
+                    context.plan.expansion_samples.len()
+                } else {
+                    1
+                },
+            )
+        }))
+    });
+    context
+        .region
+        .width()
+        .saturating_mul(context.region.height())
+        .saturating_mul(samples_per_pixel)
+        >= AUTO_GPU_WORK_THRESHOLD
+}
+
+pub(super) fn render(
+    source: &[PixelF32],
+    masks: &[f32],
+    width: usize,
+    height: usize,
+    settings: &Settings,
+    context: &RenderContext,
+) -> Result<Vec<PixelF32>, String> {
+    let gpu = match WGPU_CONTEXT.get_or_init(|| WgpuContext::new().map(Arc::new)) {
+        Ok(context) => Arc::clone(context),
+        Err(error) => return Err(error.clone()),
+    };
+    gpu.render(source, masks, width, height, settings, context)
+}
+
+struct WgpuContext {
+    device: Device,
+    queue: Queue,
+    limits: Limits,
+    pipeline: ComputePipeline,
+    layout: BindGroupLayout,
+    resources: Mutex<HashMap<std::thread::ThreadId, Arc<Mutex<WgpuResources>>>>,
+}
+
+impl WgpuContext {
+    fn new() -> Result<Self, String> {
+        let power_preference =
+            PowerPreference::from_env().unwrap_or(PowerPreference::HighPerformance);
+        let mut instance_desc = InstanceDescriptor::default();
+        if instance_desc.backends.contains(Backends::DX12)
+            && instance_desc.flags.contains(InstanceFlags::VALIDATION)
+        {
+            instance_desc
+                .flags
+                .remove(InstanceFlags::VALIDATION | InstanceFlags::GPU_BASED_VALIDATION);
+        }
+
+        let instance = Instance::new(&instance_desc);
+        let adapter = pollster::block_on(instance.request_adapter(&RequestAdapterOptions {
+            power_preference,
+            ..Default::default()
+        }))
+        .map_err(|error| format!("request_adapter failed: {error:?}"))?;
+        let required_limits = Limits::default()
+            .using_resolution(adapter.limits())
+            .using_alignment(adapter.limits());
+        let (device, queue) = pollster::block_on(adapter.request_device(&DeviceDescriptor {
+            label: Some("AOD_PixelExtend device"),
+            required_features: Features::empty(),
+            required_limits: required_limits.clone(),
+            experimental_features: ExperimentalFeatures::disabled(),
+            memory_hints: MemoryHints::Performance,
+            trace: Trace::Off,
+        }))
+        .map_err(|error| format!("request_device failed: {error:?}"))?;
+
+        let (layout, pipeline) = create_pipeline(&device);
+        Ok(Self {
+            device,
+            queue,
+            limits: required_limits,
+            pipeline,
+            layout,
+            resources: Mutex::new(HashMap::new()),
+        })
+    }
+
+    fn render(
+        &self,
+        source: &[PixelF32],
+        masks: &[f32],
+        width: usize,
+        height: usize,
+        settings: &Settings,
+        context: &RenderContext,
+    ) -> Result<Vec<PixelF32>, String> {
+        let pixel_count = width
+            .checked_mul(height)
+            .ok_or_else(|| "image dimensions overflow".to_owned())?;
+        if source.len() != pixel_count || masks.len() != pixel_count {
+            return Err("source buffer size does not match image dimensions".to_owned());
+        }
+        let width_u32 = u32::try_from(width).map_err(|_| "image width exceeds u32".to_owned())?;
+        let height_u32 =
+            u32::try_from(height).map_err(|_| "image height exceeds u32".to_owned())?;
+        let steps_per_path = context
+            .plan
+            .paths
+            .first()
+            .map_or(0, |path| path.steps.len());
+        if steps_per_path == 0
+            || context
+                .plan
+                .paths
+                .iter()
+                .any(|path| path.steps.len() != steps_per_path)
+        {
+            return Err("GPU paths must have equal, nonzero step counts".to_owned());
+        }
+
+        let source_data = source
+            .iter()
+            .map(|pixel| [pixel.red, pixel.green, pixel.blue, pixel.alpha])
+            .collect::<Vec<_>>();
+        let (direction_data, base_direction, variable_direction) = match &context.direction_field {
+            DirectionField::Constant(direction) => (
+                vec![[direction.x, direction.y]],
+                [direction.x, direction.y],
+                false,
+            ),
+            DirectionField::PerPixel { directions, .. } => (
+                directions
+                    .iter()
+                    .map(|direction| [direction.x, direction.y])
+                    .collect(),
+                [0.0, 0.0],
+                true,
+            ),
+        };
+        if variable_direction
+            && direction_data.len()
+                != context
+                    .region
+                    .width()
+                    .saturating_mul(context.region.height())
+        {
+            return Err("direction buffer size does not match the render region".to_owned());
+        }
+        let steps = context
+            .plan
+            .paths
+            .iter()
+            .flat_map(|path| {
+                path.steps.iter().map(move |step| GpuPathStep {
+                    geometry: [
+                        step.source_offset_x,
+                        step.source_offset_y,
+                        step.expansion_radius,
+                        step.falloff,
+                    ],
+                    metadata: [path.normal_sign, 0.0, 0.0, 0.0],
+                })
+            })
+            .collect::<Vec<_>>();
+        let expansion_samples = context
+            .plan
+            .expansion_samples
+            .iter()
+            .map(|sample| pack_expansion_sample(*sample))
+            .collect::<Vec<_>>();
+
+        let key = ResourceKey {
+            pixel_count,
+            direction_count: direction_data.len(),
+            step_count: steps.len(),
+            expansion_count: expansion_samples.len(),
+        };
+        self.validate_resource_sizes(key, width_u32, height_u32)?;
+        let resource = {
+            let mut resources = self
+                .resources
+                .lock()
+                .map_err(|_| "GPU resource cache lock was poisoned".to_owned())?;
+            Arc::clone(
+                resources
+                    .entry(std::thread::current().id())
+                    .or_insert_with(|| {
+                        Arc::new(Mutex::new(WgpuResources::new(
+                            &self.device,
+                            &self.layout,
+                            key,
+                        )))
+                    }),
+            )
+        };
+        let mut resource = resource
+            .lock()
+            .map_err(|_| "GPU thread resource lock was poisoned".to_owned())?;
+        if !resource.key.can_hold(key) {
+            *resource = WgpuResources::new(&self.device, &self.layout, key);
+        }
+
+        let params = GpuParams {
+            image: [
+                width_u32,
+                height_u32,
+                interpolation_code(settings.interpolation),
+                u32::from(variable_direction),
+            ],
+            region: [
+                context.region.min_x as u32,
+                context.region.min_y as u32,
+                context.region.max_x as u32,
+                context.region.max_y as u32,
+            ],
+            counts: [
+                context.plan.paths.len() as u32,
+                steps_per_path as u32,
+                expansion_samples.len() as u32,
+                blend_mode_code(settings.blend_mode),
+            ],
+            flags: [u32::from(settings.show_source), 0, 0, 0],
+            direction: [base_direction[0], base_direction[1], 0.0, 0.0],
+            sampling: [
+                settings.mitchell_b,
+                settings.mitchell_c,
+                settings.opacity,
+                0.0,
+            ],
+        };
+
+        self.queue
+            .write_buffer(&resource.params, 0, bytemuck::bytes_of(&params));
+        self.queue.write_buffer(
+            &resource.source,
+            0,
+            bytemuck::cast_slice(source_data.as_slice()),
+        );
+        self.queue
+            .write_buffer(&resource.masks, 0, bytemuck::cast_slice(masks));
+        self.queue.write_buffer(
+            &resource.directions,
+            0,
+            bytemuck::cast_slice(direction_data.as_slice()),
+        );
+        self.queue
+            .write_buffer(&resource.steps, 0, bytemuck::cast_slice(steps.as_slice()));
+        self.queue.write_buffer(
+            &resource.expansion_samples,
+            0,
+            bytemuck::cast_slice(expansion_samples.as_slice()),
+        );
+
+        let mut encoder = self
+            .device
+            .create_command_encoder(&CommandEncoderDescriptor {
+                label: Some("AOD_PixelExtend encoder"),
+            });
+        {
+            let mut pass = encoder.begin_compute_pass(&ComputePassDescriptor {
+                label: Some("AOD_PixelExtend compute"),
+                timestamp_writes: None,
+            });
+            pass.set_pipeline(&self.pipeline);
+            pass.set_bind_group(0, &resource.bind_group, &[]);
+            pass.dispatch_workgroups(
+                width_u32.div_ceil(WORKGROUP_SIZE),
+                height_u32.div_ceil(WORKGROUP_SIZE),
+                1,
+            );
+        }
+        let output_bytes = buffer_bytes::<[f32; 4]>(pixel_count);
+        encoder.copy_buffer_to_buffer(&resource.output, 0, &resource.staging, 0, output_bytes);
+
+        let (sender, receiver) = oneshot_channel();
+        encoder.map_buffer_on_submit(
+            &resource.staging,
+            MapMode::Read,
+            ..output_bytes,
+            move |result| {
+                let _ = sender.send(result);
+            },
+        );
+        self.queue.submit(Some(encoder.finish()));
+        let _ = self.device.poll(PollType::wait_indefinitely());
+
+        let Some(Ok(())) = pollster::block_on(receiver.receive()) else {
+            return Err("GPU output readback failed".to_owned());
+        };
+        let mapped = resource.staging.slice(..output_bytes).get_mapped_range();
+        let output_data: &[[f32; 4]] = bytemuck::cast_slice(&mapped);
+        let output = output_data
+            .iter()
+            .take(pixel_count)
+            .map(|pixel| PixelF32 {
+                alpha: pixel[3],
+                red: pixel[0],
+                green: pixel[1],
+                blue: pixel[2],
+            })
+            .collect();
+        drop(mapped);
+        resource.staging.unmap();
+        Ok(output)
+    }
+
+    fn validate_resource_sizes(
+        &self,
+        key: ResourceKey,
+        width: u32,
+        height: u32,
+    ) -> Result<(), String> {
+        let storage_limit = self.limits.max_storage_buffer_binding_size as u64;
+        for (label, size) in [
+            ("source/output", buffer_bytes::<[f32; 4]>(key.pixel_count)),
+            ("masks", buffer_bytes::<f32>(key.pixel_count)),
+            ("directions", buffer_bytes::<[f32; 2]>(key.direction_count)),
+            ("path steps", buffer_bytes::<GpuPathStep>(key.step_count)),
+            (
+                "expansion samples",
+                buffer_bytes::<GpuExpansionSample>(key.expansion_count),
+            ),
+        ] {
+            if size > storage_limit || size > self.limits.max_buffer_size {
+                return Err(format!(
+                    "{label} buffer requires {size} bytes, exceeding GPU limits"
+                ));
+            }
+        }
+
+        let dispatch_limit = self.limits.max_compute_workgroups_per_dimension;
+        if width.div_ceil(WORKGROUP_SIZE) > dispatch_limit
+            || height.div_ceil(WORKGROUP_SIZE) > dispatch_limit
+        {
+            return Err("image dimensions exceed GPU dispatch limits".to_owned());
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct ResourceKey {
+    pixel_count: usize,
+    direction_count: usize,
+    step_count: usize,
+    expansion_count: usize,
+}
+
+impl ResourceKey {
+    fn can_hold(self, required: Self) -> bool {
+        self.pixel_count >= required.pixel_count
+            && self.direction_count >= required.direction_count
+            && self.step_count >= required.step_count
+            && self.expansion_count >= required.expansion_count
+    }
+}
+
+struct WgpuResources {
+    key: ResourceKey,
+    params: Buffer,
+    source: Buffer,
+    masks: Buffer,
+    directions: Buffer,
+    steps: Buffer,
+    expansion_samples: Buffer,
+    output: Buffer,
+    staging: Buffer,
+    bind_group: BindGroup,
+}
+
+impl WgpuResources {
+    fn new(device: &Device, layout: &BindGroupLayout, key: ResourceKey) -> Self {
+        let source_bytes = buffer_bytes::<[f32; 4]>(key.pixel_count);
+        let mask_bytes = buffer_bytes::<f32>(key.pixel_count);
+        let direction_bytes = buffer_bytes::<[f32; 2]>(key.direction_count);
+        let step_bytes = buffer_bytes::<GpuPathStep>(key.step_count);
+        let expansion_bytes = buffer_bytes::<GpuExpansionSample>(key.expansion_count);
+        let params = create_buffer(
+            device,
+            "AOD_PixelExtend params",
+            std::mem::size_of::<GpuParams>() as u64,
+            BufferUsages::UNIFORM | BufferUsages::COPY_DST,
+        );
+        let source = create_buffer(
+            device,
+            "AOD_PixelExtend source",
+            source_bytes,
+            BufferUsages::STORAGE | BufferUsages::COPY_DST,
+        );
+        let masks = create_buffer(
+            device,
+            "AOD_PixelExtend masks",
+            mask_bytes,
+            BufferUsages::STORAGE | BufferUsages::COPY_DST,
+        );
+        let directions = create_buffer(
+            device,
+            "AOD_PixelExtend directions",
+            direction_bytes,
+            BufferUsages::STORAGE | BufferUsages::COPY_DST,
+        );
+        let steps = create_buffer(
+            device,
+            "AOD_PixelExtend steps",
+            step_bytes,
+            BufferUsages::STORAGE | BufferUsages::COPY_DST,
+        );
+        let expansion_samples = create_buffer(
+            device,
+            "AOD_PixelExtend expansion samples",
+            expansion_bytes,
+            BufferUsages::STORAGE | BufferUsages::COPY_DST,
+        );
+        let output = create_buffer(
+            device,
+            "AOD_PixelExtend output",
+            source_bytes,
+            BufferUsages::STORAGE | BufferUsages::COPY_SRC,
+        );
+        let staging = create_buffer(
+            device,
+            "AOD_PixelExtend staging",
+            source_bytes,
+            BufferUsages::MAP_READ | BufferUsages::COPY_DST,
+        );
+        let bind_group = device.create_bind_group(&BindGroupDescriptor {
+            label: Some("AOD_PixelExtend bind group"),
+            layout,
+            entries: &[
+                bind_entry(0, &params),
+                bind_entry(1, &source),
+                bind_entry(2, &masks),
+                bind_entry(3, &directions),
+                bind_entry(4, &steps),
+                bind_entry(5, &expansion_samples),
+                bind_entry(6, &output),
+            ],
+        });
+
+        Self {
+            key,
+            params,
+            source,
+            masks,
+            directions,
+            steps,
+            expansion_samples,
+            output,
+            staging,
+            bind_group,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable)]
+struct GpuParams {
+    image: [u32; 4],
+    region: [u32; 4],
+    counts: [u32; 4],
+    flags: [u32; 4],
+    direction: [f32; 4],
+    sampling: [f32; 4],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable)]
+struct GpuPathStep {
+    geometry: [f32; 4],
+    metadata: [f32; 4],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable)]
+struct GpuExpansionSample {
+    values: [f32; 4],
+}
+
+fn pack_expansion_sample(sample: ExpansionSample) -> GpuExpansionSample {
+    GpuExpansionSample {
+        values: [sample.radius_scale, sample.edge_weight, 0.0, 0.0],
+    }
+}
+
+fn interpolation_code(mode: InterpolationMode) -> u32 {
+    match mode {
+        InterpolationMode::Nearest => 0,
+        InterpolationMode::Bilinear => 1,
+        InterpolationMode::Bicubic => 2,
+        InterpolationMode::Mitchell => 3,
+    }
+}
+
+fn blend_mode_code(mode: BlendMode) -> u32 {
+    match mode {
+        BlendMode::Normal => 0,
+        BlendMode::Add => 1,
+        BlendMode::Multiply => 2,
+        BlendMode::Screen => 3,
+        BlendMode::Overlay => 4,
+        BlendMode::Darken => 5,
+        BlendMode::Lighten => 6,
+    }
+}
+
+fn buffer_bytes<T>(count: usize) -> u64 {
+    (count.max(1) as u64).saturating_mul(std::mem::size_of::<T>() as u64)
+}
+
+fn create_buffer(device: &Device, label: &'static str, size: u64, usage: BufferUsages) -> Buffer {
+    device.create_buffer(&BufferDescriptor {
+        label: Some(label),
+        size,
+        usage,
+        mapped_at_creation: false,
+    })
+}
+
+fn bind_entry(binding: u32, buffer: &Buffer) -> BindGroupEntry<'_> {
+    BindGroupEntry {
+        binding,
+        resource: buffer.as_entire_binding(),
+    }
+}
+
+fn create_pipeline(device: &Device) -> (BindGroupLayout, ComputePipeline) {
+    let shader = device.create_shader_module(ShaderModuleDescriptor {
+        label: Some("AOD_PixelExtend compute shader"),
+        source: ShaderSource::Wgsl(Cow::Borrowed(include_str!("shaders/pixel_extend.wgsl"))),
+    });
+    let layout = device.create_bind_group_layout(&BindGroupLayoutDescriptor {
+        label: Some("AOD_PixelExtend bind group layout"),
+        entries: &[
+            buffer_layout_entry(
+                0,
+                BufferBindingType::Uniform,
+                std::mem::size_of::<GpuParams>(),
+            ),
+            buffer_layout_entry(1, BufferBindingType::Storage { read_only: true }, 0),
+            buffer_layout_entry(2, BufferBindingType::Storage { read_only: true }, 0),
+            buffer_layout_entry(3, BufferBindingType::Storage { read_only: true }, 0),
+            buffer_layout_entry(4, BufferBindingType::Storage { read_only: true }, 0),
+            buffer_layout_entry(5, BufferBindingType::Storage { read_only: true }, 0),
+            buffer_layout_entry(6, BufferBindingType::Storage { read_only: false }, 0),
+        ],
+    });
+    let pipeline_layout = device.create_pipeline_layout(&PipelineLayoutDescriptor {
+        label: Some("AOD_PixelExtend pipeline layout"),
+        bind_group_layouts: &[&layout],
+        immediate_size: 0,
+    });
+    let pipeline = device.create_compute_pipeline(&ComputePipelineDescriptor {
+        label: Some("AOD_PixelExtend pipeline"),
+        layout: Some(&pipeline_layout),
+        module: &shader,
+        entry_point: Some("main"),
+        compilation_options: Default::default(),
+        cache: Default::default(),
+    });
+    (layout, pipeline)
+}
+
+fn buffer_layout_entry(
+    binding: u32,
+    ty: BufferBindingType,
+    minimum_size: usize,
+) -> BindGroupLayoutEntry {
+    BindGroupLayoutEntry {
+        binding,
+        visibility: ShaderStages::COMPUTE,
+        ty: BindingType::Buffer {
+            ty,
+            has_dynamic_offset: false,
+            min_binding_size: BufferSize::new(minimum_size as u64),
+        },
+        count: None,
+    }
+}

--- a/plugins/pixel-extend/src/gpu/shaders/pixel_extend.wgsl
+++ b/plugins/pixel-extend/src/gpu/shaders/pixel_extend.wgsl
@@ -1,0 +1,348 @@
+const EPSILON: f32 = 0.000001;
+
+struct Params {
+    image: vec4<u32>,
+    region: vec4<u32>,
+    counts: vec4<u32>,
+    flags: vec4<u32>,
+    direction: vec4<f32>,
+    sampling: vec4<f32>,
+}
+
+struct PathStep {
+    geometry: vec4<f32>,
+    metadata: vec4<f32>,
+}
+
+struct ExpansionSample {
+    values: vec4<f32>,
+}
+
+@group(0) @binding(0) var<uniform> params: Params;
+@group(0) @binding(1) var<storage, read> source_pixels: array<vec4<f32>>;
+@group(0) @binding(2) var<storage, read> source_masks: array<f32>;
+@group(0) @binding(3) var<storage, read> directions: array<vec2<f32>>;
+@group(0) @binding(4) var<storage, read> path_steps: array<PathStep>;
+@group(0) @binding(5) var<storage, read> expansion_samples: array<ExpansionSample>;
+@group(0) @binding(6) var<storage, read_write> output_pixels: array<vec4<f32>>;
+
+fn safe_unit(value: f32) -> f32 {
+    if value != value {
+        return 0.0;
+    }
+    return clamp(value, 0.0, 1.0);
+}
+
+fn sanitize_pixel(pixel: vec4<f32>) -> vec4<f32> {
+    return vec4<f32>(
+        safe_unit(pixel.r),
+        safe_unit(pixel.g),
+        safe_unit(pixel.b),
+        safe_unit(pixel.a),
+    );
+}
+
+fn transparent_pixel() -> vec4<f32> {
+    return vec4<f32>(0.0);
+}
+
+fn pixel_index(x: i32, y: i32) -> u32 {
+    return u32(y) * params.image.x + u32(x);
+}
+
+fn in_bounds(x: i32, y: i32) -> bool {
+    return x >= 0 && y >= 0 && x < i32(params.image.x) && y < i32(params.image.y);
+}
+
+fn fetch_pixel(x: i32, y: i32) -> vec4<f32> {
+    if !in_bounds(x, y) {
+        return transparent_pixel();
+    }
+    return source_pixels[pixel_index(x, y)];
+}
+
+fn fetch_mask(x: i32, y: i32) -> f32 {
+    if !in_bounds(x, y) {
+        return 0.0;
+    }
+    return source_masks[pixel_index(x, y)];
+}
+
+fn round_away_from_zero(value: f32) -> i32 {
+    if value >= 0.0 {
+        return i32(floor(value + 0.5));
+    }
+    return i32(ceil(value - 0.5));
+}
+
+fn cubic_weight(distance: f32) -> f32 {
+    let x = abs(distance);
+    let a = -0.5;
+    if x <= 1.0 {
+        return (a + 2.0) * x * x * x - (a + 3.0) * x * x + 1.0;
+    }
+    if x < 2.0 {
+        return a * x * x * x - 5.0 * a * x * x + 8.0 * a * x - 4.0 * a;
+    }
+    return 0.0;
+}
+
+fn mitchell_weight(distance: f32) -> f32 {
+    let x = abs(distance);
+    let b = params.sampling.x;
+    let c = params.sampling.y;
+    if x < 1.0 {
+        return ((12.0 - 9.0 * b - 6.0 * c) * x * x * x
+            + (-18.0 + 12.0 * b + 6.0 * c) * x * x
+            + (6.0 - 2.0 * b)) / 6.0;
+    }
+    if x < 2.0 {
+        return ((-b - 6.0 * c) * x * x * x
+            + (6.0 * b + 30.0 * c) * x * x
+            + (-12.0 * b - 48.0 * c) * x
+            + (8.0 * b + 24.0 * c)) / 6.0;
+    }
+    return 0.0;
+}
+
+fn interpolation_weight(distance: f32) -> f32 {
+    if params.image.z == 2u {
+        return cubic_weight(distance);
+    }
+    return mitchell_weight(distance);
+}
+
+fn sample_mask_4x4(position: vec2<f32>) -> f32 {
+    let start = vec2<i32>(floor(position)) - vec2<i32>(1);
+    var sum = 0.0;
+    var weight_sum = 0.0;
+    for (var oy = 0i; oy < 4i; oy += 1i) {
+        let sy = start.y + oy;
+        let wy = interpolation_weight(position.y - f32(sy));
+        for (var ox = 0i; ox < 4i; ox += 1i) {
+            let sx = start.x + ox;
+            let weight = interpolation_weight(position.x - f32(sx)) * wy;
+            sum += fetch_mask(sx, sy) * weight;
+            weight_sum += weight;
+        }
+    }
+    if abs(weight_sum) <= EPSILON {
+        return 0.0;
+    }
+    return sum / weight_sum;
+}
+
+fn sample_pixel_4x4(position: vec2<f32>) -> vec4<f32> {
+    let start = vec2<i32>(floor(position)) - vec2<i32>(1);
+    var sum = transparent_pixel();
+    var weight_sum = 0.0;
+    for (var oy = 0i; oy < 4i; oy += 1i) {
+        let sy = start.y + oy;
+        let wy = interpolation_weight(position.y - f32(sy));
+        for (var ox = 0i; ox < 4i; ox += 1i) {
+            let sx = start.x + ox;
+            let weight = interpolation_weight(position.x - f32(sx)) * wy;
+            sum += fetch_pixel(sx, sy) * weight;
+            weight_sum += weight;
+        }
+    }
+    if abs(weight_sum) <= EPSILON {
+        return transparent_pixel();
+    }
+    return clamp(sum / weight_sum, vec4<f32>(0.0), vec4<f32>(1.0));
+}
+
+fn sample_mask(position: vec2<f32>) -> f32 {
+    if params.image.z == 0u {
+        return fetch_mask(round_away_from_zero(position.x), round_away_from_zero(position.y));
+    }
+    if params.image.z >= 2u {
+        return sample_mask_4x4(position);
+    }
+
+    let lower = vec2<i32>(floor(position));
+    let fraction = position - vec2<f32>(lower);
+    let top = mix(fetch_mask(lower.x, lower.y), fetch_mask(lower.x + 1i, lower.y), fraction.x);
+    let bottom = mix(
+        fetch_mask(lower.x, lower.y + 1i),
+        fetch_mask(lower.x + 1i, lower.y + 1i),
+        fraction.x,
+    );
+    return mix(top, bottom, fraction.y);
+}
+
+fn sample_pixel(position: vec2<f32>) -> vec4<f32> {
+    if params.image.z == 0u {
+        return fetch_pixel(round_away_from_zero(position.x), round_away_from_zero(position.y));
+    }
+    if params.image.z >= 2u {
+        return sample_pixel_4x4(position);
+    }
+
+    let lower = vec2<i32>(floor(position));
+    let fraction = position - vec2<f32>(lower);
+    let top = mix(fetch_pixel(lower.x, lower.y), fetch_pixel(lower.x + 1i, lower.y), fraction.x);
+    let bottom = mix(
+        fetch_pixel(lower.x, lower.y + 1i),
+        fetch_pixel(lower.x + 1i, lower.y + 1i),
+        fraction.x,
+    );
+    return mix(top, bottom, fraction.y);
+}
+
+fn alpha_over(top: vec4<f32>, bottom: vec4<f32>) -> vec4<f32> {
+    let top_alpha = clamp(top.a, 0.0, 1.0);
+    let bottom_alpha = clamp(bottom.a, 0.0, 1.0);
+    let output_alpha = top_alpha + bottom_alpha * (1.0 - top_alpha);
+    if output_alpha <= EPSILON {
+        return transparent_pixel();
+    }
+    return vec4<f32>(top.rgb + bottom.rgb * (1.0 - top_alpha), output_alpha);
+}
+
+fn offset_point(
+    output_position: vec2<f32>,
+    direction: vec2<f32>,
+    local_position: vec2<f32>,
+) -> vec2<f32> {
+    return output_position + vec2<f32>(
+        direction.x * local_position.x - direction.y * local_position.y,
+        direction.y * local_position.x + direction.x * local_position.y,
+    );
+}
+
+fn sample_extension_point(position: vec2<f32>, falloff: f32) -> vec4<f32> {
+    let mask = clamp(sample_mask(position), 0.0, 1.0);
+    let opacity = clamp(mask * falloff, 0.0, 1.0);
+    if opacity <= EPSILON {
+        return transparent_pixel();
+    }
+    return sample_pixel(position) * opacity;
+}
+
+fn extend_path(
+    output_position: vec2<f32>,
+    direction: vec2<f32>,
+    path_index: u32,
+) -> vec4<f32> {
+    var result = transparent_pixel();
+    let first_step = path_index * params.counts.y;
+    for (var step_index = 0u; step_index < params.counts.y; step_index += 1u) {
+        let step = path_steps[first_step + step_index];
+        var step_pixel = transparent_pixel();
+        if step.geometry.z <= EPSILON || params.counts.z <= 1u {
+            let position = offset_point(output_position, direction, step.geometry.xy);
+            step_pixel = sample_extension_point(position, step.geometry.w);
+        } else {
+            for (var sample_index = 0u; sample_index < params.counts.z; sample_index += 1u) {
+                let sample = expansion_samples[sample_index].values;
+                let local_y = step.geometry.y
+                    + step.metadata.x * sample.x * step.geometry.z;
+                let position = offset_point(
+                    output_position,
+                    direction,
+                    vec2<f32>(step.geometry.x, local_y),
+                );
+                let pixel = sample_extension_point(position, step.geometry.w * sample.y);
+                step_pixel = alpha_over(step_pixel, pixel);
+                if step_pixel.a >= 0.999 {
+                    break;
+                }
+            }
+        }
+
+        if step_pixel.a > EPSILON {
+            result = alpha_over(result, step_pixel);
+            if result.a >= 0.999 {
+                break;
+            }
+        }
+    }
+    return result;
+}
+
+fn unpremultiplied_rgb(pixel: vec4<f32>) -> vec3<f32> {
+    if pixel.a <= EPSILON {
+        return vec3<f32>(0.0);
+    }
+    return vec3<f32>(
+        safe_unit(pixel.r / pixel.a),
+        safe_unit(pixel.g / pixel.a),
+        safe_unit(pixel.b / pixel.a),
+    );
+}
+
+fn blend_channel(base: f32, blend: f32) -> f32 {
+    if params.counts.w == 1u {
+        return clamp(base + blend, 0.0, 1.0);
+    }
+    if params.counts.w == 2u {
+        return base * blend;
+    }
+    if params.counts.w == 3u {
+        return 1.0 - (1.0 - base) * (1.0 - blend);
+    }
+    if params.counts.w == 4u {
+        if base <= 0.5 {
+            return 2.0 * base * blend;
+        }
+        return 1.0 - 2.0 * (1.0 - base) * (1.0 - blend);
+    }
+    if params.counts.w == 5u {
+        return min(base, blend);
+    }
+    if params.counts.w == 6u {
+        return max(base, blend);
+    }
+    return blend;
+}
+
+fn blend_behind_source(source: vec4<f32>, extension: vec4<f32>) -> vec4<f32> {
+    let base = unpremultiplied_rgb(source);
+    let blend = unpremultiplied_rgb(extension);
+    let blended = vec4<f32>(
+        blend_channel(base.r, blend.r) * extension.a,
+        blend_channel(base.g, blend.g) * extension.a,
+        blend_channel(base.b, blend.b) * extension.a,
+        extension.a,
+    );
+    return alpha_over(blended, source);
+}
+
+@compute @workgroup_size(16, 16, 1)
+fn main(@builtin(global_invocation_id) invocation: vec3<u32>) {
+    if invocation.x >= params.image.x || invocation.y >= params.image.y {
+        return;
+    }
+
+    let index = invocation.y * params.image.x + invocation.x;
+    let source = source_pixels[index];
+    var extension = transparent_pixel();
+    if invocation.x >= params.region.x
+        && invocation.y >= params.region.y
+        && invocation.x < params.region.z
+        && invocation.y < params.region.w
+    {
+        var direction = params.direction.xy;
+        if params.image.w != 0u {
+            let direction_index = (invocation.y - params.region.y)
+                * (params.region.z - params.region.x)
+                + (invocation.x - params.region.x);
+            direction = directions[direction_index];
+        }
+        let output_position = vec2<f32>(invocation.xy);
+        for (var path_index = 0u; path_index < params.counts.x; path_index += 1u) {
+            extension = alpha_over(
+                extension,
+                extend_path(output_position, direction, path_index),
+            );
+        }
+        extension *= clamp(params.sampling.z, 0.0, 1.0);
+    }
+
+    var output = extension;
+    if params.flags.x != 0u {
+        output = blend_behind_source(source, extension);
+    }
+    output_pixels[index] = sanitize_pixel(output);
+}

--- a/plugins/pixel-extend/src/lib.rs
+++ b/plugins/pixel-extend/src/lib.rs
@@ -6,6 +6,8 @@ use std::env;
 use ae::pf::*;
 use utils::ToPixel;
 
+mod gpu;
+
 #[derive(Eq, PartialEq, Hash, Clone, Copy, Debug)]
 enum Params {
     Direction,
@@ -1179,6 +1181,15 @@ impl Plugin {
                 region,
             }
         });
+        if let Some(context) = render_context.as_ref()
+            && gpu::should_render(context)
+            && let Ok(output) =
+                gpu::render(&source, &mask_map.values, width, height, &settings, context)
+        {
+            write_output_buffer(&mut out_layer, &output)?;
+            return Ok(());
+        }
+
         match settings.interpolation {
             InterpolationMode::Nearest => render_output::<NearestKernel>(
                 &mut out_layer,
@@ -2337,6 +2348,20 @@ fn write_output_pixel(dst: &mut GenericPixelMut<'_>, px: PixelF32) {
     }
 }
 
+fn write_output_buffer(out_layer: &mut Layer, pixels: &[PixelF32]) -> Result<(), Error> {
+    let width = out_layer.width();
+    let progress_final = out_layer.height() as i32;
+    out_layer.iterate(0, progress_final, None, |x, y, mut dst| {
+        let pixel = pixels
+            .get(y as usize * width + x as usize)
+            .copied()
+            .ok_or(Error::BadCallbackParameter)?;
+        write_output_pixel(&mut dst, pixel);
+        Ok(())
+    })?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2383,6 +2408,66 @@ mod tests {
         assert_close(actual.red, expected.red);
         assert_close(actual.green, expected.green);
         assert_close(actual.blue, expected.blue);
+    }
+
+    fn render_cpu_pixels<K: InterpolationKernel>(
+        source: &[PixelF32],
+        masks: &[f32],
+        width: usize,
+        height: usize,
+        settings: &Settings,
+        context: &RenderContext,
+    ) -> Vec<PixelF32> {
+        let source_image = SourceImage {
+            pixels: source,
+            masks,
+            width,
+            height,
+        };
+        let mut output = Vec::with_capacity(source.len());
+        for y in 0..height {
+            for x in 0..width {
+                let extension = if context.region.contains(x, y) {
+                    scale_pixel_opacity(
+                        extend_pixel::<K>(
+                            &source_image,
+                            x as f32,
+                            y as f32,
+                            settings,
+                            context.direction_field.at(x, y),
+                            &context.plan,
+                        ),
+                        settings.opacity,
+                    )
+                } else {
+                    transparent_pixel()
+                };
+                let pixel = if settings.show_source {
+                    blend_behind_source(source[y * width + x], extension, settings.blend_mode)
+                } else {
+                    extension
+                };
+                output.push(sanitize_pixel(pixel));
+            }
+        }
+        output
+    }
+
+    fn assert_gpu_pixels_close(actual: &[PixelF32], expected: &[PixelF32]) {
+        assert_eq!(actual.len(), expected.len());
+        for (index, (actual, expected)) in actual.iter().zip(expected).enumerate() {
+            for (channel, actual, expected) in [
+                ("alpha", actual.alpha, expected.alpha),
+                ("red", actual.red, expected.red),
+                ("green", actual.green, expected.green),
+                ("blue", actual.blue, expected.blue),
+            ] {
+                assert!(
+                    (actual - expected).abs() <= 2.0e-4,
+                    "pixel={index}, channel={channel}, actual={actual}, expected={expected}"
+                );
+            }
+        }
     }
 
     fn legacy_mask_support_scan<F>(
@@ -2611,6 +2696,108 @@ mod tests {
     #[test]
     fn extension_region_contains_all_variable_direction_samples() {
         assert_extension_region_contains_samples(true);
+    }
+
+    #[test]
+    fn gpu_render_matches_cpu_interpolation_paths() {
+        let width = 8;
+        let height = 7;
+        let mut source = vec![transparent_pixel(); width * height];
+        for y in 1..height - 1 {
+            for x in 1..width - 1 {
+                let alpha = 0.25 + (x + y) as f32 * 0.045;
+                source[y * width + x] = PixelF32 {
+                    alpha,
+                    red: alpha * x as f32 / width as f32,
+                    green: alpha * y as f32 / height as f32,
+                    blue: alpha * (x + y) as f32 / (width + height) as f32,
+                };
+            }
+        }
+
+        let mut settings = test_settings();
+        settings.extend_count = 4;
+        settings.step_size = 0.8;
+        settings.offset = -0.35;
+        settings.decay = 0.82;
+        settings.expansion_per_step = 0.45;
+        settings.expansion_samples = 5;
+        settings.opacity = 0.73;
+        settings.blend_mode = BlendMode::Screen;
+        let mask_map = build_mask_map(&source, width, height, &settings);
+        let plan = build_render_plan(&settings);
+        let region = RenderRegion {
+            min_x: 0,
+            min_y: 0,
+            max_x: width,
+            max_y: height,
+        };
+        let directions = (0..width * height)
+            .map(|index| DirectionBasis::from_angle(0.2 + index as f32 * 0.017))
+            .collect();
+        let context = RenderContext {
+            direction_field: DirectionField::PerPixel { directions, region },
+            plan,
+            region,
+        };
+
+        for mode in [
+            InterpolationMode::Nearest,
+            InterpolationMode::Bilinear,
+            InterpolationMode::Bicubic,
+            InterpolationMode::Mitchell,
+        ] {
+            settings.interpolation = mode;
+            let expected = match mode {
+                InterpolationMode::Nearest => render_cpu_pixels::<NearestKernel>(
+                    &source,
+                    &mask_map.values,
+                    width,
+                    height,
+                    &settings,
+                    &context,
+                ),
+                InterpolationMode::Bilinear => render_cpu_pixels::<BilinearKernel>(
+                    &source,
+                    &mask_map.values,
+                    width,
+                    height,
+                    &settings,
+                    &context,
+                ),
+                InterpolationMode::Bicubic => render_cpu_pixels::<BicubicKernel>(
+                    &source,
+                    &mask_map.values,
+                    width,
+                    height,
+                    &settings,
+                    &context,
+                ),
+                InterpolationMode::Mitchell => render_cpu_pixels::<MitchellKernel>(
+                    &source,
+                    &mask_map.values,
+                    width,
+                    height,
+                    &settings,
+                    &context,
+                ),
+            };
+            let actual = match gpu::render(
+                &source,
+                &mask_map.values,
+                width,
+                height,
+                &settings,
+                &context,
+            ) {
+                Ok(actual) => actual,
+                Err(error) => {
+                    eprintln!("Skipping GPU comparison because wgpu is unavailable: {error}");
+                    return;
+                }
+            };
+            assert_gpu_pixels_close(&actual, &expected);
+        }
     }
 
     fn assert_extension_region_contains_samples(variable_direction: bool) {

--- a/plugins/pixel-extend/src/lib.rs
+++ b/plugins/pixel-extend/src/lib.rs
@@ -304,6 +304,147 @@ struct RenderPlan {
     expansion_samples: Vec<ExpansionSample>,
 }
 
+trait InterpolationKernel {
+    const IS_NEAREST: bool = false;
+
+    fn sample_mask(
+        source: &[f32],
+        width: usize,
+        height: usize,
+        x: f32,
+        y: f32,
+        settings: &Settings,
+    ) -> f32;
+
+    fn sample_pixel(
+        source: &[PixelF32],
+        width: usize,
+        height: usize,
+        x: f32,
+        y: f32,
+        settings: &Settings,
+    ) -> PixelF32;
+}
+
+struct NearestKernel;
+struct BilinearKernel;
+struct BicubicKernel;
+struct MitchellKernel;
+
+impl InterpolationKernel for NearestKernel {
+    const IS_NEAREST: bool = true;
+
+    fn sample_mask(
+        source: &[f32],
+        width: usize,
+        height: usize,
+        x: f32,
+        y: f32,
+        _settings: &Settings,
+    ) -> f32 {
+        sample_mask_nearest(source, width, height, x, y)
+    }
+
+    fn sample_pixel(
+        source: &[PixelF32],
+        width: usize,
+        height: usize,
+        x: f32,
+        y: f32,
+        _settings: &Settings,
+    ) -> PixelF32 {
+        sample_nearest(source, width, height, x, y)
+    }
+}
+
+impl InterpolationKernel for BilinearKernel {
+    fn sample_mask(
+        source: &[f32],
+        width: usize,
+        height: usize,
+        x: f32,
+        y: f32,
+        _settings: &Settings,
+    ) -> f32 {
+        sample_mask_bilinear(source, width, height, x, y)
+    }
+
+    fn sample_pixel(
+        source: &[PixelF32],
+        width: usize,
+        height: usize,
+        x: f32,
+        y: f32,
+        _settings: &Settings,
+    ) -> PixelF32 {
+        sample_bilinear(source, width, height, x, y)
+    }
+}
+
+impl InterpolationKernel for BicubicKernel {
+    fn sample_mask(
+        source: &[f32],
+        width: usize,
+        height: usize,
+        x: f32,
+        y: f32,
+        _settings: &Settings,
+    ) -> f32 {
+        sample_mask_bicubic(source, width, height, x, y)
+    }
+
+    fn sample_pixel(
+        source: &[PixelF32],
+        width: usize,
+        height: usize,
+        x: f32,
+        y: f32,
+        _settings: &Settings,
+    ) -> PixelF32 {
+        sample_bicubic(source, width, height, x, y)
+    }
+}
+
+impl InterpolationKernel for MitchellKernel {
+    fn sample_mask(
+        source: &[f32],
+        width: usize,
+        height: usize,
+        x: f32,
+        y: f32,
+        settings: &Settings,
+    ) -> f32 {
+        sample_mask_mitchell(
+            source,
+            width,
+            height,
+            x,
+            y,
+            settings.mitchell_b,
+            settings.mitchell_c,
+        )
+    }
+
+    fn sample_pixel(
+        source: &[PixelF32],
+        width: usize,
+        height: usize,
+        x: f32,
+        y: f32,
+        settings: &Settings,
+    ) -> PixelF32 {
+        sample_mitchell(
+            source,
+            width,
+            height,
+            x,
+            y,
+            settings.mitchell_b,
+            settings.mitchell_c,
+        )
+    }
+}
+
 #[derive(Clone, Copy, Debug, Default)]
 struct WeightedPixel {
     red: f32,
@@ -979,38 +1120,78 @@ impl Plugin {
                 build_render_plan(&settings),
             )
         });
-        let progress_final = out_layer.height() as i32;
-
-        out_layer.iterate(0, progress_final, None, |x, y, mut dst| {
-            let pixel_index = y as usize * width + x as usize;
-            let source_px = source[pixel_index];
-            let extend_px = if let Some((direction_field, render_plan)) = &render_context {
-                scale_pixel_opacity(
-                    extend_pixel(
-                        &source_image,
-                        x as f32,
-                        y as f32,
-                        &settings,
-                        direction_field.at(pixel_index),
-                        render_plan,
-                    ),
-                    settings.opacity,
-                )
-            } else {
-                transparent_pixel()
-            };
-            let out_px = if settings.show_source {
-                blend_behind_source(source_px, extend_px, settings.blend_mode)
-            } else {
-                extend_px
-            };
-
-            write_output_pixel(&mut dst, sanitize_pixel(out_px));
-            Ok(())
-        })?;
+        match settings.interpolation {
+            InterpolationMode::Nearest => render_output::<NearestKernel>(
+                &mut out_layer,
+                &source,
+                &source_image,
+                &settings,
+                render_context.as_ref(),
+            )?,
+            InterpolationMode::Bilinear => render_output::<BilinearKernel>(
+                &mut out_layer,
+                &source,
+                &source_image,
+                &settings,
+                render_context.as_ref(),
+            )?,
+            InterpolationMode::Bicubic => render_output::<BicubicKernel>(
+                &mut out_layer,
+                &source,
+                &source_image,
+                &settings,
+                render_context.as_ref(),
+            )?,
+            InterpolationMode::Mitchell => render_output::<MitchellKernel>(
+                &mut out_layer,
+                &source,
+                &source_image,
+                &settings,
+                render_context.as_ref(),
+            )?,
+        }
 
         Ok(())
     }
+}
+
+fn render_output<K: InterpolationKernel>(
+    out_layer: &mut Layer,
+    source: &[PixelF32],
+    source_image: &SourceImage<'_>,
+    settings: &Settings,
+    render_context: Option<&(DirectionField, RenderPlan)>,
+) -> Result<(), Error> {
+    let width = source_image.width;
+    let progress_final = out_layer.height() as i32;
+    out_layer.iterate(0, progress_final, None, |x, y, mut dst| {
+        let pixel_index = y as usize * width + x as usize;
+        let source_px = source[pixel_index];
+        let extend_px = if let Some((direction_field, render_plan)) = render_context {
+            scale_pixel_opacity(
+                extend_pixel::<K>(
+                    source_image,
+                    x as f32,
+                    y as f32,
+                    settings,
+                    direction_field.at(pixel_index),
+                    render_plan,
+                ),
+                settings.opacity,
+            )
+        } else {
+            transparent_pixel()
+        };
+        let out_px = if settings.show_source {
+            blend_behind_source(source_px, extend_px, settings.blend_mode)
+        } else {
+            extend_px
+        };
+
+        write_output_pixel(&mut dst, sanitize_pixel(out_px));
+        Ok(())
+    })?;
+    Ok(())
 }
 
 fn read_settings(in_data: InData, params: &mut Parameters<Params>) -> Result<Settings, Error> {
@@ -1110,7 +1291,7 @@ fn angle_degrees(
     Ok(params.get(id)?.as_angle()?.float_value()? as f32)
 }
 
-fn extend_pixel(
+fn extend_pixel<K: InterpolationKernel>(
     source: &SourceImage<'_>,
     x: f32,
     y: f32,
@@ -1124,7 +1305,7 @@ fn extend_pixel(
 
     let mut out = transparent_pixel();
     for path in &render_plan.paths {
-        let direction_px = extend_pixel_one_direction(
+        let direction_px = extend_pixel_one_direction::<K>(
             source,
             x,
             y,
@@ -1138,7 +1319,7 @@ fn extend_pixel(
     out
 }
 
-fn extend_pixel_one_direction(
+fn extend_pixel_one_direction<K: InterpolationKernel>(
     source: &SourceImage<'_>,
     x: f32,
     y: f32,
@@ -1152,9 +1333,9 @@ fn extend_pixel_one_direction(
     for step in &path.steps {
         let step_px = if step.expansion_radius <= EPSILON || expansion_samples.len() <= 1 {
             let (sx, sy) = direction.offset_point(x, y, step.source_offset_x, step.source_offset_y);
-            sample_extension_point(source, sx, sy, settings, step.falloff)
+            sample_extension_point::<K>(source, sx, sy, settings, step.falloff)
         } else {
-            sample_expanded_extension(
+            sample_expanded_extension::<K>(
                 source,
                 (x, y),
                 direction,
@@ -1176,26 +1357,31 @@ fn extend_pixel_one_direction(
     out
 }
 
-fn sample_extension_point(
+fn sample_extension_point<K: InterpolationKernel>(
     source: &SourceImage<'_>,
     x: f32,
     y: f32,
     settings: &Settings,
     falloff: f32,
 ) -> PixelF32 {
-    let mask = sample_mask(source.masks, source.width, source.height, x, y, settings);
+    if !x.is_finite() || !y.is_finite() {
+        return transparent_pixel();
+    }
+
+    let mask =
+        K::sample_mask(source.masks, source.width, source.height, x, y, settings).clamp(0.0, 1.0);
     let weight = mask * falloff;
     if weight <= EPSILON {
         return transparent_pixel();
     }
 
     scale_pixel_opacity(
-        sample_pixel(source.pixels, source.width, source.height, x, y, settings),
+        K::sample_pixel(source.pixels, source.width, source.height, x, y, settings),
         weight,
     )
 }
 
-fn sample_expanded_extension(
+fn sample_expanded_extension<K: InterpolationKernel>(
     source: &SourceImage<'_>,
     output: (f32, f32),
     direction: DirectionBasis,
@@ -1204,14 +1390,30 @@ fn sample_expanded_extension(
     expansion_samples: &[ExpansionSample],
     settings: &Settings,
 ) -> PixelF32 {
+    if K::IS_NEAREST {
+        return sample_expanded_nearest(
+            source,
+            output,
+            direction,
+            normal_sign,
+            step,
+            expansion_samples,
+        );
+    }
+
     let mut out = transparent_pixel();
 
     for sample in expansion_samples {
         let local_y =
             step.source_offset_y + normal_sign * sample.radius_scale * step.expansion_radius;
         let (sx, sy) = direction.offset_point(output.0, output.1, step.source_offset_x, local_y);
-        let px =
-            sample_extension_point(source, sx, sy, settings, step.falloff * sample.edge_weight);
+        let px = sample_extension_point::<K>(
+            source,
+            sx,
+            sy,
+            settings,
+            step.falloff * sample.edge_weight,
+        );
         out = alpha_over(out, px);
         if out.alpha >= 0.999 {
             break;
@@ -1219,6 +1421,85 @@ fn sample_expanded_extension(
     }
 
     out
+}
+
+fn sample_expanded_nearest(
+    source: &SourceImage<'_>,
+    output: (f32, f32),
+    direction: DirectionBasis,
+    normal_sign: f32,
+    step: &PathStep,
+    expansion_samples: &[ExpansionSample],
+) -> PixelF32 {
+    let mut out = transparent_pixel();
+    let mut cached_coord = None;
+    let mut cached_pixel = transparent_pixel();
+    let mut cached_weight = 0.0f32;
+    let mut run_alpha = 0.0f32;
+    let mut run_rgb_scale = 0.0f32;
+
+    for sample in expansion_samples {
+        let local_y =
+            step.source_offset_y + normal_sign * sample.radius_scale * step.expansion_radius;
+        let (sx, sy) = direction.offset_point(output.0, output.1, step.source_offset_x, local_y);
+        let coord = (sx.is_finite() && sy.is_finite())
+            .then_some((sx.round() as isize, sy.round() as isize));
+
+        if coord != cached_coord {
+            out = append_nearest_run(out, cached_pixel, run_alpha, run_rgb_scale);
+            cached_coord = coord;
+            cached_pixel = transparent_pixel();
+            cached_weight = 0.0;
+            run_alpha = 0.0;
+            run_rgb_scale = 0.0;
+
+            if let Some((ix, iy)) = coord {
+                cached_weight =
+                    fetch_mask_or_zero(source.masks, source.width, source.height, ix, iy)
+                        .clamp(0.0, 1.0)
+                        * step.falloff;
+                if cached_weight > EPSILON {
+                    cached_pixel =
+                        fetch_or_transparent(source.pixels, source.width, source.height, ix, iy);
+                }
+            }
+        }
+
+        let opacity = clamp01(cached_weight * sample.edge_weight);
+        if opacity <= EPSILON {
+            continue;
+        }
+        let remaining_alpha = 1.0 - run_alpha;
+        run_rgb_scale += opacity * remaining_alpha;
+        run_alpha += clamp01(cached_pixel.alpha * opacity) * remaining_alpha;
+
+        let combined_alpha = out.alpha + run_alpha * (1.0 - out.alpha);
+        if combined_alpha >= 0.999 {
+            return append_nearest_run(out, cached_pixel, run_alpha, run_rgb_scale);
+        }
+    }
+
+    append_nearest_run(out, cached_pixel, run_alpha, run_rgb_scale)
+}
+
+fn append_nearest_run(
+    out: PixelF32,
+    source: PixelF32,
+    run_alpha: f32,
+    run_rgb_scale: f32,
+) -> PixelF32 {
+    if run_rgb_scale <= EPSILON && run_alpha <= EPSILON {
+        return out;
+    }
+    alpha_over(
+        out,
+        PixelF32 {
+            alpha: run_alpha,
+            red: source.red * run_rgb_scale,
+            green: source.green * run_rgb_scale,
+            blue: source.blue * run_rgb_scale,
+        },
+    )
 }
 
 fn build_render_plan(settings: &Settings) -> RenderPlan {
@@ -1458,63 +1739,6 @@ fn smooth_threshold(distance: f32, softness: f32) -> f32 {
     }
 }
 
-fn sample_pixel(
-    source: &[PixelF32],
-    width: usize,
-    height: usize,
-    x: f32,
-    y: f32,
-    settings: &Settings,
-) -> PixelF32 {
-    if !x.is_finite() || !y.is_finite() {
-        return transparent_pixel();
-    }
-
-    match settings.interpolation {
-        InterpolationMode::Nearest => sample_nearest(source, width, height, x, y),
-        InterpolationMode::Bilinear => sample_bilinear(source, width, height, x, y),
-        InterpolationMode::Bicubic => sample_bicubic(source, width, height, x, y),
-        InterpolationMode::Mitchell => sample_mitchell(
-            source,
-            width,
-            height,
-            x,
-            y,
-            settings.mitchell_b,
-            settings.mitchell_c,
-        ),
-    }
-}
-
-fn sample_mask(
-    source: &[f32],
-    width: usize,
-    height: usize,
-    x: f32,
-    y: f32,
-    settings: &Settings,
-) -> f32 {
-    if !x.is_finite() || !y.is_finite() {
-        return 0.0;
-    }
-
-    match settings.interpolation {
-        InterpolationMode::Nearest => sample_mask_nearest(source, width, height, x, y),
-        InterpolationMode::Bilinear => sample_mask_bilinear(source, width, height, x, y),
-        InterpolationMode::Bicubic => sample_mask_bicubic(source, width, height, x, y),
-        InterpolationMode::Mitchell => sample_mask_mitchell(
-            source,
-            width,
-            height,
-            x,
-            y,
-            settings.mitchell_b,
-            settings.mitchell_c,
-        ),
-    }
-    .clamp(0.0, 1.0)
-}
-
 fn sample_mask_nearest(source: &[f32], width: usize, height: usize, x: f32, y: f32) -> f32 {
     fetch_mask_or_zero(
         source,
@@ -1543,7 +1767,7 @@ fn sample_mask_bilinear(source: &[f32], width: usize, height: usize, x: f32, y: 
 }
 
 fn sample_mask_bicubic(source: &[f32], width: usize, height: usize, x: f32, y: f32) -> f32 {
-    sample_mask_separable(source, width, height, x, y, 2.0, |d| cubic_weight(d, -0.5))
+    sample_mask_4x4(source, width, height, x, y, |d| cubic_weight(d, -0.5))
 }
 
 fn sample_mask_mitchell(
@@ -1555,42 +1779,29 @@ fn sample_mask_mitchell(
     b: f32,
     c: f32,
 ) -> f32 {
-    sample_mask_separable(source, width, height, x, y, 2.0, |d| {
-        mitchell_weight(d, b, c)
-    })
+    sample_mask_4x4(source, width, height, x, y, |d| mitchell_weight(d, b, c))
 }
 
-fn sample_mask_separable<F>(
+fn sample_mask_4x4<F>(
     source: &[f32],
     width: usize,
     height: usize,
     x: f32,
     y: f32,
-    radius: f32,
-    mut weight_fn: F,
+    weight_fn: F,
 ) -> f32
 where
-    F: FnMut(f32) -> f32,
+    F: Fn(f32) -> f32 + Copy,
 {
-    let min_y = (y - radius).floor() as isize;
-    let max_y = (y + radius).ceil() as isize;
-    let min_x = (x - radius).floor() as isize;
-    let max_x = (x + radius).ceil() as isize;
+    let (start_x, weights_x) = kernel_weights_4(x, weight_fn);
+    let (start_y, weights_y) = kernel_weights_4(y, weight_fn);
     let mut sum = 0.0;
     let mut weight_sum = 0.0;
 
-    for sy in min_y..=max_y {
-        let wy = weight_fn(y - sy as f32);
-        if wy == 0.0 {
-            continue;
-        }
-
-        for sx in min_x..=max_x {
-            let wx = weight_fn(x - sx as f32);
-            if wx == 0.0 {
-                continue;
-            }
-
+    for (y_offset, wy) in weights_y.into_iter().enumerate() {
+        let sy = start_y + y_offset as isize;
+        for (x_offset, wx) in weights_x.into_iter().enumerate() {
+            let sx = start_x + x_offset as isize;
             let weight = wx * wy;
             sum += fetch_mask_or_zero(source, width, height, sx, sy) * weight;
             weight_sum += weight;
@@ -1631,7 +1842,7 @@ fn sample_bilinear(source: &[PixelF32], width: usize, height: usize, x: f32, y: 
 }
 
 fn sample_bicubic(source: &[PixelF32], width: usize, height: usize, x: f32, y: f32) -> PixelF32 {
-    sample_separable(source, width, height, x, y, 2.0, |d| cubic_weight(d, -0.5))
+    sample_pixel_4x4(source, width, height, x, y, |d| cubic_weight(d, -0.5))
 }
 
 fn sample_mitchell(
@@ -1643,46 +1854,45 @@ fn sample_mitchell(
     b: f32,
     c: f32,
 ) -> PixelF32 {
-    sample_separable(source, width, height, x, y, 2.0, |d| {
-        mitchell_weight(d, b, c)
-    })
+    sample_pixel_4x4(source, width, height, x, y, |d| mitchell_weight(d, b, c))
 }
 
-fn sample_separable<F>(
+fn sample_pixel_4x4<F>(
     source: &[PixelF32],
     width: usize,
     height: usize,
     x: f32,
     y: f32,
-    radius: f32,
-    mut weight_fn: F,
+    weight_fn: F,
 ) -> PixelF32
 where
-    F: FnMut(f32) -> f32,
+    F: Fn(f32) -> f32 + Copy,
 {
-    let min_y = (y - radius).floor() as isize;
-    let max_y = (y + radius).ceil() as isize;
-    let min_x = (x - radius).floor() as isize;
-    let max_x = (x + radius).ceil() as isize;
+    let (start_x, weights_x) = kernel_weights_4(x, weight_fn);
+    let (start_y, weights_y) = kernel_weights_4(y, weight_fn);
     let mut acc = WeightedPixel::default();
 
-    for sy in min_y..=max_y {
-        let wy = weight_fn(y - sy as f32);
-        if wy == 0.0 {
-            continue;
-        }
-
-        for sx in min_x..=max_x {
-            let wx = weight_fn(x - sx as f32);
-            if wx == 0.0 {
-                continue;
-            }
-
+    for (y_offset, wy) in weights_y.into_iter().enumerate() {
+        let sy = start_y + y_offset as isize;
+        for (x_offset, wx) in weights_x.into_iter().enumerate() {
+            let sx = start_x + x_offset as isize;
             acc.add(fetch_or_transparent(source, width, height, sx, sy), wx * wy);
         }
     }
 
     acc.finish()
+}
+
+fn kernel_weights_4<F>(coord: f32, weight_fn: F) -> (isize, [f32; 4])
+where
+    F: Fn(f32) -> f32,
+{
+    let start = coord.floor() as isize - 1;
+    let mut weights = [0.0; 4];
+    for (offset, weight) in weights.iter_mut().enumerate() {
+        *weight = weight_fn(coord - (start + offset as isize) as f32);
+    }
+    (start, weights)
 }
 
 fn cubic_weight(d: f32, a: f32) -> f32 {
@@ -1962,6 +2172,52 @@ mod tests {
         );
     }
 
+    fn assert_pixel_close(actual: PixelF32, expected: PixelF32) {
+        assert_close(actual.alpha, expected.alpha);
+        assert_close(actual.red, expected.red);
+        assert_close(actual.green, expected.green);
+        assert_close(actual.blue, expected.blue);
+    }
+
+    fn legacy_mask_support_scan<F>(
+        source: &[f32],
+        width: usize,
+        height: usize,
+        x: f32,
+        y: f32,
+        mut weight_fn: F,
+    ) -> f32
+    where
+        F: FnMut(f32) -> f32,
+    {
+        let min_y = (y - 2.0).floor() as isize;
+        let max_y = (y + 2.0).ceil() as isize;
+        let min_x = (x - 2.0).floor() as isize;
+        let max_x = (x + 2.0).ceil() as isize;
+        let mut sum = 0.0;
+        let mut weight_sum = 0.0;
+        for sy in min_y..=max_y {
+            let wy = weight_fn(y - sy as f32);
+            if wy == 0.0 {
+                continue;
+            }
+            for sx in min_x..=max_x {
+                let wx = weight_fn(x - sx as f32);
+                if wx == 0.0 {
+                    continue;
+                }
+                let weight = wx * wy;
+                sum += fetch_mask_or_zero(source, width, height, sx, sy) * weight;
+                weight_sum += weight;
+            }
+        }
+        if weight_sum.abs() <= EPSILON {
+            0.0
+        } else {
+            sum / weight_sum
+        }
+    }
+
     fn assert_path_matches_incremental_geometry(settings: &Settings, direction_sign: f32) {
         let path = build_direction_path(settings, direction_sign);
         let base_angle = if direction_sign < 0.0 {
@@ -2022,5 +2278,78 @@ mod tests {
         };
         assert_close(direction.x, settings.direction_rad.cos());
         assert_close(direction.y, settings.direction_rad.sin());
+    }
+
+    #[test]
+    fn four_tap_kernels_match_legacy_support_scan() {
+        let source = [
+            0.0, 0.1, 0.2, 0.3, 0.4, 0.15, 0.25, 0.35, 0.45, 0.55, 0.3, 0.4, 0.5, 0.6, 0.7, 0.45,
+            0.55, 0.65, 0.75, 0.85,
+        ];
+        for (x, y) in [(-0.25, 0.4), (0.0, 0.0), (1.3, 2.7), (4.8, 3.2)] {
+            let cubic_expected =
+                legacy_mask_support_scan(&source, 5, 4, x, y, |d| cubic_weight(d, -0.5));
+            assert_close(sample_mask_bicubic(&source, 5, 4, x, y), cubic_expected);
+
+            let mitchell_expected = legacy_mask_support_scan(&source, 5, 4, x, y, |d| {
+                mitchell_weight(d, 1.0 / 3.0, 1.0 / 3.0)
+            });
+            assert_close(
+                sample_mask_mitchell(&source, 5, 4, x, y, 1.0 / 3.0, 1.0 / 3.0),
+                mitchell_expected,
+            );
+        }
+    }
+
+    #[test]
+    fn nearest_expansion_cache_preserves_compositing() {
+        let pixels = vec![
+            PixelF32 {
+                alpha: 0.4,
+                red: 0.3,
+                green: 0.2,
+                blue: 0.1,
+            };
+            9
+        ];
+        let masks = vec![0.8; 9];
+        let source = SourceImage {
+            pixels: &pixels,
+            masks: &masks,
+            width: 3,
+            height: 3,
+        };
+        let mut settings = test_settings();
+        settings.interpolation = InterpolationMode::Nearest;
+        let samples = build_expansion_samples(5);
+        let step = PathStep {
+            source_offset_x: 0.0,
+            source_offset_y: 0.0,
+            expansion_radius: 0.2,
+            falloff: 0.75,
+        };
+        let direction = DirectionBasis::from_angle(0.3);
+
+        let mut expected = transparent_pixel();
+        for sample in &samples {
+            let local_y = sample.radius_scale * step.expansion_radius;
+            let (sx, sy) = direction.offset_point(1.0, 1.0, 0.0, local_y);
+            expected = alpha_over(
+                expected,
+                sample_extension_point::<NearestKernel>(
+                    &source,
+                    sx,
+                    sy,
+                    &settings,
+                    step.falloff * sample.edge_weight,
+                ),
+            );
+            if expected.alpha >= 0.999 {
+                break;
+            }
+        }
+
+        let actual = sample_expanded_nearest(&source, (1.0, 1.0), direction, 1.0, &step, &samples);
+        assert_pixel_close(actual, expected);
     }
 }

--- a/plugins/pixel-extend/src/lib.rs
+++ b/plugins/pixel-extend/src/lib.rs
@@ -241,6 +241,69 @@ struct SourceImage<'a> {
     height: usize,
 }
 
+#[derive(Clone, Copy, Debug)]
+struct DirectionBasis {
+    x: f32,
+    y: f32,
+}
+
+impl DirectionBasis {
+    fn from_angle(angle: f32) -> Self {
+        Self {
+            x: angle.cos(),
+            y: angle.sin(),
+        }
+    }
+
+    fn offset_point(self, x: f32, y: f32, local_x: f32, local_y: f32) -> (f32, f32) {
+        (
+            x + self.x * local_x - self.y * local_y,
+            y + self.y * local_x + self.x * local_y,
+        )
+    }
+}
+
+#[derive(Debug)]
+enum DirectionField {
+    Constant(DirectionBasis),
+    PerPixel(Vec<DirectionBasis>),
+}
+
+impl DirectionField {
+    fn at(&self, index: usize) -> DirectionBasis {
+        match self {
+            Self::Constant(direction) => *direction,
+            Self::PerPixel(directions) => directions[index],
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct PathStep {
+    source_offset_x: f32,
+    source_offset_y: f32,
+    expansion_radius: f32,
+    falloff: f32,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ExpansionSample {
+    radius_scale: f32,
+    edge_weight: f32,
+}
+
+#[derive(Debug)]
+struct DirectionPath {
+    steps: Vec<PathStep>,
+    normal_sign: f32,
+}
+
+#[derive(Debug)]
+struct RenderPlan {
+    paths: Vec<DirectionPath>,
+    expansion_samples: Vec<ExpansionSample>,
+}
+
 #[derive(Clone, Copy, Debug, Default)]
 struct WeightedPixel {
     red: f32,
@@ -880,13 +943,17 @@ impl Plugin {
         let source = capture_source(&in_layer);
         let masks = build_mask_map(&source, &settings);
         let has_extension_source = masks.iter().any(|&mask| mask > EPSILON);
+        let should_render_extension = has_extension_source
+            && settings.opacity > EPSILON
+            && settings.extend_count > 0
+            && settings.step_size > EPSILON;
         let source_image = SourceImage {
             pixels: &source,
             masks: &masks,
             width,
             height,
         };
-        let map_checkout = if settings.use_direction_map {
+        let map_checkout = if settings.use_direction_map && should_render_extension {
             Some(params.checkout_at(Params::DirectionMapLayer, None, None, None)?)
         } else {
             None
@@ -906,22 +973,26 @@ impl Plugin {
             }
             _ => None,
         };
+        let render_context = should_render_extension.then(|| {
+            (
+                build_direction_field(width, height, &settings, direction_map.as_ref()),
+                build_render_plan(&settings),
+            )
+        });
         let progress_final = out_layer.height() as i32;
-        let should_render_extension = has_extension_source
-            && settings.opacity > EPSILON
-            && settings.extend_count > 0
-            && settings.step_size > EPSILON;
 
         out_layer.iterate(0, progress_final, None, |x, y, mut dst| {
-            let source_px = source[y as usize * width + x as usize];
-            let extend_px = if should_render_extension {
+            let pixel_index = y as usize * width + x as usize;
+            let source_px = source[pixel_index];
+            let extend_px = if let Some((direction_field, render_plan)) = &render_context {
                 scale_pixel_opacity(
                     extend_pixel(
                         &source_image,
                         x as f32,
                         y as f32,
                         &settings,
-                        direction_map.as_ref(),
+                        direction_field.at(pixel_index),
+                        render_plan,
                     ),
                     settings.opacity,
                 )
@@ -1044,27 +1115,27 @@ fn extend_pixel(
     x: f32,
     y: f32,
     settings: &Settings,
-    direction_map: Option<&DirectionMapData<'_>>,
+    direction: DirectionBasis,
+    render_plan: &RenderPlan,
 ) -> PixelF32 {
     if settings.extend_count == 0 || settings.step_size <= EPSILON {
         return transparent_pixel();
     }
 
-    let direction_rad =
-        mapped_direction_rad(x, y, source.width, source.height, settings, direction_map);
-
-    match settings.extend_direction {
-        ExtendDirection::Forward => {
-            extend_pixel_one_direction(source, x, y, settings, direction_rad, 1.0)
-        }
-        ExtendDirection::Backward => {
-            extend_pixel_one_direction(source, x, y, settings, direction_rad, -1.0)
-        }
-        ExtendDirection::Both => alpha_over(
-            extend_pixel_one_direction(source, x, y, settings, direction_rad, 1.0),
-            extend_pixel_one_direction(source, x, y, settings, direction_rad, -1.0),
-        ),
+    let mut out = transparent_pixel();
+    for path in &render_plan.paths {
+        let direction_px = extend_pixel_one_direction(
+            source,
+            x,
+            y,
+            settings,
+            direction,
+            path,
+            &render_plan.expansion_samples,
+        );
+        out = alpha_over(out, direction_px);
     }
+    out
 }
 
 fn extend_pixel_one_direction(
@@ -1072,40 +1143,25 @@ fn extend_pixel_one_direction(
     x: f32,
     y: f32,
     settings: &Settings,
-    direction_rad: f32,
-    direction_sign: f32,
+    direction: DirectionBasis,
+    path: &DirectionPath,
+    expansion_samples: &[ExpansionSample],
 ) -> PixelF32 {
     let mut out = transparent_pixel();
-    let base_angle = direction_rad
-        + if direction_sign < 0.0 {
-            std::f32::consts::PI
-        } else {
-            0.0
-        };
-    let mut path_x = base_angle.cos() * settings.offset;
-    let mut path_y = base_angle.sin() * settings.offset;
-    let mut falloff = 1.0f32;
 
-    for step in 0..=settings.extend_count {
-        let t = if settings.extend_count == 0 {
-            0.0
-        } else {
-            step as f32 / settings.extend_count as f32
-        };
-        let sx = x - path_x;
-        let sy = y - path_y;
-        let expansion_radius = step as f32 * settings.expansion_per_step;
-        let step_px = if expansion_radius <= EPSILON || settings.expansion_samples <= 1 {
-            sample_extension_point(source, sx, sy, settings, falloff)
+    for step in &path.steps {
+        let step_px = if step.expansion_radius <= EPSILON || expansion_samples.len() <= 1 {
+            let (sx, sy) = direction.offset_point(x, y, step.source_offset_x, step.source_offset_y);
+            sample_extension_point(source, sx, sy, settings, step.falloff)
         } else {
             sample_expanded_extension(
                 source,
-                sx,
-                sy,
-                base_angle,
-                expansion_radius,
+                (x, y),
+                direction,
+                path.normal_sign,
+                step,
+                expansion_samples,
                 settings,
-                falloff,
             )
         };
 
@@ -1114,14 +1170,6 @@ fn extend_pixel_one_direction(
             if out.alpha >= 0.999 {
                 break;
             }
-        }
-
-        let angle = base_angle + settings.angle_change_rad * t * direction_sign;
-        path_x += angle.cos() * settings.step_size;
-        path_y += angle.sin() * settings.step_size;
-        falloff *= settings.decay;
-        if falloff <= EPSILON && settings.decay < 1.0 {
-            break;
         }
     }
 
@@ -1149,34 +1197,21 @@ fn sample_extension_point(
 
 fn sample_expanded_extension(
     source: &SourceImage<'_>,
-    x: f32,
-    y: f32,
-    angle: f32,
-    radius: f32,
+    output: (f32, f32),
+    direction: DirectionBasis,
+    normal_sign: f32,
+    step: &PathStep,
+    expansion_samples: &[ExpansionSample],
     settings: &Settings,
-    falloff: f32,
 ) -> PixelF32 {
-    let sample_count = settings.expansion_samples.max(1);
-    let denom = sample_count.saturating_sub(1).max(1) as f32;
-    let normal_x = -angle.sin();
-    let normal_y = angle.cos();
     let mut out = transparent_pixel();
 
-    for sample in 0..sample_count {
-        let u = if sample_count == 1 {
-            0.0
-        } else {
-            (sample as f32 / denom) * 2.0 - 1.0
-        };
-        let offset = u * radius;
-        let edge_weight = 1.0 - u.abs() * 0.5;
-        let px = sample_extension_point(
-            source,
-            x + normal_x * offset,
-            y + normal_y * offset,
-            settings,
-            falloff * edge_weight,
-        );
+    for sample in expansion_samples {
+        let local_y =
+            step.source_offset_y + normal_sign * sample.radius_scale * step.expansion_radius;
+        let (sx, sy) = direction.offset_point(output.0, output.1, step.source_offset_x, local_y);
+        let px =
+            sample_extension_point(source, sx, sy, settings, step.falloff * sample.edge_weight);
         out = alpha_over(out, px);
         if out.alpha >= 0.999 {
             break;
@@ -1184,6 +1219,78 @@ fn sample_expanded_extension(
     }
 
     out
+}
+
+fn build_render_plan(settings: &Settings) -> RenderPlan {
+    let mut paths = Vec::with_capacity(match settings.extend_direction {
+        ExtendDirection::Both => 2,
+        _ => 1,
+    });
+    match settings.extend_direction {
+        ExtendDirection::Forward => paths.push(build_direction_path(settings, 1.0)),
+        ExtendDirection::Backward => paths.push(build_direction_path(settings, -1.0)),
+        ExtendDirection::Both => {
+            paths.push(build_direction_path(settings, 1.0));
+            paths.push(build_direction_path(settings, -1.0));
+        }
+    }
+
+    RenderPlan {
+        paths,
+        expansion_samples: build_expansion_samples(settings.expansion_samples),
+    }
+}
+
+fn build_direction_path(settings: &Settings, direction_sign: f32) -> DirectionPath {
+    let mut steps = Vec::with_capacity(settings.extend_count.saturating_add(1));
+    let mut path_x = direction_sign * settings.offset;
+    let mut path_y = 0.0f32;
+    let mut falloff = 1.0f32;
+
+    for step in 0..=settings.extend_count {
+        steps.push(PathStep {
+            source_offset_x: -path_x,
+            source_offset_y: -path_y,
+            expansion_radius: step as f32 * settings.expansion_per_step,
+            falloff,
+        });
+
+        let t = if settings.extend_count == 0 {
+            0.0
+        } else {
+            step as f32 / settings.extend_count as f32
+        };
+        let angle_delta = settings.angle_change_rad * t;
+        path_x += direction_sign * angle_delta.cos() * settings.step_size;
+        path_y += angle_delta.sin() * settings.step_size;
+        falloff *= settings.decay;
+        if falloff <= EPSILON && settings.decay < 1.0 {
+            break;
+        }
+    }
+
+    DirectionPath {
+        steps,
+        normal_sign: direction_sign,
+    }
+}
+
+fn build_expansion_samples(sample_count: usize) -> Vec<ExpansionSample> {
+    let sample_count = sample_count.max(1);
+    let denom = sample_count.saturating_sub(1).max(1) as f32;
+    (0..sample_count)
+        .map(|sample| {
+            let radius_scale = if sample_count == 1 {
+                0.0
+            } else {
+                (sample as f32 / denom) * 2.0 - 1.0
+            };
+            ExpansionSample {
+                radius_scale,
+                edge_weight: 1.0 - radius_scale.abs() * 0.5,
+            }
+        })
+        .collect()
 }
 
 fn odd_sample_count(count: usize) -> usize {
@@ -1195,38 +1302,43 @@ fn odd_sample_count(count: usize) -> usize {
     }
 }
 
-fn mapped_direction_rad(
-    x: f32,
-    y: f32,
-    out_width: usize,
-    out_height: usize,
+fn build_direction_field(
+    width: usize,
+    height: usize,
     settings: &Settings,
     direction_map: Option<&DirectionMapData<'_>>,
-) -> f32 {
+) -> DirectionField {
+    let base = DirectionBasis::from_angle(settings.direction_rad);
     if !settings.use_direction_map || settings.map_influence <= EPSILON {
-        return settings.direction_rad;
+        return DirectionField::Constant(base);
     }
 
     let Some(map) = direction_map else {
-        return settings.direction_rad;
+        return DirectionField::Constant(base);
     };
 
-    let map_x = remap_axis_to_map(x, out_width, map.width);
-    let map_y = remap_axis_to_map(y, out_height, map.height);
-    let Some((map_dx, map_dy)) = direction_map_vector(map, map_x, map_y, settings) else {
-        return settings.direction_rad;
-    };
-
-    let base_x = settings.direction_rad.cos();
-    let base_y = settings.direction_rad.sin();
-    let influence = settings.map_influence;
-    let dir_x = base_x * (1.0 - influence) + map_dx * influence;
-    let dir_y = base_y * (1.0 - influence) + map_dy * influence;
-    if dir_x.abs() <= EPSILON && dir_y.abs() <= EPSILON {
-        settings.direction_rad
-    } else {
-        dir_y.atan2(dir_x)
+    let mut directions = Vec::with_capacity(width.saturating_mul(height));
+    for y in 0..height {
+        for x in 0..width {
+            let map_x = remap_axis_to_map(x as f32, width, map.width);
+            let map_y = remap_axis_to_map(y as f32, height, map.height);
+            let direction = direction_map_vector(map, map_x, map_y, settings)
+                .and_then(|(map_dx, map_dy)| {
+                    let influence = settings.map_influence;
+                    let dir_x = base.x * (1.0 - influence) + map_dx * influence;
+                    let dir_y = base.y * (1.0 - influence) + map_dy * influence;
+                    let len = (dir_x * dir_x + dir_y * dir_y).sqrt();
+                    (len.is_finite() && len > EPSILON).then_some(DirectionBasis {
+                        x: dir_x / len,
+                        y: dir_y / len,
+                    })
+                })
+                .unwrap_or(base);
+            directions.push(direction);
+        }
     }
+
+    DirectionField::PerPixel(directions)
 }
 
 fn direction_map_vector(
@@ -1806,5 +1918,109 @@ fn write_output_pixel(dst: &mut GenericPixelMut<'_>, px: PixelF32) {
             p.greenF = px.green as _;
             p.blueF = px.blue as _;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_settings() -> Settings {
+        Settings {
+            direction_rad: 0.37,
+            extend_count: 8,
+            extend_direction: ExtendDirection::Both,
+            step_size: 1.25,
+            offset: 2.5,
+            use_direction_map: false,
+            map_channel: MapChannel::Red,
+            map_vector_mode: MapVectorMode::Gradient,
+            map_influence: 0.0,
+            decay: 0.9,
+            angle_change_rad: 0.7,
+            expansion_per_step: 0.4,
+            expansion_samples: 5,
+            basis: SourceBasis::Alpha,
+            select_mode: SelectMode::Above,
+            invert_detection: false,
+            threshold: 0.5,
+            softness: 0.0,
+            target_color: transparent_pixel(),
+            interpolation: InterpolationMode::Bilinear,
+            mitchell_b: 1.0 / 3.0,
+            mitchell_c: 1.0 / 3.0,
+            blend_mode: BlendMode::Normal,
+            opacity: 1.0,
+            show_source: true,
+        }
+    }
+
+    fn assert_close(actual: f32, expected: f32) {
+        assert!(
+            (actual - expected).abs() <= 1.0e-5,
+            "actual={actual}, expected={expected}"
+        );
+    }
+
+    fn assert_path_matches_incremental_geometry(settings: &Settings, direction_sign: f32) {
+        let path = build_direction_path(settings, direction_sign);
+        let base_angle = if direction_sign < 0.0 {
+            std::f32::consts::PI
+        } else {
+            0.0
+        };
+        let mut path_x = base_angle.cos() * settings.offset;
+        let mut path_y = base_angle.sin() * settings.offset;
+        let mut falloff = 1.0f32;
+
+        for (step, planned) in path.steps.iter().enumerate() {
+            assert_close(planned.source_offset_x, -path_x);
+            assert_close(planned.source_offset_y, -path_y);
+            assert_close(
+                planned.expansion_radius,
+                step as f32 * settings.expansion_per_step,
+            );
+            assert_close(planned.falloff, falloff);
+
+            let t = step as f32 / settings.extend_count as f32;
+            let angle = base_angle + settings.angle_change_rad * t * direction_sign;
+            path_x += angle.cos() * settings.step_size;
+            path_y += angle.sin() * settings.step_size;
+            falloff *= settings.decay;
+        }
+    }
+
+    #[test]
+    fn precomputed_paths_match_incremental_geometry() {
+        let settings = test_settings();
+        assert_path_matches_incremental_geometry(&settings, 1.0);
+        assert_path_matches_incremental_geometry(&settings, -1.0);
+    }
+
+    #[test]
+    fn precomputed_expansion_samples_keep_order_and_weights() {
+        let samples = build_expansion_samples(5);
+        let expected = [
+            (-1.0, 0.5),
+            (-0.5, 0.75),
+            (0.0, 1.0),
+            (0.5, 0.75),
+            (1.0, 0.5),
+        ];
+        for (sample, (radius_scale, edge_weight)) in samples.iter().zip(expected) {
+            assert_close(sample.radius_scale, radius_scale);
+            assert_close(sample.edge_weight, edge_weight);
+        }
+    }
+
+    #[test]
+    fn constant_direction_field_avoids_per_pixel_storage() {
+        let settings = test_settings();
+        let field = build_direction_field(1920, 1080, &settings, None);
+        let DirectionField::Constant(direction) = field else {
+            panic!("expected a constant direction field");
+        };
+        assert_close(direction.x, settings.direction_rad.cos());
+        assert_close(direction.y, settings.direction_rad.sin());
     }
 }

--- a/plugins/pixel-extend/src/lib.rs
+++ b/plugins/pixel-extend/src/lib.rs
@@ -1,0 +1,1810 @@
+#![allow(clippy::drop_non_drop, clippy::question_mark)]
+
+use after_effects as ae;
+use std::env;
+
+use ae::pf::*;
+use utils::ToPixel;
+
+#[derive(Eq, PartialEq, Hash, Clone, Copy, Debug)]
+enum Params {
+    Direction,
+    ExtendCount,
+    ExtendDirection,
+    StepSize,
+    Offset,
+    DirectionMapGroupStart,
+    UseDirectionMap,
+    DirectionMapLayer,
+    MapChannel,
+    MapVectorMode,
+    MapInfluence,
+    DirectionMapGroupEnd,
+    ShapeGroupStart,
+    Decay,
+    AngleChange,
+    ExpansionPerStep,
+    ExpansionSamples,
+    ShapeGroupEnd,
+    DetectionGroupStart,
+    Basis,
+    SelectMode,
+    ColorMode,
+    InvertDetection,
+    Threshold,
+    Softness,
+    TargetColor,
+    DetectionGroupEnd,
+    InterpolationGroupStart,
+    Interpolation,
+    MitchellB,
+    MitchellC,
+    InterpolationGroupEnd,
+    CompositeGroupStart,
+    BlendMode,
+    Opacity,
+    ShowSource,
+    CompositeGroupEnd,
+}
+
+#[derive(Default)]
+struct Plugin {
+    aegp_id: Option<ae::aegp::PluginId>,
+}
+
+ae::define_effect!(Plugin, (), Params);
+
+const PLUGIN_DESCRIPTION: &str =
+    "Extends pixels in adjustable directions with selectable source masks and interpolation.";
+const EPSILON: f32 = 1.0e-6;
+
+#[derive(Clone, Copy, Debug)]
+enum SourceBasis {
+    Alpha,
+    Lightness,
+    Color,
+}
+
+impl SourceBasis {
+    fn from_popup_value(value: i32) -> Self {
+        match value {
+            2 => Self::Lightness,
+            3 => Self::Color,
+            _ => Self::Alpha,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum SelectMode {
+    Above,
+    Below,
+    Similar,
+    Different,
+}
+
+impl SelectMode {
+    fn from_popup_value(value: i32) -> Self {
+        match value {
+            2 => Self::Below,
+            3 => Self::Similar,
+            4 => Self::Different,
+            _ => Self::Above,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum InterpolationMode {
+    Nearest,
+    Bilinear,
+    Bicubic,
+    Mitchell,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum ExtendDirection {
+    Forward,
+    Backward,
+    Both,
+}
+
+impl ExtendDirection {
+    fn from_popup_value(value: i32) -> Self {
+        match value {
+            2 => Self::Backward,
+            3 => Self::Both,
+            _ => Self::Forward,
+        }
+    }
+}
+
+impl InterpolationMode {
+    fn from_popup_value(value: i32) -> Self {
+        match value {
+            1 => Self::Nearest,
+            3 => Self::Bicubic,
+            4 => Self::Mitchell,
+            _ => Self::Bilinear,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum BlendMode {
+    Normal,
+    Add,
+    Multiply,
+    Screen,
+    Overlay,
+    Darken,
+    Lighten,
+}
+
+impl BlendMode {
+    fn from_popup_value(value: i32) -> Self {
+        match value {
+            2 => Self::Add,
+            3 => Self::Multiply,
+            4 => Self::Screen,
+            5 => Self::Overlay,
+            6 => Self::Darken,
+            7 => Self::Lighten,
+            _ => Self::Normal,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum MapChannel {
+    Red,
+    Green,
+    Blue,
+    Alpha,
+    Hue,
+    Saturation,
+    Value,
+}
+
+impl MapChannel {
+    fn from_popup_value(value: i32) -> Self {
+        match value {
+            2 => Self::Green,
+            3 => Self::Blue,
+            4 => Self::Alpha,
+            5 => Self::Hue,
+            6 => Self::Saturation,
+            7 => Self::Value,
+            _ => Self::Red,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum MapVectorMode {
+    Gradient,
+    Divergence,
+    Rotation,
+}
+
+impl MapVectorMode {
+    fn from_popup_value(value: i32) -> Self {
+        match value {
+            2 => Self::Divergence,
+            3 => Self::Rotation,
+            _ => Self::Gradient,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Settings {
+    direction_rad: f32,
+    extend_count: usize,
+    extend_direction: ExtendDirection,
+    step_size: f32,
+    offset: f32,
+    use_direction_map: bool,
+    map_channel: MapChannel,
+    map_vector_mode: MapVectorMode,
+    map_influence: f32,
+    decay: f32,
+    angle_change_rad: f32,
+    expansion_per_step: f32,
+    expansion_samples: usize,
+    basis: SourceBasis,
+    select_mode: SelectMode,
+    invert_detection: bool,
+    threshold: f32,
+    softness: f32,
+    target_color: PixelF32,
+    interpolation: InterpolationMode,
+    mitchell_b: f32,
+    mitchell_c: f32,
+    blend_mode: BlendMode,
+    opacity: f32,
+    show_source: bool,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct DirectionMapData<'a> {
+    pixels: &'a [PixelF32],
+    width: usize,
+    height: usize,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct SourceImage<'a> {
+    pixels: &'a [PixelF32],
+    masks: &'a [f32],
+    width: usize,
+    height: usize,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct WeightedPixel {
+    red: f32,
+    green: f32,
+    blue: f32,
+    alpha: f32,
+    weight: f32,
+}
+
+impl WeightedPixel {
+    fn add(&mut self, px: PixelF32, weight: f32) {
+        if weight == 0.0 || !weight.is_finite() {
+            return;
+        }
+
+        self.red += px.red * weight;
+        self.green += px.green * weight;
+        self.blue += px.blue * weight;
+        self.alpha += px.alpha * weight;
+        self.weight += weight;
+    }
+
+    fn finish(self) -> PixelF32 {
+        if self.weight.abs() <= EPSILON {
+            return transparent_pixel();
+        }
+
+        let inv = 1.0 / self.weight;
+        PixelF32 {
+            alpha: clamp01(self.alpha * inv),
+            red: clamp01(self.red * inv),
+            green: clamp01(self.green * inv),
+            blue: clamp01(self.blue * inv),
+        }
+    }
+}
+
+impl AdobePluginGlobal for Plugin {
+    fn params_setup(
+        &self,
+        params: &mut ae::Parameters<Params>,
+        _in_data: InData,
+        _: OutData,
+    ) -> Result<(), Error> {
+        params.add(
+            Params::Direction,
+            "Direction",
+            AngleDef::setup(|d| {
+                d.set_default(45.0);
+                d.set_value(d.default());
+            }),
+        )?;
+
+        params.add(
+            Params::ExtendCount,
+            "Extend Count",
+            SliderDef::setup(|d| {
+                d.set_valid_min(0);
+                d.set_valid_max(4096);
+                d.set_slider_min(0);
+                d.set_slider_max(512);
+                d.set_default(64);
+            }),
+        )?;
+
+        params.add(
+            Params::ExtendDirection,
+            "Extend Direction",
+            PopupDef::setup(|d| {
+                d.set_options(&["Forward", "Backward", "Both"]);
+                d.set_default(1);
+            }),
+        )?;
+
+        params.add(
+            Params::StepSize,
+            "Step Size (px)",
+            FloatSliderDef::setup(|d| {
+                d.set_valid_min(0.0);
+                d.set_valid_max(64.0);
+                d.set_slider_min(0.0);
+                d.set_slider_max(16.0);
+                d.set_default(1.0);
+                d.set_precision(3);
+            }),
+        )?;
+
+        params.add(
+            Params::Offset,
+            "Offset",
+            FloatSliderDef::setup(|d| {
+                d.set_valid_min(-4096.0);
+                d.set_valid_max(4096.0);
+                d.set_slider_min(-512.0);
+                d.set_slider_max(512.0);
+                d.set_default(0.0);
+                d.set_precision(3);
+            }),
+        )?;
+
+        params.add_group(
+            Params::DirectionMapGroupStart,
+            Params::DirectionMapGroupEnd,
+            "Direction Map",
+            true,
+            |params| {
+                params.add_with_flags(
+                    Params::UseDirectionMap,
+                    "Use Direction Map",
+                    CheckBoxDef::setup(|d| {
+                        d.set_default(false);
+                    }),
+                    ae::ParamFlag::SUPERVISE,
+                    ae::ParamUIFlags::empty(),
+                )?;
+
+                params.add_with_flags(
+                    Params::DirectionMapLayer,
+                    "Direction Map Layer",
+                    LayerDef::new(),
+                    ae::ParamFlag::empty(),
+                    ae::ParamUIFlags::INVISIBLE,
+                )?;
+
+                params.add_with_flags(
+                    Params::MapChannel,
+                    "Map Channel",
+                    PopupDef::setup(|d| {
+                        d.set_options(&[
+                            "Red",
+                            "Green",
+                            "Blue",
+                            "Alpha",
+                            "Hue",
+                            "Saturation",
+                            "Value",
+                        ]);
+                        d.set_default(1);
+                    }),
+                    ae::ParamFlag::empty(),
+                    ae::ParamUIFlags::INVISIBLE,
+                )?;
+
+                params.add_with_flags(
+                    Params::MapVectorMode,
+                    "Map Vector Mode",
+                    PopupDef::setup(|d| {
+                        d.set_options(&["Gradient", "Divergence", "Rotation"]);
+                        d.set_default(1);
+                    }),
+                    ae::ParamFlag::empty(),
+                    ae::ParamUIFlags::INVISIBLE,
+                )?;
+
+                params.add_with_flags(
+                    Params::MapInfluence,
+                    "Map Influence",
+                    FloatSliderDef::setup(|d| {
+                        d.set_valid_min(0.0);
+                        d.set_valid_max(100.0);
+                        d.set_slider_min(0.0);
+                        d.set_slider_max(100.0);
+                        d.set_default(100.0);
+                        d.set_precision(2);
+                    }),
+                    ae::ParamFlag::empty(),
+                    ae::ParamUIFlags::INVISIBLE,
+                )?;
+
+                Ok(())
+            },
+        )?;
+
+        params.add_group(
+            Params::ShapeGroupStart,
+            Params::ShapeGroupEnd,
+            "Falloff / Curve",
+            true,
+            |params| {
+                params.add(
+                    Params::Decay,
+                    "Decay",
+                    FloatSliderDef::setup(|d| {
+                        d.set_valid_min(0.0);
+                        d.set_valid_max(1.0);
+                        d.set_slider_min(0.0);
+                        d.set_slider_max(1.0);
+                        d.set_default(1.0);
+                        d.set_precision(4);
+                    }),
+                )?;
+
+                params.add(
+                    Params::AngleChange,
+                    "Angle Change",
+                    AngleDef::setup(|d| {
+                        d.set_default(0.0);
+                        d.set_value(d.default());
+                    }),
+                )?;
+
+                params.add(
+                    Params::ExpansionPerStep,
+                    "Expansion / Step",
+                    FloatSliderDef::setup(|d| {
+                        d.set_valid_min(0.0);
+                        d.set_valid_max(64.0);
+                        d.set_slider_min(0.0);
+                        d.set_slider_max(8.0);
+                        d.set_default(0.0);
+                        d.set_precision(3);
+                    }),
+                )?;
+
+                params.add(
+                    Params::ExpansionSamples,
+                    "Expansion Samples",
+                    SliderDef::setup(|d| {
+                        d.set_valid_min(1);
+                        d.set_valid_max(65);
+                        d.set_slider_min(1);
+                        d.set_slider_max(17);
+                        d.set_default(5);
+                    }),
+                )?;
+
+                Ok(())
+            },
+        )?;
+
+        params.add_group(
+            Params::DetectionGroupStart,
+            Params::DetectionGroupEnd,
+            "Pixel Detection",
+            false,
+            |params| {
+                params.add_with_flags(
+                    Params::Basis,
+                    "Source Basis",
+                    PopupDef::setup(|d| {
+                        d.set_options(&["Alpha", "Lightness", "Color"]);
+                        d.set_default(1);
+                    }),
+                    ae::ParamFlag::SUPERVISE,
+                    ae::ParamUIFlags::empty(),
+                )?;
+
+                params.add(
+                    Params::SelectMode,
+                    "Threshold Mode",
+                    PopupDef::setup(|d| {
+                        d.set_options(&["Above / Brighter", "Below / Darker"]);
+                        d.set_default(1);
+                    }),
+                )?;
+
+                params.add_with_flags(
+                    Params::ColorMode,
+                    "Color Mode",
+                    PopupDef::setup(|d| {
+                        d.set_options(&["Similar Color", "Different Color"]);
+                        d.set_default(1);
+                    }),
+                    ae::ParamFlag::empty(),
+                    ae::ParamUIFlags::INVISIBLE,
+                )?;
+
+                params.add(
+                    Params::InvertDetection,
+                    "Invert Detection",
+                    CheckBoxDef::setup(|d| {
+                        d.set_default(false);
+                    }),
+                )?;
+
+                params.add(
+                    Params::Threshold,
+                    "Threshold",
+                    FloatSliderDef::setup(|d| {
+                        d.set_valid_min(0.0);
+                        d.set_valid_max(1.0);
+                        d.set_slider_min(0.0);
+                        d.set_slider_max(1.0);
+                        d.set_default(0.5);
+                        d.set_precision(4);
+                    }),
+                )?;
+
+                params.add(
+                    Params::Softness,
+                    "Softness",
+                    FloatSliderDef::setup(|d| {
+                        d.set_valid_min(0.0);
+                        d.set_valid_max(1.0);
+                        d.set_slider_min(0.0);
+                        d.set_slider_max(1.0);
+                        d.set_default(0.0);
+                        d.set_precision(4);
+                    }),
+                )?;
+
+                params.add_with_flags(
+                    Params::TargetColor,
+                    "Target Color",
+                    ColorDef::setup(|d| {
+                        d.set_default(Pixel8 {
+                            alpha: 255,
+                            red: 255,
+                            green: 255,
+                            blue: 255,
+                        });
+                    }),
+                    ae::ParamFlag::empty(),
+                    ae::ParamUIFlags::INVISIBLE,
+                )?;
+
+                Ok(())
+            },
+        )?;
+
+        params.add_group(
+            Params::InterpolationGroupStart,
+            Params::InterpolationGroupEnd,
+            "Interpolation",
+            true,
+            |params| {
+                params.add_with_flags(
+                    Params::Interpolation,
+                    "Interpolation",
+                    PopupDef::setup(|d| {
+                        d.set_options(&["Nearest", "Bilinear", "Bicubic", "Mitchell"]);
+                        d.set_default(2);
+                    }),
+                    ae::ParamFlag::SUPERVISE,
+                    ae::ParamUIFlags::empty(),
+                )?;
+
+                params.add_with_flags(
+                    Params::MitchellB,
+                    "Mitchell B",
+                    FloatSliderDef::setup(|d| {
+                        d.set_valid_min(0.0);
+                        d.set_valid_max(1.0);
+                        d.set_slider_min(0.0);
+                        d.set_slider_max(1.0);
+                        d.set_default(1.0 / 3.0);
+                        d.set_precision(3);
+                    }),
+                    ae::ParamFlag::empty(),
+                    ae::ParamUIFlags::INVISIBLE,
+                )?;
+
+                params.add_with_flags(
+                    Params::MitchellC,
+                    "Mitchell C",
+                    FloatSliderDef::setup(|d| {
+                        d.set_valid_min(0.0);
+                        d.set_valid_max(1.0);
+                        d.set_slider_min(0.0);
+                        d.set_slider_max(1.0);
+                        d.set_default(1.0 / 3.0);
+                        d.set_precision(3);
+                    }),
+                    ae::ParamFlag::empty(),
+                    ae::ParamUIFlags::INVISIBLE,
+                )?;
+
+                Ok(())
+            },
+        )?;
+
+        params.add_group(
+            Params::CompositeGroupStart,
+            Params::CompositeGroupEnd,
+            "Composite",
+            false,
+            |params| {
+                params.add_with_flags(
+                    Params::ShowSource,
+                    "Show Source",
+                    CheckBoxDef::setup(|d| {
+                        d.set_default(true);
+                    }),
+                    ae::ParamFlag::SUPERVISE,
+                    ae::ParamUIFlags::empty(),
+                )?;
+
+                params.add(
+                    Params::BlendMode,
+                    "Blend Mode",
+                    PopupDef::setup(|d| {
+                        d.set_options(&[
+                            "Normal", "Add", "Multiply", "Screen", "Overlay", "Darken", "Lighten",
+                        ]);
+                        d.set_default(1);
+                    }),
+                )?;
+
+                params.add(
+                    Params::Opacity,
+                    "Opacity",
+                    FloatSliderDef::setup(|d| {
+                        d.set_valid_min(0.0);
+                        d.set_valid_max(100.0);
+                        d.set_slider_min(0.0);
+                        d.set_slider_max(100.0);
+                        d.set_default(100.0);
+                        d.set_precision(2);
+                    }),
+                )?;
+
+                Ok(())
+            },
+        )?;
+
+        Ok(())
+    }
+
+    fn handle_command(
+        &mut self,
+        cmd: ae::Command,
+        in_data: InData,
+        mut out_data: OutData,
+        params: &mut ae::Parameters<Params>,
+    ) -> Result<(), ae::Error> {
+        match cmd {
+            ae::Command::About => {
+                out_data.set_return_msg(
+                    format!(
+                        "AOD_PixelExtend - {version}\r\r{PLUGIN_DESCRIPTION}\rCopyright (c) 2026-{build_year} Aodaruma",
+                        version = env!("CARGO_PKG_VERSION"),
+                        build_year = env!("BUILD_YEAR")
+                    )
+                    .as_str(),
+                );
+            }
+            ae::Command::GlobalSetup => {
+                out_data.set_out_flag(OutFlags::SendUpdateParamsUi, true);
+                out_data.set_out_flag2(OutFlags2::SupportsSmartRender, true);
+                out_data.set_out_flag2(OutFlags2::ParamGroupStartCollapsedFlag, true);
+                if let Ok(suite) = ae::aegp::suites::Utility::new()
+                    && let Ok(plugin_id) = suite.register_with_aegp("AOD_PixelExtend")
+                {
+                    self.aegp_id = Some(plugin_id);
+                }
+            }
+            ae::Command::Render {
+                in_layer,
+                out_layer,
+            } => {
+                self.do_render(in_data, in_layer, out_layer, params)?;
+            }
+            ae::Command::SmartPreRender { mut extra } => {
+                let req = extra.output_request();
+
+                if let Ok(in_result) = extra.callbacks().checkout_layer(
+                    0,
+                    0,
+                    &req,
+                    in_data.current_time(),
+                    in_data.time_step(),
+                    in_data.time_scale(),
+                ) {
+                    let _ = extra.union_result_rect(in_result.result_rect.into());
+                    let _ = extra.union_max_result_rect(in_result.max_result_rect.into());
+                } else {
+                    return Err(Error::InterruptCancel);
+                }
+            }
+            ae::Command::SmartRender { extra } => {
+                let cb = extra.callbacks();
+                let in_layer_opt = cb.checkout_layer_pixels(0)?;
+                let out_layer_opt = cb.checkout_output()?;
+
+                if let (Some(in_layer), Some(out_layer)) = (in_layer_opt, out_layer_opt) {
+                    self.do_render(in_data, in_layer, out_layer, params)?;
+                }
+
+                cb.checkin_layer_pixels(0)?;
+            }
+            ae::Command::UserChangedParam { param_index } => {
+                let changed = params.type_at(param_index);
+                if changed == Params::Basis
+                    || changed == Params::Interpolation
+                    || changed == Params::ShowSource
+                    || changed == Params::UseDirectionMap
+                {
+                    out_data.set_out_flag(OutFlags::RefreshUi, true);
+                }
+            }
+            ae::Command::UpdateParamsUi => {
+                let mut params_copy = params.cloned();
+                self.update_params_ui(in_data, &mut params_copy)?;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+}
+
+impl Plugin {
+    fn update_params_ui(
+        &self,
+        in_data: InData,
+        params: &mut Parameters<Params>,
+    ) -> Result<(), Error> {
+        let basis = SourceBasis::from_popup_value(params.get(Params::Basis)?.as_popup()?.value());
+        let interpolation = InterpolationMode::from_popup_value(
+            params.get(Params::Interpolation)?.as_popup()?.value(),
+        );
+        let show_source = params.get(Params::ShowSource)?.as_checkbox()?.value();
+        let use_direction_map = params.get(Params::UseDirectionMap)?.as_checkbox()?.value();
+
+        self.set_param_visible(
+            in_data,
+            params,
+            Params::DirectionMapLayer,
+            use_direction_map,
+        )?;
+        self.set_param_visible(in_data, params, Params::MapChannel, use_direction_map)?;
+        self.set_param_visible(in_data, params, Params::MapVectorMode, use_direction_map)?;
+        self.set_param_visible(in_data, params, Params::MapInfluence, use_direction_map)?;
+        self.set_param_visible(
+            in_data,
+            params,
+            Params::SelectMode,
+            !matches!(basis, SourceBasis::Color),
+        )?;
+        self.set_param_visible(
+            in_data,
+            params,
+            Params::ColorMode,
+            matches!(basis, SourceBasis::Color),
+        )?;
+        self.set_param_visible(
+            in_data,
+            params,
+            Params::TargetColor,
+            matches!(basis, SourceBasis::Color),
+        )?;
+        self.set_param_visible(
+            in_data,
+            params,
+            Params::MitchellB,
+            matches!(interpolation, InterpolationMode::Mitchell),
+        )?;
+        self.set_param_visible(
+            in_data,
+            params,
+            Params::MitchellC,
+            matches!(interpolation, InterpolationMode::Mitchell),
+        )?;
+        self.set_param_visible(in_data, params, Params::BlendMode, show_source)?;
+
+        Self::set_param_name(
+            params,
+            Params::Threshold,
+            match basis {
+                SourceBasis::Alpha => "Alpha Threshold",
+                SourceBasis::Lightness => "Lightness Threshold",
+                SourceBasis::Color => "Color Tolerance",
+            },
+        )?;
+        Ok(())
+    }
+
+    fn set_param_name(
+        params: &mut ae::Parameters<Params>,
+        id: Params,
+        name: &str,
+    ) -> Result<(), Error> {
+        let mut p = params.get_mut(id)?;
+        p.set_name(name)?;
+        p.update_param_ui()?;
+        Ok(())
+    }
+
+    fn set_param_visible(
+        &self,
+        in_data: InData,
+        params: &mut ae::Parameters<Params>,
+        id: Params,
+        visible: bool,
+    ) -> Result<(), Error> {
+        if in_data.is_premiere() {
+            return Self::set_param_ui_flag(params, id, ae::pf::ParamUIFlags::INVISIBLE, !visible);
+        }
+
+        if let Some(plugin_id) = self.aegp_id {
+            let effect = in_data.effect();
+            if let Some(index) = params.index(id)
+                && let Ok(effect_ref) = effect.aegp_effect(plugin_id)
+                && let Ok(stream) = effect_ref.new_stream_by_index(plugin_id, index as i32)
+            {
+                return stream.set_dynamic_stream_flag(
+                    ae::aegp::DynamicStreamFlags::Hidden,
+                    false,
+                    !visible,
+                );
+            }
+        }
+
+        Self::set_param_ui_flag(params, id, ae::pf::ParamUIFlags::INVISIBLE, !visible)
+    }
+
+    fn set_param_ui_flag(
+        params: &mut ae::Parameters<Params>,
+        id: Params,
+        flag: ae::pf::ParamUIFlags,
+        status: bool,
+    ) -> Result<(), Error> {
+        let current_status = (params.get(id)?.ui_flags().bits() & flag.bits()) != 0;
+        if current_status == status {
+            return Ok(());
+        }
+
+        let mut p = params.get_mut(id)?;
+        p.set_ui_flag(flag, status);
+        p.update_param_ui()?;
+        Ok(())
+    }
+
+    fn do_render(
+        &self,
+        in_data: InData,
+        in_layer: Layer,
+        mut out_layer: Layer,
+        params: &mut Parameters<Params>,
+    ) -> Result<(), Error> {
+        let width = in_layer.width();
+        let height = in_layer.height();
+        if width == 0 || height == 0 {
+            return Ok(());
+        }
+
+        let settings = read_settings(in_data, params)?;
+        let source = capture_source(&in_layer);
+        let masks = build_mask_map(&source, &settings);
+        let has_extension_source = masks.iter().any(|&mask| mask > EPSILON);
+        let source_image = SourceImage {
+            pixels: &source,
+            masks: &masks,
+            width,
+            height,
+        };
+        let map_checkout = if settings.use_direction_map {
+            Some(params.checkout_at(Params::DirectionMapLayer, None, None, None)?)
+        } else {
+            None
+        };
+        let map_layer = match map_checkout.as_ref() {
+            Some(checkout) => checkout.as_layer()?.value(),
+            None => None,
+        };
+        let map_source = map_layer.as_ref().map(capture_source);
+        let direction_map = match (map_layer.as_ref(), map_source.as_ref()) {
+            (Some(layer), Some(pixels)) if layer.width() > 0 && layer.height() > 0 => {
+                Some(DirectionMapData {
+                    pixels,
+                    width: layer.width(),
+                    height: layer.height(),
+                })
+            }
+            _ => None,
+        };
+        let progress_final = out_layer.height() as i32;
+        let should_render_extension = has_extension_source
+            && settings.opacity > EPSILON
+            && settings.extend_count > 0
+            && settings.step_size > EPSILON;
+
+        out_layer.iterate(0, progress_final, None, |x, y, mut dst| {
+            let source_px = source[y as usize * width + x as usize];
+            let extend_px = if should_render_extension {
+                scale_pixel_opacity(
+                    extend_pixel(
+                        &source_image,
+                        x as f32,
+                        y as f32,
+                        &settings,
+                        direction_map.as_ref(),
+                    ),
+                    settings.opacity,
+                )
+            } else {
+                transparent_pixel()
+            };
+            let out_px = if settings.show_source {
+                blend_behind_source(source_px, extend_px, settings.blend_mode)
+            } else {
+                extend_px
+            };
+
+            write_output_pixel(&mut dst, sanitize_pixel(out_px));
+            Ok(())
+        })?;
+
+        Ok(())
+    }
+}
+
+fn read_settings(in_data: InData, params: &mut Parameters<Params>) -> Result<Settings, Error> {
+    let direction_rad = (angle_degrees(in_data, params, Params::Direction)? - 90.0).to_radians();
+    let extend_count = params.get(Params::ExtendCount)?.as_slider()?.value().max(0) as usize;
+    let extend_direction =
+        ExtendDirection::from_popup_value(params.get(Params::ExtendDirection)?.as_popup()?.value());
+    let step_size = (params.get(Params::StepSize)?.as_float_slider()?.value() as f32).max(0.0);
+    let offset = params.get(Params::Offset)?.as_float_slider()?.value() as f32;
+    let use_direction_map = params.get(Params::UseDirectionMap)?.as_checkbox()?.value();
+    let map_channel =
+        MapChannel::from_popup_value(params.get(Params::MapChannel)?.as_popup()?.value());
+    let map_vector_mode =
+        MapVectorMode::from_popup_value(params.get(Params::MapVectorMode)?.as_popup()?.value());
+    let map_influence = ((params.get(Params::MapInfluence)?.as_float_slider()?.value() as f32)
+        / 100.0)
+        .clamp(0.0, 1.0);
+    let decay = (params.get(Params::Decay)?.as_float_slider()?.value() as f32).clamp(0.0, 1.0);
+    let angle_change_rad = angle_degrees(in_data, params, Params::AngleChange)?.to_radians();
+    let expansion_per_step = (params
+        .get(Params::ExpansionPerStep)?
+        .as_float_slider()?
+        .value() as f32)
+        .max(0.0);
+    let expansion_samples = odd_sample_count(
+        params
+            .get(Params::ExpansionSamples)?
+            .as_slider()?
+            .value()
+            .max(1) as usize,
+    );
+    let basis = SourceBasis::from_popup_value(params.get(Params::Basis)?.as_popup()?.value());
+    let select_mode = if matches!(basis, SourceBasis::Color) {
+        match params.get(Params::ColorMode)?.as_popup()?.value() {
+            2 => SelectMode::Different,
+            _ => SelectMode::Similar,
+        }
+    } else {
+        SelectMode::from_popup_value(params.get(Params::SelectMode)?.as_popup()?.value())
+    };
+    let invert_detection = params.get(Params::InvertDetection)?.as_checkbox()?.value();
+    let threshold =
+        (params.get(Params::Threshold)?.as_float_slider()?.value() as f32).clamp(0.0, 1.0);
+    let softness =
+        (params.get(Params::Softness)?.as_float_slider()?.value() as f32).clamp(0.0, 1.0);
+    let target_color = params
+        .get(Params::TargetColor)?
+        .as_color()?
+        .value()
+        .to_pixel32();
+    let interpolation =
+        InterpolationMode::from_popup_value(params.get(Params::Interpolation)?.as_popup()?.value());
+    let mitchell_b =
+        (params.get(Params::MitchellB)?.as_float_slider()?.value() as f32).clamp(0.0, 1.0);
+    let mitchell_c =
+        (params.get(Params::MitchellC)?.as_float_slider()?.value() as f32).clamp(0.0, 1.0);
+    let blend_mode =
+        BlendMode::from_popup_value(params.get(Params::BlendMode)?.as_popup()?.value());
+    let opacity =
+        ((params.get(Params::Opacity)?.as_float_slider()?.value() as f32) / 100.0).clamp(0.0, 1.0);
+    let show_source = params.get(Params::ShowSource)?.as_checkbox()?.value();
+
+    Ok(Settings {
+        direction_rad,
+        extend_count,
+        extend_direction,
+        step_size,
+        offset,
+        use_direction_map,
+        map_channel,
+        map_vector_mode,
+        map_influence,
+        decay,
+        angle_change_rad,
+        expansion_per_step,
+        expansion_samples,
+        basis,
+        select_mode,
+        invert_detection,
+        threshold,
+        softness,
+        target_color,
+        interpolation,
+        mitchell_b,
+        mitchell_c,
+        blend_mode,
+        opacity,
+        show_source,
+    })
+}
+
+fn angle_degrees(
+    _in_data: InData,
+    params: &mut Parameters<Params>,
+    id: Params,
+) -> Result<f32, Error> {
+    Ok(params.get(id)?.as_angle()?.float_value()? as f32)
+}
+
+fn extend_pixel(
+    source: &SourceImage<'_>,
+    x: f32,
+    y: f32,
+    settings: &Settings,
+    direction_map: Option<&DirectionMapData<'_>>,
+) -> PixelF32 {
+    if settings.extend_count == 0 || settings.step_size <= EPSILON {
+        return transparent_pixel();
+    }
+
+    let direction_rad =
+        mapped_direction_rad(x, y, source.width, source.height, settings, direction_map);
+
+    match settings.extend_direction {
+        ExtendDirection::Forward => {
+            extend_pixel_one_direction(source, x, y, settings, direction_rad, 1.0)
+        }
+        ExtendDirection::Backward => {
+            extend_pixel_one_direction(source, x, y, settings, direction_rad, -1.0)
+        }
+        ExtendDirection::Both => alpha_over(
+            extend_pixel_one_direction(source, x, y, settings, direction_rad, 1.0),
+            extend_pixel_one_direction(source, x, y, settings, direction_rad, -1.0),
+        ),
+    }
+}
+
+fn extend_pixel_one_direction(
+    source: &SourceImage<'_>,
+    x: f32,
+    y: f32,
+    settings: &Settings,
+    direction_rad: f32,
+    direction_sign: f32,
+) -> PixelF32 {
+    let mut out = transparent_pixel();
+    let base_angle = direction_rad
+        + if direction_sign < 0.0 {
+            std::f32::consts::PI
+        } else {
+            0.0
+        };
+    let mut path_x = base_angle.cos() * settings.offset;
+    let mut path_y = base_angle.sin() * settings.offset;
+    let mut falloff = 1.0f32;
+
+    for step in 0..=settings.extend_count {
+        let t = if settings.extend_count == 0 {
+            0.0
+        } else {
+            step as f32 / settings.extend_count as f32
+        };
+        let sx = x - path_x;
+        let sy = y - path_y;
+        let expansion_radius = step as f32 * settings.expansion_per_step;
+        let step_px = if expansion_radius <= EPSILON || settings.expansion_samples <= 1 {
+            sample_extension_point(source, sx, sy, settings, falloff)
+        } else {
+            sample_expanded_extension(
+                source,
+                sx,
+                sy,
+                base_angle,
+                expansion_radius,
+                settings,
+                falloff,
+            )
+        };
+
+        if step_px.alpha > EPSILON {
+            out = alpha_over(out, step_px);
+            if out.alpha >= 0.999 {
+                break;
+            }
+        }
+
+        let angle = base_angle + settings.angle_change_rad * t * direction_sign;
+        path_x += angle.cos() * settings.step_size;
+        path_y += angle.sin() * settings.step_size;
+        falloff *= settings.decay;
+        if falloff <= EPSILON && settings.decay < 1.0 {
+            break;
+        }
+    }
+
+    out
+}
+
+fn sample_extension_point(
+    source: &SourceImage<'_>,
+    x: f32,
+    y: f32,
+    settings: &Settings,
+    falloff: f32,
+) -> PixelF32 {
+    let mask = sample_mask(source.masks, source.width, source.height, x, y, settings);
+    let weight = mask * falloff;
+    if weight <= EPSILON {
+        return transparent_pixel();
+    }
+
+    scale_pixel_opacity(
+        sample_pixel(source.pixels, source.width, source.height, x, y, settings),
+        weight,
+    )
+}
+
+fn sample_expanded_extension(
+    source: &SourceImage<'_>,
+    x: f32,
+    y: f32,
+    angle: f32,
+    radius: f32,
+    settings: &Settings,
+    falloff: f32,
+) -> PixelF32 {
+    let sample_count = settings.expansion_samples.max(1);
+    let denom = sample_count.saturating_sub(1).max(1) as f32;
+    let normal_x = -angle.sin();
+    let normal_y = angle.cos();
+    let mut out = transparent_pixel();
+
+    for sample in 0..sample_count {
+        let u = if sample_count == 1 {
+            0.0
+        } else {
+            (sample as f32 / denom) * 2.0 - 1.0
+        };
+        let offset = u * radius;
+        let edge_weight = 1.0 - u.abs() * 0.5;
+        let px = sample_extension_point(
+            source,
+            x + normal_x * offset,
+            y + normal_y * offset,
+            settings,
+            falloff * edge_weight,
+        );
+        out = alpha_over(out, px);
+        if out.alpha >= 0.999 {
+            break;
+        }
+    }
+
+    out
+}
+
+fn odd_sample_count(count: usize) -> usize {
+    let count = count.clamp(1, 65);
+    if count.is_multiple_of(2) {
+        (count + 1).min(65)
+    } else {
+        count
+    }
+}
+
+fn mapped_direction_rad(
+    x: f32,
+    y: f32,
+    out_width: usize,
+    out_height: usize,
+    settings: &Settings,
+    direction_map: Option<&DirectionMapData<'_>>,
+) -> f32 {
+    if !settings.use_direction_map || settings.map_influence <= EPSILON {
+        return settings.direction_rad;
+    }
+
+    let Some(map) = direction_map else {
+        return settings.direction_rad;
+    };
+
+    let map_x = remap_axis_to_map(x, out_width, map.width);
+    let map_y = remap_axis_to_map(y, out_height, map.height);
+    let Some((map_dx, map_dy)) = direction_map_vector(map, map_x, map_y, settings) else {
+        return settings.direction_rad;
+    };
+
+    let base_x = settings.direction_rad.cos();
+    let base_y = settings.direction_rad.sin();
+    let influence = settings.map_influence;
+    let dir_x = base_x * (1.0 - influence) + map_dx * influence;
+    let dir_y = base_y * (1.0 - influence) + map_dy * influence;
+    if dir_x.abs() <= EPSILON && dir_y.abs() <= EPSILON {
+        settings.direction_rad
+    } else {
+        dir_y.atan2(dir_x)
+    }
+}
+
+fn direction_map_vector(
+    map: &DirectionMapData<'_>,
+    x: f32,
+    y: f32,
+    settings: &Settings,
+) -> Option<(f32, f32)> {
+    let left = sample_map_scalar(map, x - 1.0, y, settings.map_channel);
+    let right = sample_map_scalar(map, x + 1.0, y, settings.map_channel);
+    let up = sample_map_scalar(map, x, y - 1.0, settings.map_channel);
+    let down = sample_map_scalar(map, x, y + 1.0, settings.map_channel);
+
+    let dx = 0.5 * (right - left);
+    let dy = 0.5 * (down - up);
+    let (vx, vy) = match settings.map_vector_mode {
+        MapVectorMode::Gradient => (dx, dy),
+        MapVectorMode::Divergence => (-dx, -dy),
+        MapVectorMode::Rotation => (-dy, dx),
+    };
+    let len = (vx * vx + vy * vy).sqrt();
+    if !len.is_finite() || len <= EPSILON {
+        None
+    } else {
+        Some((vx / len, vy / len))
+    }
+}
+
+fn remap_axis_to_map(coord: f32, out_len: usize, map_len: usize) -> f32 {
+    if out_len == 0 || map_len == 0 || out_len == map_len {
+        coord
+    } else {
+        ((coord + 0.5) * map_len as f32 / out_len as f32) - 0.5
+    }
+}
+
+fn sample_map_scalar(map: &DirectionMapData<'_>, x: f32, y: f32, channel: MapChannel) -> f32 {
+    map_channel_value(sample_map_pixel(map, x, y), channel)
+}
+
+fn sample_map_pixel(map: &DirectionMapData<'_>, x: f32, y: f32) -> PixelF32 {
+    if !x.is_finite() || !y.is_finite() {
+        return transparent_pixel();
+    }
+
+    let x0 = x.floor() as isize;
+    let y0 = y.floor() as isize;
+    let x1 = x0 + 1;
+    let y1 = y0 + 1;
+    let tx = x - x0 as f32;
+    let ty = y - y0 as f32;
+    let p00 = fetch_clamped(map.pixels, map.width, map.height, x0, y0);
+    let p10 = fetch_clamped(map.pixels, map.width, map.height, x1, y0);
+    let p01 = fetch_clamped(map.pixels, map.width, map.height, x0, y1);
+    let p11 = fetch_clamped(map.pixels, map.width, map.height, x1, y1);
+
+    lerp_pixel(lerp_pixel(p00, p10, tx), lerp_pixel(p01, p11, tx), ty)
+}
+
+fn map_channel_value(px: PixelF32, channel: MapChannel) -> f32 {
+    let (r, g, b) = unpremultiplied_rgb(px);
+    match channel {
+        MapChannel::Red => r,
+        MapChannel::Green => g,
+        MapChannel::Blue => b,
+        MapChannel::Alpha => sanitize_unit(px.alpha),
+        MapChannel::Hue => rgb_to_hsv(r, g, b).0,
+        MapChannel::Saturation => rgb_to_hsv(r, g, b).1,
+        MapChannel::Value => rgb_to_hsv(r, g, b).2,
+    }
+}
+
+fn build_mask_map(source: &[PixelF32], settings: &Settings) -> Vec<f32> {
+    source.iter().map(|&px| source_mask(px, settings)).collect()
+}
+
+fn source_mask(px: PixelF32, settings: &Settings) -> f32 {
+    let mask = match settings.basis {
+        SourceBasis::Alpha => scalar_mask(px.alpha, settings),
+        SourceBasis::Lightness => {
+            let (r, g, b) = unpremultiplied_rgb(px);
+            scalar_mask(0.2126 * r + 0.7152 * g + 0.0722 * b, settings)
+        }
+        SourceBasis::Color => color_mask(px, settings),
+    };
+
+    if settings.invert_detection {
+        1.0 - mask
+    } else {
+        mask
+    }
+}
+
+fn scalar_mask(value: f32, settings: &Settings) -> f32 {
+    match settings.select_mode {
+        SelectMode::Below => smooth_threshold(settings.threshold - value, settings.softness),
+        _ => smooth_threshold(value - settings.threshold, settings.softness),
+    }
+}
+
+fn color_mask(px: PixelF32, settings: &Settings) -> f32 {
+    let (r, g, b) = unpremultiplied_rgb(px);
+    let (tr, tg, tb) = unpremultiplied_rgb(settings.target_color);
+    let dist = ((r - tr).powi(2) + (g - tg).powi(2) + (b - tb).powi(2)).sqrt() / 3.0_f32.sqrt();
+
+    match settings.select_mode {
+        SelectMode::Different => smooth_threshold(dist - settings.threshold, settings.softness),
+        _ => smooth_threshold(settings.threshold - dist, settings.softness),
+    }
+}
+
+fn smooth_threshold(distance: f32, softness: f32) -> f32 {
+    if softness <= EPSILON {
+        if distance >= 0.0 { 1.0 } else { 0.0 }
+    } else {
+        (distance / softness).clamp(0.0, 1.0)
+    }
+}
+
+fn sample_pixel(
+    source: &[PixelF32],
+    width: usize,
+    height: usize,
+    x: f32,
+    y: f32,
+    settings: &Settings,
+) -> PixelF32 {
+    if !x.is_finite() || !y.is_finite() {
+        return transparent_pixel();
+    }
+
+    match settings.interpolation {
+        InterpolationMode::Nearest => sample_nearest(source, width, height, x, y),
+        InterpolationMode::Bilinear => sample_bilinear(source, width, height, x, y),
+        InterpolationMode::Bicubic => sample_bicubic(source, width, height, x, y),
+        InterpolationMode::Mitchell => sample_mitchell(
+            source,
+            width,
+            height,
+            x,
+            y,
+            settings.mitchell_b,
+            settings.mitchell_c,
+        ),
+    }
+}
+
+fn sample_mask(
+    source: &[f32],
+    width: usize,
+    height: usize,
+    x: f32,
+    y: f32,
+    settings: &Settings,
+) -> f32 {
+    if !x.is_finite() || !y.is_finite() {
+        return 0.0;
+    }
+
+    match settings.interpolation {
+        InterpolationMode::Nearest => sample_mask_nearest(source, width, height, x, y),
+        InterpolationMode::Bilinear => sample_mask_bilinear(source, width, height, x, y),
+        InterpolationMode::Bicubic => sample_mask_bicubic(source, width, height, x, y),
+        InterpolationMode::Mitchell => sample_mask_mitchell(
+            source,
+            width,
+            height,
+            x,
+            y,
+            settings.mitchell_b,
+            settings.mitchell_c,
+        ),
+    }
+    .clamp(0.0, 1.0)
+}
+
+fn sample_mask_nearest(source: &[f32], width: usize, height: usize, x: f32, y: f32) -> f32 {
+    fetch_mask_or_zero(
+        source,
+        width,
+        height,
+        x.round() as isize,
+        y.round() as isize,
+    )
+}
+
+fn sample_mask_bilinear(source: &[f32], width: usize, height: usize, x: f32, y: f32) -> f32 {
+    let x0 = x.floor() as isize;
+    let y0 = y.floor() as isize;
+    let x1 = x0 + 1;
+    let y1 = y0 + 1;
+    let tx = x - x0 as f32;
+    let ty = y - y0 as f32;
+
+    let p00 = fetch_mask_or_zero(source, width, height, x0, y0);
+    let p10 = fetch_mask_or_zero(source, width, height, x1, y0);
+    let p01 = fetch_mask_or_zero(source, width, height, x0, y1);
+    let p11 = fetch_mask_or_zero(source, width, height, x1, y1);
+    let top = p00 + (p10 - p00) * tx;
+    let bottom = p01 + (p11 - p01) * tx;
+    top + (bottom - top) * ty
+}
+
+fn sample_mask_bicubic(source: &[f32], width: usize, height: usize, x: f32, y: f32) -> f32 {
+    sample_mask_separable(source, width, height, x, y, 2.0, |d| cubic_weight(d, -0.5))
+}
+
+fn sample_mask_mitchell(
+    source: &[f32],
+    width: usize,
+    height: usize,
+    x: f32,
+    y: f32,
+    b: f32,
+    c: f32,
+) -> f32 {
+    sample_mask_separable(source, width, height, x, y, 2.0, |d| {
+        mitchell_weight(d, b, c)
+    })
+}
+
+fn sample_mask_separable<F>(
+    source: &[f32],
+    width: usize,
+    height: usize,
+    x: f32,
+    y: f32,
+    radius: f32,
+    mut weight_fn: F,
+) -> f32
+where
+    F: FnMut(f32) -> f32,
+{
+    let min_y = (y - radius).floor() as isize;
+    let max_y = (y + radius).ceil() as isize;
+    let min_x = (x - radius).floor() as isize;
+    let max_x = (x + radius).ceil() as isize;
+    let mut sum = 0.0;
+    let mut weight_sum = 0.0;
+
+    for sy in min_y..=max_y {
+        let wy = weight_fn(y - sy as f32);
+        if wy == 0.0 {
+            continue;
+        }
+
+        for sx in min_x..=max_x {
+            let wx = weight_fn(x - sx as f32);
+            if wx == 0.0 {
+                continue;
+            }
+
+            let weight = wx * wy;
+            sum += fetch_mask_or_zero(source, width, height, sx, sy) * weight;
+            weight_sum += weight;
+        }
+    }
+
+    if weight_sum.abs() <= EPSILON {
+        0.0
+    } else {
+        sum / weight_sum
+    }
+}
+
+fn sample_nearest(source: &[PixelF32], width: usize, height: usize, x: f32, y: f32) -> PixelF32 {
+    fetch_or_transparent(
+        source,
+        width,
+        height,
+        x.round() as isize,
+        y.round() as isize,
+    )
+}
+
+fn sample_bilinear(source: &[PixelF32], width: usize, height: usize, x: f32, y: f32) -> PixelF32 {
+    let x0 = x.floor() as isize;
+    let y0 = y.floor() as isize;
+    let x1 = x0 + 1;
+    let y1 = y0 + 1;
+    let tx = x - x0 as f32;
+    let ty = y - y0 as f32;
+
+    let p00 = fetch_or_transparent(source, width, height, x0, y0);
+    let p10 = fetch_or_transparent(source, width, height, x1, y0);
+    let p01 = fetch_or_transparent(source, width, height, x0, y1);
+    let p11 = fetch_or_transparent(source, width, height, x1, y1);
+
+    lerp_pixel(lerp_pixel(p00, p10, tx), lerp_pixel(p01, p11, tx), ty)
+}
+
+fn sample_bicubic(source: &[PixelF32], width: usize, height: usize, x: f32, y: f32) -> PixelF32 {
+    sample_separable(source, width, height, x, y, 2.0, |d| cubic_weight(d, -0.5))
+}
+
+fn sample_mitchell(
+    source: &[PixelF32],
+    width: usize,
+    height: usize,
+    x: f32,
+    y: f32,
+    b: f32,
+    c: f32,
+) -> PixelF32 {
+    sample_separable(source, width, height, x, y, 2.0, |d| {
+        mitchell_weight(d, b, c)
+    })
+}
+
+fn sample_separable<F>(
+    source: &[PixelF32],
+    width: usize,
+    height: usize,
+    x: f32,
+    y: f32,
+    radius: f32,
+    mut weight_fn: F,
+) -> PixelF32
+where
+    F: FnMut(f32) -> f32,
+{
+    let min_y = (y - radius).floor() as isize;
+    let max_y = (y + radius).ceil() as isize;
+    let min_x = (x - radius).floor() as isize;
+    let max_x = (x + radius).ceil() as isize;
+    let mut acc = WeightedPixel::default();
+
+    for sy in min_y..=max_y {
+        let wy = weight_fn(y - sy as f32);
+        if wy == 0.0 {
+            continue;
+        }
+
+        for sx in min_x..=max_x {
+            let wx = weight_fn(x - sx as f32);
+            if wx == 0.0 {
+                continue;
+            }
+
+            acc.add(fetch_or_transparent(source, width, height, sx, sy), wx * wy);
+        }
+    }
+
+    acc.finish()
+}
+
+fn cubic_weight(d: f32, a: f32) -> f32 {
+    let x = d.abs();
+    if x <= 1.0 {
+        (a + 2.0) * x * x * x - (a + 3.0) * x * x + 1.0
+    } else if x < 2.0 {
+        a * x * x * x - 5.0 * a * x * x + 8.0 * a * x - 4.0 * a
+    } else {
+        0.0
+    }
+}
+
+fn mitchell_weight(d: f32, b: f32, c: f32) -> f32 {
+    let x = d.abs();
+
+    if x < 1.0 {
+        ((12.0 - 9.0 * b - 6.0 * c) * x * x * x
+            + (-18.0 + 12.0 * b + 6.0 * c) * x * x
+            + (6.0 - 2.0 * b))
+            / 6.0
+    } else if x < 2.0 {
+        ((-b - 6.0 * c) * x * x * x
+            + (6.0 * b + 30.0 * c) * x * x
+            + (-12.0 * b - 48.0 * c) * x
+            + (8.0 * b + 24.0 * c))
+            / 6.0
+    } else {
+        0.0
+    }
+}
+
+fn fetch_or_transparent(
+    source: &[PixelF32],
+    width: usize,
+    height: usize,
+    x: isize,
+    y: isize,
+) -> PixelF32 {
+    if x < 0 || y < 0 || x >= width as isize || y >= height as isize {
+        return transparent_pixel();
+    }
+    source[y as usize * width + x as usize]
+}
+
+fn fetch_mask_or_zero(source: &[f32], width: usize, height: usize, x: isize, y: isize) -> f32 {
+    if x < 0 || y < 0 || x >= width as isize || y >= height as isize {
+        return 0.0;
+    }
+    source[y as usize * width + x as usize]
+}
+
+fn fetch_clamped(source: &[PixelF32], width: usize, height: usize, x: isize, y: isize) -> PixelF32 {
+    if width == 0 || height == 0 {
+        return transparent_pixel();
+    }
+
+    let x = x.clamp(0, width as isize - 1) as usize;
+    let y = y.clamp(0, height as isize - 1) as usize;
+    source[y * width + x]
+}
+
+fn lerp_pixel(a: PixelF32, b: PixelF32, t: f32) -> PixelF32 {
+    PixelF32 {
+        alpha: a.alpha + (b.alpha - a.alpha) * t,
+        red: a.red + (b.red - a.red) * t,
+        green: a.green + (b.green - a.green) * t,
+        blue: a.blue + (b.blue - a.blue) * t,
+    }
+}
+
+fn alpha_over(top: PixelF32, bottom: PixelF32) -> PixelF32 {
+    let top_a = clamp01(top.alpha);
+    let bottom_a = clamp01(bottom.alpha);
+    let out_a = top_a + bottom_a * (1.0 - top_a);
+    if out_a <= EPSILON {
+        return transparent_pixel();
+    }
+
+    PixelF32 {
+        alpha: out_a,
+        red: top.red + bottom.red * (1.0 - top_a),
+        green: top.green + bottom.green * (1.0 - top_a),
+        blue: top.blue + bottom.blue * (1.0 - top_a),
+    }
+}
+
+fn blend_behind_source(source: PixelF32, extension: PixelF32, mode: BlendMode) -> PixelF32 {
+    let blended_extension = blend_pixels(source, extension, mode);
+    alpha_over(blended_extension, source)
+}
+
+fn blend_pixels(base: PixelF32, blend: PixelF32, mode: BlendMode) -> PixelF32 {
+    let (base_r, base_g, base_b) = unpremultiplied_rgb(base);
+    let (blend_r, blend_g, blend_b) = unpremultiplied_rgb(blend);
+    let out_a = blend.alpha;
+    let red = blend_channel(base_r, blend_r, mode);
+    let green = blend_channel(base_g, blend_g, mode);
+    let blue = blend_channel(base_b, blend_b, mode);
+
+    PixelF32 {
+        alpha: out_a,
+        red: red * out_a,
+        green: green * out_a,
+        blue: blue * out_a,
+    }
+}
+
+fn blend_channel(base: f32, blend: f32, mode: BlendMode) -> f32 {
+    match mode {
+        BlendMode::Normal => blend,
+        BlendMode::Add => clamp01(base + blend),
+        BlendMode::Multiply => base * blend,
+        BlendMode::Screen => 1.0 - (1.0 - base) * (1.0 - blend),
+        BlendMode::Overlay => {
+            if base <= 0.5 {
+                2.0 * base * blend
+            } else {
+                1.0 - 2.0 * (1.0 - base) * (1.0 - blend)
+            }
+        }
+        BlendMode::Darken => base.min(blend),
+        BlendMode::Lighten => base.max(blend),
+    }
+}
+
+fn scale_pixel_opacity(px: PixelF32, opacity: f32) -> PixelF32 {
+    let opacity = clamp01(opacity);
+    PixelF32 {
+        alpha: px.alpha * opacity,
+        red: px.red * opacity,
+        green: px.green * opacity,
+        blue: px.blue * opacity,
+    }
+}
+
+fn capture_source(layer: &Layer) -> Vec<PixelF32> {
+    let width = layer.width();
+    let height = layer.height();
+    let world_type = layer.world_type();
+    let mut source = vec![transparent_pixel(); width * height];
+
+    for y in 0..height {
+        for x in 0..width {
+            source[y * width + x] = match world_type {
+                ae::aegp::WorldType::U8 => layer.as_pixel8(x, y).to_pixel32(),
+                ae::aegp::WorldType::U15 => layer.as_pixel16(x, y).to_pixel32(),
+                ae::aegp::WorldType::F32 | ae::aegp::WorldType::None => *layer.as_pixel32(x, y),
+            };
+        }
+    }
+
+    source
+}
+
+fn unpremultiplied_rgb(px: PixelF32) -> (f32, f32, f32) {
+    if px.alpha > EPSILON {
+        (
+            sanitize_unit(px.red / px.alpha),
+            sanitize_unit(px.green / px.alpha),
+            sanitize_unit(px.blue / px.alpha),
+        )
+    } else {
+        (0.0, 0.0, 0.0)
+    }
+}
+
+fn rgb_to_hsv(r: f32, g: f32, b: f32) -> (f32, f32, f32) {
+    let max = r.max(g).max(b);
+    let min = r.min(g).min(b);
+    let delta = max - min;
+    let value = max;
+    let saturation = if max <= EPSILON { 0.0 } else { delta / max };
+    if delta <= EPSILON {
+        return (0.0, saturation, value);
+    }
+
+    let hue_prime = if (max - r).abs() <= f32::EPSILON {
+        ((g - b) / delta).rem_euclid(6.0)
+    } else if (max - g).abs() <= f32::EPSILON {
+        ((b - r) / delta) + 2.0
+    } else {
+        ((r - g) / delta) + 4.0
+    };
+
+    ((hue_prime / 6.0).rem_euclid(1.0), saturation, value)
+}
+
+fn transparent_pixel() -> PixelF32 {
+    PixelF32 {
+        alpha: 0.0,
+        red: 0.0,
+        green: 0.0,
+        blue: 0.0,
+    }
+}
+
+fn sanitize_pixel(px: PixelF32) -> PixelF32 {
+    PixelF32 {
+        alpha: sanitize_unit(px.alpha),
+        red: sanitize_unit(px.red),
+        green: sanitize_unit(px.green),
+        blue: sanitize_unit(px.blue),
+    }
+}
+
+fn sanitize_unit(v: f32) -> f32 {
+    if v.is_finite() {
+        v.clamp(0.0, 1.0)
+    } else {
+        0.0
+    }
+}
+
+fn clamp01(v: f32) -> f32 {
+    v.clamp(0.0, 1.0)
+}
+
+fn write_output_pixel(dst: &mut GenericPixelMut<'_>, px: PixelF32) {
+    match dst {
+        GenericPixelMut::Pixel8(p) => {
+            **p = px.to_pixel8();
+        }
+        GenericPixelMut::Pixel16(p) => {
+            **p = px.to_pixel16();
+        }
+        GenericPixelMut::PixelF32(p) => {
+            **p = px;
+        }
+        GenericPixelMut::PixelF64(p) => {
+            p.alphaF = px.alpha as _;
+            p.redF = px.red as _;
+            p.greenF = px.green as _;
+            p.blueF = px.blue as _;
+        }
+    }
+}

--- a/plugins/pixel-extend/src/lib.rs
+++ b/plugins/pixel-extend/src/lib.rs
@@ -266,15 +266,48 @@ impl DirectionBasis {
 #[derive(Debug)]
 enum DirectionField {
     Constant(DirectionBasis),
-    PerPixel(Vec<DirectionBasis>),
+    PerPixel {
+        directions: Vec<DirectionBasis>,
+        region: RenderRegion,
+    },
 }
 
 impl DirectionField {
-    fn at(&self, index: usize) -> DirectionBasis {
+    fn at(&self, x: usize, y: usize) -> DirectionBasis {
         match self {
             Self::Constant(direction) => *direction,
-            Self::PerPixel(directions) => directions[index],
+            Self::PerPixel { directions, region } => {
+                directions[(y - region.min_y) * region.width() + (x - region.min_x)]
+            }
         }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct RenderRegion {
+    min_x: usize,
+    min_y: usize,
+    max_x: usize,
+    max_y: usize,
+}
+
+#[derive(Debug)]
+struct MaskMap {
+    values: Vec<f32>,
+    region: Option<RenderRegion>,
+}
+
+impl RenderRegion {
+    fn width(self) -> usize {
+        self.max_x.saturating_sub(self.min_x)
+    }
+
+    fn height(self) -> usize {
+        self.max_y.saturating_sub(self.min_y)
+    }
+
+    fn contains(self, x: usize, y: usize) -> bool {
+        x >= self.min_x && x < self.max_x && y >= self.min_y && y < self.max_y
     }
 }
 
@@ -302,6 +335,13 @@ struct DirectionPath {
 struct RenderPlan {
     paths: Vec<DirectionPath>,
     expansion_samples: Vec<ExpansionSample>,
+}
+
+#[derive(Debug)]
+struct RenderContext {
+    direction_field: DirectionField,
+    plan: RenderPlan,
+    region: RenderRegion,
 }
 
 trait InterpolationKernel {
@@ -1082,15 +1122,15 @@ impl Plugin {
 
         let settings = read_settings(in_data, params)?;
         let source = capture_source(&in_layer);
-        let masks = build_mask_map(&source, &settings);
-        let has_extension_source = masks.iter().any(|&mask| mask > EPSILON);
-        let should_render_extension = has_extension_source
+        let mask_map = build_mask_map(&source, width, height, &settings);
+        let mask_region = mask_map.region;
+        let should_render_extension = mask_region.is_some()
             && settings.opacity > EPSILON
             && settings.extend_count > 0
             && settings.step_size > EPSILON;
         let source_image = SourceImage {
             pixels: &source,
-            masks: &masks,
+            masks: &mask_map.values,
             width,
             height,
         };
@@ -1115,10 +1155,29 @@ impl Plugin {
             _ => None,
         };
         let render_context = should_render_extension.then(|| {
-            (
-                build_direction_field(width, height, &settings, direction_map.as_ref()),
-                build_render_plan(&settings),
-            )
+            let plan = build_render_plan(&settings);
+            let variable_direction = settings.use_direction_map
+                && settings.map_influence > EPSILON
+                && direction_map.is_some();
+            let region = build_extension_region(
+                mask_region.expect("extension source checked above"),
+                width,
+                height,
+                &settings,
+                &plan,
+                variable_direction,
+            );
+            RenderContext {
+                direction_field: build_direction_field(
+                    width,
+                    height,
+                    region,
+                    &settings,
+                    direction_map.as_ref(),
+                ),
+                plan,
+                region,
+            }
         });
         match settings.interpolation {
             InterpolationMode::Nearest => render_output::<NearestKernel>(
@@ -1160,22 +1219,24 @@ fn render_output<K: InterpolationKernel>(
     source: &[PixelF32],
     source_image: &SourceImage<'_>,
     settings: &Settings,
-    render_context: Option<&(DirectionField, RenderPlan)>,
+    render_context: Option<&RenderContext>,
 ) -> Result<(), Error> {
     let width = source_image.width;
     let progress_final = out_layer.height() as i32;
     out_layer.iterate(0, progress_final, None, |x, y, mut dst| {
         let pixel_index = y as usize * width + x as usize;
         let source_px = source[pixel_index];
-        let extend_px = if let Some((direction_field, render_plan)) = render_context {
+        let extend_px = if let Some(context) = render_context
+            && context.region.contains(x as usize, y as usize)
+        {
             scale_pixel_opacity(
                 extend_pixel::<K>(
                     source_image,
                     x as f32,
                     y as f32,
                     settings,
-                    direction_field.at(pixel_index),
-                    render_plan,
+                    context.direction_field.at(x as usize, y as usize),
+                    &context.plan,
                 ),
                 settings.opacity,
             )
@@ -1574,6 +1635,117 @@ fn build_expansion_samples(sample_count: usize) -> Vec<ExpansionSample> {
         .collect()
 }
 
+#[cfg(test)]
+fn find_mask_region(masks: &[f32], width: usize, height: usize) -> Option<RenderRegion> {
+    let mut min_x = width;
+    let mut min_y = height;
+    let mut max_x = 0usize;
+    let mut max_y = 0usize;
+
+    for (index, &mask) in masks.iter().enumerate() {
+        if mask <= EPSILON {
+            continue;
+        }
+        let x = index % width;
+        let y = index / width;
+        min_x = min_x.min(x);
+        min_y = min_y.min(y);
+        max_x = max_x.max(x + 1);
+        max_y = max_y.max(y + 1);
+    }
+
+    (min_x < max_x && min_y < max_y).then_some(RenderRegion {
+        min_x,
+        min_y,
+        max_x,
+        max_y,
+    })
+}
+
+fn build_extension_region(
+    mask_region: RenderRegion,
+    width: usize,
+    height: usize,
+    settings: &Settings,
+    plan: &RenderPlan,
+    variable_direction: bool,
+) -> RenderRegion {
+    let mut min_offset_x = f32::INFINITY;
+    let mut min_offset_y = f32::INFINITY;
+    let mut max_offset_x = f32::NEG_INFINITY;
+    let mut max_offset_y = f32::NEG_INFINITY;
+    let base_direction = DirectionBasis::from_angle(settings.direction_rad);
+
+    for_each_plan_offset(plan, |local_x, local_y| {
+        if variable_direction {
+            let radius = local_x.hypot(local_y);
+            min_offset_x = min_offset_x.min(-radius);
+            min_offset_y = min_offset_y.min(-radius);
+            max_offset_x = max_offset_x.max(radius);
+            max_offset_y = max_offset_y.max(radius);
+        } else {
+            let (world_x, world_y) = base_direction.offset_point(0.0, 0.0, local_x, local_y);
+            min_offset_x = min_offset_x.min(world_x);
+            min_offset_y = min_offset_y.min(world_y);
+            max_offset_x = max_offset_x.max(world_x);
+            max_offset_y = max_offset_y.max(world_y);
+        }
+    });
+
+    if !min_offset_x.is_finite() {
+        min_offset_x = 0.0;
+        min_offset_y = 0.0;
+        max_offset_x = 0.0;
+        max_offset_y = 0.0;
+    }
+
+    let support = match settings.interpolation {
+        InterpolationMode::Nearest => 0.5,
+        InterpolationMode::Bilinear => 1.0,
+        InterpolationMode::Bicubic | InterpolationMode::Mitchell => 2.0,
+    };
+    let source_min_x = mask_region.min_x as f32 - support;
+    let source_min_y = mask_region.min_y as f32 - support;
+    let source_max_x = mask_region.max_x.saturating_sub(1) as f32 + support;
+    let source_max_y = mask_region.max_y.saturating_sub(1) as f32 + support;
+
+    RenderRegion {
+        min_x: clamp_region_min(source_min_x - max_offset_x, width),
+        min_y: clamp_region_min(source_min_y - max_offset_y, height),
+        max_x: clamp_region_max(source_max_x - min_offset_x, width),
+        max_y: clamp_region_max(source_max_y - min_offset_y, height),
+    }
+}
+
+fn for_each_plan_offset<F>(plan: &RenderPlan, mut visit: F)
+where
+    F: FnMut(f32, f32),
+{
+    for path in &plan.paths {
+        for step in &path.steps {
+            if step.expansion_radius <= EPSILON || plan.expansion_samples.len() <= 1 {
+                visit(step.source_offset_x, step.source_offset_y);
+                continue;
+            }
+            for sample in &plan.expansion_samples {
+                visit(
+                    step.source_offset_x,
+                    step.source_offset_y
+                        + path.normal_sign * sample.radius_scale * step.expansion_radius,
+                );
+            }
+        }
+    }
+}
+
+fn clamp_region_min(value: f32, limit: usize) -> usize {
+    (value.floor() as isize).clamp(0, limit as isize) as usize
+}
+
+fn clamp_region_max(value: f32, limit: usize) -> usize {
+    ((value.ceil() as isize).saturating_add(1)).clamp(0, limit as isize) as usize
+}
+
 fn odd_sample_count(count: usize) -> usize {
     let count = count.clamp(1, 65);
     if count.is_multiple_of(2) {
@@ -1586,6 +1758,7 @@ fn odd_sample_count(count: usize) -> usize {
 fn build_direction_field(
     width: usize,
     height: usize,
+    region: RenderRegion,
     settings: &Settings,
     direction_map: Option<&DirectionMapData<'_>>,
 ) -> DirectionField {
@@ -1598,9 +1771,9 @@ fn build_direction_field(
         return DirectionField::Constant(base);
     };
 
-    let mut directions = Vec::with_capacity(width.saturating_mul(height));
-    for y in 0..height {
-        for x in 0..width {
+    let mut directions = Vec::with_capacity(region.width().saturating_mul(region.height()));
+    for y in region.min_y..region.max_y {
+        for x in region.min_x..region.max_x {
             let map_x = remap_axis_to_map(x as f32, width, map.width);
             let map_y = remap_axis_to_map(y as f32, height, map.height);
             let direction = direction_map_vector(map, map_x, map_y, settings)
@@ -1619,7 +1792,7 @@ fn build_direction_field(
         }
     }
 
-    DirectionField::PerPixel(directions)
+    DirectionField::PerPixel { directions, region }
 }
 
 fn direction_map_vector(
@@ -1692,8 +1865,41 @@ fn map_channel_value(px: PixelF32, channel: MapChannel) -> f32 {
     }
 }
 
-fn build_mask_map(source: &[PixelF32], settings: &Settings) -> Vec<f32> {
-    source.iter().map(|&px| source_mask(px, settings)).collect()
+fn build_mask_map(
+    source: &[PixelF32],
+    width: usize,
+    height: usize,
+    settings: &Settings,
+) -> MaskMap {
+    let mut values = Vec::with_capacity(source.len());
+    let mut min_x = width;
+    let mut min_y = height;
+    let mut max_x = 0usize;
+    let mut max_y = 0usize;
+
+    for (index, &pixel) in source.iter().enumerate() {
+        let mask = source_mask(pixel, settings);
+        values.push(mask);
+        if mask <= EPSILON {
+            continue;
+        }
+        let x = index % width;
+        let y = index / width;
+        min_x = min_x.min(x);
+        min_y = min_y.min(y);
+        max_x = max_x.max(x + 1);
+        max_y = max_y.max(y + 1);
+    }
+
+    MaskMap {
+        values,
+        region: (min_x < max_x && min_y < max_y).then_some(RenderRegion {
+            min_x,
+            min_y,
+            max_x,
+            max_y,
+        }),
+    }
 }
 
 fn source_mask(px: PixelF32, settings: &Settings) -> f32 {
@@ -2272,7 +2478,18 @@ mod tests {
     #[test]
     fn constant_direction_field_avoids_per_pixel_storage() {
         let settings = test_settings();
-        let field = build_direction_field(1920, 1080, &settings, None);
+        let field = build_direction_field(
+            1920,
+            1080,
+            RenderRegion {
+                min_x: 0,
+                min_y: 0,
+                max_x: 1920,
+                max_y: 1080,
+            },
+            &settings,
+            None,
+        );
         let DirectionField::Constant(direction) = field else {
             panic!("expected a constant direction field");
         };
@@ -2351,5 +2568,93 @@ mod tests {
 
         let actual = sample_expanded_nearest(&source, (1.0, 1.0), direction, 1.0, &step, &samples);
         assert_pixel_close(actual, expected);
+    }
+
+    #[test]
+    fn decay_limits_precomputed_hot_loop_steps() {
+        let mut settings = test_settings();
+        settings.extend_count = 100;
+        settings.decay = 0.1;
+        let path = build_direction_path(&settings, 1.0);
+        assert!(path.steps.len() < settings.extend_count + 1);
+        assert!(path.steps.iter().all(|step| step.falloff > EPSILON));
+    }
+
+    #[test]
+    fn mask_generation_tracks_nonzero_region_in_one_pass() {
+        let mut pixels = vec![transparent_pixel(); 12];
+        pixels[6] = PixelF32 {
+            alpha: 0.8,
+            red: 0.4,
+            green: 0.2,
+            blue: 0.1,
+        };
+        let settings = test_settings();
+        let mask_map = build_mask_map(&pixels, 4, 3, &settings);
+        assert_eq!(
+            mask_map.region,
+            Some(RenderRegion {
+                min_x: 2,
+                min_y: 1,
+                max_x: 3,
+                max_y: 2,
+            })
+        );
+        assert!(mask_map.values[6] > EPSILON);
+    }
+
+    #[test]
+    fn extension_region_contains_all_constant_direction_samples() {
+        assert_extension_region_contains_samples(false);
+    }
+
+    #[test]
+    fn extension_region_contains_all_variable_direction_samples() {
+        assert_extension_region_contains_samples(true);
+    }
+
+    fn assert_extension_region_contains_samples(variable_direction: bool) {
+        let width = 24;
+        let height = 20;
+        let mut masks = vec![0.0; width * height];
+        masks[9 * width + 11] = 1.0;
+        masks[10 * width + 12] = 0.5;
+        let mask_region = find_mask_region(&masks, width, height).unwrap();
+        let mut settings = test_settings();
+        settings.direction_rad = 0.43;
+        settings.extend_count = 9;
+        settings.offset = -1.2;
+        settings.angle_change_rad = 1.1;
+        settings.expansion_per_step = 0.35;
+        settings.expansion_samples = 7;
+        settings.interpolation = InterpolationMode::Nearest;
+        let plan = build_render_plan(&settings);
+        let region = build_extension_region(
+            mask_region,
+            width,
+            height,
+            &settings,
+            &plan,
+            variable_direction,
+        );
+
+        for y in 0..height {
+            for x in 0..width {
+                let direction = if variable_direction {
+                    DirectionBasis::from_angle((x + y * width) as f32 * 0.17)
+                } else {
+                    DirectionBasis::from_angle(settings.direction_rad)
+                };
+                let mut can_reach_mask = false;
+                for_each_plan_offset(&plan, |local_x, local_y| {
+                    let (sx, sy) = direction.offset_point(x as f32, y as f32, local_x, local_y);
+                    can_reach_mask |= sample_mask_nearest(&masks, width, height, sx, sy) > EPSILON;
+                });
+                assert!(
+                    !can_reach_mask || region.contains(x, y),
+                    "region {region:?} excludes reachable output ({x}, {y})"
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Add `AOD_PixelExtend` with adjustable direction, count, offset, decay, angle change, expansion, interpolation, blending, opacity, and source visibility.
- Add alpha/lightness/color detection, inversion, forward/backward/both extension, and RGBA/HSV direction-map controls.
- Add grouped dynamic UI and preserve the existing parameter order and AE match name.
- Precompute CPU render paths and bounds, then use a wgpu compute renderer for heavy frames with automatic CPU fallback.
- Reuse GPU buffers and validate GPU resource limits before dispatch.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace`
- `cargo clippy -p pixel_extend --all-targets -- -D warnings`
- `cargo test`
- CPU/GPU output comparison across Nearest, Bilinear, Bicubic, and Mitchell interpolation
- `NO_INSTALL=1 just -f plugins/pixel-extend/Justfile release`