### PR TITLE
ADD: SpaceConvert, ImageTransform, ImageCrypt, GlassDisplace, RainbowGenerate, and ImageRelight

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1336,6 +1336,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "image_relight"
+version = "0.5.0"
+dependencies = [
+ "after-effects",
+ "bytemuck",
+ "chrono",
+ "futures-intrusive",
+ "pipl",
+ "pollster",
+ "utils",
+ "wgpu",
+ "winres",
+]
+
+[[package]]
 name = "image_scaler"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1104,7 +1104,7 @@ checksum = "19fc433e8437a212d1b6f1e68c7824af3aed907da60afa994e7f542d18d12aa9"
 
 [[package]]
 name = "glass_displace"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "after-effects",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1109,6 +1109,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19fc433e8437a212d1b6f1e68c7824af3aed907da60afa994e7f542d18d12aa9"
 
 [[package]]
+name = "glass_displace"
+version = "0.3.0"
+dependencies = [
+ "after-effects",
+ "chrono",
+ "pipl",
+ "utils",
+ "winres",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2264,6 +2264,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "rainbow_generate"
+version = "0.3.0"
+dependencies = [
+ "after-effects",
+ "chrono",
+ "pipl",
+ "utils",
+ "winres",
+]
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1320,6 +1320,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "image_crypt"
+version = "0.2.0"
+dependencies = [
+ "after-effects",
+ "chrono",
+ "pipl",
+ "utils",
+ "winres",
+]
+
+[[package]]
 name = "image_scaler"
 version = "0.1.0"
 dependencies = [
@@ -1328,6 +1339,17 @@ dependencies = [
  "palette",
  "pipl",
  "utils",
+]
+
+[[package]]
+name = "image_transform"
+version = "0.1.0"
+dependencies = [
+ "after-effects",
+ "chrono",
+ "pipl",
+ "utils",
+ "winres",
 ]
 
 [[package]]
@@ -2638,6 +2660,17 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "space_convert"
+version = "0.2.0"
+dependencies = [
+ "after-effects",
+ "chrono",
+ "pipl",
+ "utils",
+ "winres",
+]
 
 [[package]]
 name = "spirv"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,12 +794,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fast-srgb8"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
-
-[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1940,27 +1934,33 @@ dependencies = [
 
 [[package]]
 name = "palette"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+checksum = "ddeed8580d347d2abf3dcf06a5f0b3dc020258338526b277847cd4248a70fc64"
 dependencies = [
  "approx",
- "fast-srgb8",
  "palette_derive",
+ "palette_math",
  "phf",
 ]
 
 [[package]]
 name = "palette_derive"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+checksum = "88537020289b719d81be994ccf1bbf4990f477e2f69ee52fe3e45f43a02e56be"
 dependencies = [
  "by_address",
  "proc-macro2",
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "palette_math"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e6eb142958d64335fb0e345c5b9ead2ecd6fc438c307e9d7d3c4fd428dbaf12"
 
 [[package]]
 name = "parking_lot"
@@ -2010,42 +2010,18 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_macros",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
  "phf_shared",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator",
- "phf_shared",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
 name = "phf_shared"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]
@@ -2265,10 +2241,11 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rainbow_generate"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "after-effects",
  "chrono",
+ "palette",
  "pipl",
  "utils",
  "winres",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2677,7 +2677,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "space_convert"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "after-effects",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1348,7 +1348,7 @@ dependencies = [
 
 [[package]]
 name = "image_transform"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "after-effects",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ wgpu = { version = "28", features = ["spirv"] }
 bytemuck = { version = "1.16.0", features = ["derive"] }
 pollster = { version = "0.4" }
 futures-intrusive = { version = "0.5" }
+palette = { version = "0.7.7", default-features = false, features = ["std"] }
 
 
 [workspace.lints]

--- a/crates/utils/src/image.rs
+++ b/crates/utils/src/image.rs
@@ -1,0 +1,491 @@
+use after_effects as ae;
+
+use ae::PixelF32;
+use ae::pf::Layer;
+
+use crate::ToPixel;
+
+pub const TRANSPARENT: PixelF32 = PixelF32 {
+    alpha: 0.0,
+    red: 0.0,
+    green: 0.0,
+    blue: 0.0,
+};
+
+// f32 no longer represents every integer beyond 2^52. Coordinates this large
+// cannot describe a meaningful image sample and may overflow neighbour math.
+const MAX_SAFE_SAMPLE_COORDINATE: f32 = 4_503_599_627_370_496.0;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SampleEdge {
+    Transparent,
+    Clamp,
+    Tile,
+    Mirror,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum SampleFilter {
+    Nearest,
+    Bilinear,
+    Bicubic,
+    Mitchell { b: f32, c: f32 },
+    Lanczos { lobes: f32 },
+    CubicBSpline,
+    EwaQuadratic { radius: f32 },
+}
+
+#[inline]
+pub fn finite_or(value: f32, fallback: f32) -> f32 {
+    if value.is_finite() { value } else { fallback }
+}
+
+#[inline]
+pub fn unpremultiplied_rgb(pixel: PixelF32) -> [f32; 3] {
+    let alpha = finite_or(pixel.alpha, 0.0);
+    if alpha.abs() > 1.0e-6 {
+        [
+            finite_or(pixel.red / alpha, 0.0),
+            finite_or(pixel.green / alpha, 0.0),
+            finite_or(pixel.blue / alpha, 0.0),
+        ]
+    } else {
+        [0.0; 3]
+    }
+}
+
+#[inline]
+pub fn luma(pixel: PixelF32) -> f32 {
+    let rgb = unpremultiplied_rgb(pixel);
+    0.2126 * rgb[0] + 0.7152 * rgb[1] + 0.0722 * rgb[2]
+}
+
+pub fn sanitize_pixel(mut pixel: PixelF32, clamp_rgb: bool) -> PixelF32 {
+    pixel.alpha = finite_or(pixel.alpha, 0.0).clamp(0.0, 1.0);
+    pixel.red = finite_or(pixel.red, 0.0);
+    pixel.green = finite_or(pixel.green, 0.0);
+    pixel.blue = finite_or(pixel.blue, 0.0);
+    if clamp_rgb {
+        pixel.red = pixel.red.clamp(0.0, 1.0);
+        pixel.green = pixel.green.clamp(0.0, 1.0);
+        pixel.blue = pixel.blue.clamp(0.0, 1.0);
+    }
+    pixel
+}
+
+pub fn read_pixel(layer: &Layer, x: usize, y: usize) -> PixelF32 {
+    if x >= layer.width() || y >= layer.height() {
+        return TRANSPARENT;
+    }
+    match layer.world_type() {
+        ae::aegp::WorldType::U8 => layer.as_pixel8(x, y).to_pixel32(),
+        ae::aegp::WorldType::U15 => layer.as_pixel16(x, y).to_pixel32(),
+        ae::aegp::WorldType::F32 | ae::aegp::WorldType::None => *layer.as_pixel32(x, y),
+    }
+}
+
+pub fn read_layer(layer: &Layer) -> Vec<PixelF32> {
+    let width = layer.width();
+    let height = layer.height();
+    let mut pixels = vec![TRANSPARENT; width.saturating_mul(height)];
+    for y in 0..height {
+        for x in 0..width {
+            pixels[y * width + x] = read_pixel(layer, x, y);
+        }
+    }
+    pixels
+}
+
+pub fn sample_nearest(
+    pixels: &[PixelF32],
+    width: usize,
+    height: usize,
+    x: f32,
+    y: f32,
+    edge: SampleEdge,
+) -> PixelF32 {
+    if !coordinates_are_safe(x, y) {
+        return TRANSPARENT;
+    }
+    sample_integer(
+        pixels,
+        width,
+        height,
+        x.round() as i64,
+        y.round() as i64,
+        edge,
+    )
+}
+
+pub fn sample_bilinear(
+    pixels: &[PixelF32],
+    width: usize,
+    height: usize,
+    x: f32,
+    y: f32,
+    edge: SampleEdge,
+) -> PixelF32 {
+    if width == 0 || height == 0 || !coordinates_are_safe(x, y) {
+        return TRANSPARENT;
+    }
+    let x0 = x.floor();
+    let y0 = y.floor();
+    let tx = x - x0;
+    let ty = y - y0;
+    let x0 = x0 as i64;
+    let y0 = y0 as i64;
+    let p00 = sample_integer(pixels, width, height, x0, y0, edge);
+    let x1 = x0.saturating_add(1);
+    let y1 = y0.saturating_add(1);
+    let p10 = sample_integer(pixels, width, height, x1, y0, edge);
+    let p01 = sample_integer(pixels, width, height, x0, y1, edge);
+    let p11 = sample_integer(pixels, width, height, x1, y1, edge);
+    lerp_pixel(lerp_pixel(p00, p10, tx), lerp_pixel(p01, p11, tx), ty)
+}
+
+pub fn sample_filtered(
+    pixels: &[PixelF32],
+    width: usize,
+    height: usize,
+    x: f32,
+    y: f32,
+    edge: SampleEdge,
+    filter: SampleFilter,
+) -> PixelF32 {
+    match filter {
+        SampleFilter::Nearest => sample_nearest(pixels, width, height, x, y, edge),
+        SampleFilter::Bilinear => sample_bilinear(pixels, width, height, x, y, edge),
+        SampleFilter::Bicubic => sample_separable(pixels, width, height, x, y, edge, 2.0, |d| {
+            cubic_keys_weight(d, -0.5)
+        }),
+        SampleFilter::Mitchell { b, c } => {
+            sample_separable(pixels, width, height, x, y, edge, 2.0, |d| {
+                mitchell_weight(d, b, c)
+            })
+        }
+        SampleFilter::Lanczos { lobes } => {
+            let lobes = finite_or(lobes, 3.0).clamp(1.0, 8.0);
+            sample_separable(pixels, width, height, x, y, edge, lobes, |d| {
+                lanczos_weight(d, lobes)
+            })
+        }
+        SampleFilter::CubicBSpline => {
+            sample_separable(pixels, width, height, x, y, edge, 2.0, cubic_bspline_weight)
+        }
+        SampleFilter::EwaQuadratic { radius } => sample_radial_quadratic(
+            pixels,
+            width,
+            height,
+            x,
+            y,
+            edge,
+            finite_or(radius, 2.0).clamp(0.5, 8.0),
+        ),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn sample_separable<F>(
+    pixels: &[PixelF32],
+    width: usize,
+    height: usize,
+    x: f32,
+    y: f32,
+    edge: SampleEdge,
+    radius: f32,
+    weight: F,
+) -> PixelF32
+where
+    F: Fn(f32) -> f32,
+{
+    if width == 0 || height == 0 || !coordinates_are_safe(x, y) {
+        return TRANSPARENT;
+    }
+    let min_x = (x - radius).floor() as i64;
+    let max_x = (x + radius).ceil() as i64;
+    let min_y = (y - radius).floor() as i64;
+    let max_y = (y + radius).ceil() as i64;
+    let mut sum = TRANSPARENT;
+    let mut weight_sum = 0.0;
+    for sy in min_y..=max_y {
+        let wy = weight(y - sy as f32);
+        if wy == 0.0 {
+            continue;
+        }
+        for sx in min_x..=max_x {
+            let sample_weight = wy * weight(x - sx as f32);
+            if sample_weight == 0.0 || !sample_weight.is_finite() {
+                continue;
+            }
+            add_weighted(
+                &mut sum,
+                sample_integer(pixels, width, height, sx, sy, edge),
+                sample_weight,
+            );
+            weight_sum += sample_weight;
+        }
+    }
+    normalized_pixel(sum, weight_sum)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn sample_radial_quadratic(
+    pixels: &[PixelF32],
+    width: usize,
+    height: usize,
+    x: f32,
+    y: f32,
+    edge: SampleEdge,
+    radius: f32,
+) -> PixelF32 {
+    if width == 0 || height == 0 || !coordinates_are_safe(x, y) {
+        return TRANSPARENT;
+    }
+    let radius_squared = radius * radius;
+    let min_x = (x - radius).floor() as i64;
+    let max_x = (x + radius).ceil() as i64;
+    let min_y = (y - radius).floor() as i64;
+    let max_y = (y + radius).ceil() as i64;
+    let mut sum = TRANSPARENT;
+    let mut weight_sum = 0.0;
+    for sy in min_y..=max_y {
+        let dy = y - sy as f32;
+        for sx in min_x..=max_x {
+            let dx = x - sx as f32;
+            let normalized_radius = (dx * dx + dy * dy) / radius_squared;
+            if normalized_radius >= 1.0 {
+                continue;
+            }
+            let sample_weight = (1.0 - normalized_radius).powi(2);
+            add_weighted(
+                &mut sum,
+                sample_integer(pixels, width, height, sx, sy, edge),
+                sample_weight,
+            );
+            weight_sum += sample_weight;
+        }
+    }
+    normalized_pixel(sum, weight_sum)
+}
+
+fn add_weighted(sum: &mut PixelF32, pixel: PixelF32, weight: f32) {
+    sum.alpha += pixel.alpha * weight;
+    sum.red += pixel.red * weight;
+    sum.green += pixel.green * weight;
+    sum.blue += pixel.blue * weight;
+}
+
+fn normalized_pixel(pixel: PixelF32, weight_sum: f32) -> PixelF32 {
+    if !weight_sum.is_finite() || weight_sum.abs() <= 1.0e-8 {
+        return TRANSPARENT;
+    }
+    let inverse = weight_sum.recip();
+    PixelF32 {
+        alpha: pixel.alpha * inverse,
+        red: pixel.red * inverse,
+        green: pixel.green * inverse,
+        blue: pixel.blue * inverse,
+    }
+}
+
+fn cubic_keys_weight(distance: f32, a: f32) -> f32 {
+    let x = distance.abs();
+    if x <= 1.0 {
+        (a + 2.0) * x.powi(3) - (a + 3.0) * x.powi(2) + 1.0
+    } else if x < 2.0 {
+        a * x.powi(3) - 5.0 * a * x.powi(2) + 8.0 * a * x - 4.0 * a
+    } else {
+        0.0
+    }
+}
+
+fn mitchell_weight(distance: f32, b: f32, c: f32) -> f32 {
+    let x = distance.abs();
+    let b = finite_or(b, 1.0 / 3.0).clamp(0.0, 1.0);
+    let c = finite_or(c, 1.0 / 3.0).clamp(0.0, 1.0);
+    if x < 1.0 {
+        ((12.0 - 9.0 * b - 6.0 * c) * x.powi(3) + (-18.0 + 12.0 * b + 6.0 * c) * x.powi(2) + 6.0
+            - 2.0 * b)
+            / 6.0
+    } else if x < 2.0 {
+        ((-b - 6.0 * c) * x.powi(3)
+            + (6.0 * b + 30.0 * c) * x.powi(2)
+            + (-12.0 * b - 48.0 * c) * x
+            + 8.0 * b
+            + 24.0 * c)
+            / 6.0
+    } else {
+        0.0
+    }
+}
+
+fn cubic_bspline_weight(distance: f32) -> f32 {
+    let x = distance.abs();
+    if x < 1.0 {
+        (4.0 - 6.0 * x.powi(2) + 3.0 * x.powi(3)) / 6.0
+    } else if x < 2.0 {
+        (2.0 - x).powi(3) / 6.0
+    } else {
+        0.0
+    }
+}
+
+fn sinc(value: f32) -> f32 {
+    if value.abs() < 1.0e-6 {
+        1.0
+    } else {
+        let angle = std::f32::consts::PI * value;
+        angle.sin() / angle
+    }
+}
+
+fn lanczos_weight(distance: f32, lobes: f32) -> f32 {
+    let x = distance.abs();
+    if x >= lobes {
+        0.0
+    } else {
+        sinc(x) * sinc(x / lobes)
+    }
+}
+
+#[inline]
+fn coordinates_are_safe(x: f32, y: f32) -> bool {
+    x.is_finite()
+        && y.is_finite()
+        && x.abs() <= MAX_SAFE_SAMPLE_COORDINATE
+        && y.abs() <= MAX_SAFE_SAMPLE_COORDINATE
+}
+
+#[inline]
+pub fn lerp_pixel(a: PixelF32, b: PixelF32, t: f32) -> PixelF32 {
+    PixelF32 {
+        alpha: a.alpha + (b.alpha - a.alpha) * t,
+        red: a.red + (b.red - a.red) * t,
+        green: a.green + (b.green - a.green) * t,
+        blue: a.blue + (b.blue - a.blue) * t,
+    }
+}
+
+fn sample_integer(
+    pixels: &[PixelF32],
+    width: usize,
+    height: usize,
+    x: i64,
+    y: i64,
+    edge: SampleEdge,
+) -> PixelF32 {
+    let Some(x) = resolve_coordinate(x, width, edge) else {
+        return TRANSPARENT;
+    };
+    let Some(y) = resolve_coordinate(y, height, edge) else {
+        return TRANSPARENT;
+    };
+    pixels.get(y * width + x).copied().unwrap_or(TRANSPARENT)
+}
+
+fn resolve_coordinate(value: i64, length: usize, edge: SampleEdge) -> Option<usize> {
+    if length == 0 {
+        return None;
+    }
+    let length = length as i64;
+    match edge {
+        SampleEdge::Transparent => (0..length).contains(&value).then_some(value as usize),
+        SampleEdge::Clamp => Some(value.clamp(0, length - 1) as usize),
+        SampleEdge::Tile => Some(value.rem_euclid(length) as usize),
+        SampleEdge::Mirror => {
+            if length == 1 {
+                return Some(0);
+            }
+            let period = length * 2 - 2;
+            let folded = value.rem_euclid(period);
+            Some(if folded < length {
+                folded as usize
+            } else {
+                (period - folded) as usize
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pixel(value: f32) -> PixelF32 {
+        PixelF32 {
+            alpha: 1.0,
+            red: value,
+            green: value,
+            blue: value,
+        }
+    }
+
+    #[test]
+    fn edge_modes_resolve_outside_coordinates() {
+        let pixels = vec![pixel(0.0), pixel(1.0), pixel(2.0)];
+        assert_eq!(
+            sample_nearest(&pixels, 3, 1, -1.0, 0.0, SampleEdge::Transparent).alpha,
+            0.0
+        );
+        assert_eq!(
+            sample_nearest(&pixels, 3, 1, -1.0, 0.0, SampleEdge::Clamp).red,
+            0.0
+        );
+        assert_eq!(
+            sample_nearest(&pixels, 3, 1, -1.0, 0.0, SampleEdge::Tile).red,
+            2.0
+        );
+        assert_eq!(
+            sample_nearest(&pixels, 3, 1, -1.0, 0.0, SampleEdge::Mirror).red,
+            1.0
+        );
+    }
+
+    #[test]
+    fn bilinear_interpolation_blends_four_neighbors() {
+        let pixels = vec![pixel(0.0), pixel(1.0), pixel(2.0), pixel(3.0)];
+        let result = sample_bilinear(&pixels, 2, 2, 0.5, 0.5, SampleEdge::Clamp);
+        assert!((result.red - 1.5).abs() < 1.0e-6);
+    }
+
+    #[test]
+    fn extreme_coordinates_are_transparent_without_overflowing() {
+        let pixels = vec![pixel(1.0)];
+        for edge in [
+            SampleEdge::Transparent,
+            SampleEdge::Clamp,
+            SampleEdge::Tile,
+            SampleEdge::Mirror,
+        ] {
+            assert_eq!(
+                sample_bilinear(&pixels, 1, 1, f32::MAX, f32::MIN, edge).alpha,
+                0.0
+            );
+            assert_eq!(
+                sample_nearest(&pixels, 1, 1, f32::INFINITY, 0.0, edge).alpha,
+                0.0
+            );
+        }
+    }
+
+    #[test]
+    fn reconstruction_filters_preserve_a_constant_field() {
+        let pixels = vec![pixel(0.625); 25];
+        for filter in [
+            SampleFilter::Nearest,
+            SampleFilter::Bilinear,
+            SampleFilter::Bicubic,
+            SampleFilter::Mitchell {
+                b: 1.0 / 3.0,
+                c: 1.0 / 3.0,
+            },
+            SampleFilter::Lanczos { lobes: 3.0 },
+            SampleFilter::CubicBSpline,
+            SampleFilter::EwaQuadratic { radius: 2.0 },
+        ] {
+            let result = sample_filtered(&pixels, 5, 5, 2.25, 1.75, SampleEdge::Clamp, filter);
+            assert!((result.red - 0.625).abs() < 1.0e-5, "{filter:?}");
+            assert!((result.alpha - 1.0).abs() < 1.0e-5, "{filter:?}");
+        }
+    }
+}

--- a/crates/utils/src/image.rs
+++ b/crates/utils/src/image.rs
@@ -16,6 +16,22 @@ pub const TRANSPARENT: PixelF32 = PixelF32 {
 // cannot describe a meaningful image sample and may overflow neighbour math.
 const MAX_SAFE_SAMPLE_COORDINATE: f32 = 4_503_599_627_370_496.0;
 
+// Separable filters currently top out at 8-lobe Lanczos. A non-integral
+// coordinate can cover one more tap than the two inclusive radius endpoints.
+const MAX_SEPARABLE_RADIUS: usize = 8;
+const MAX_SEPARABLE_TAPS: usize = MAX_SEPARABLE_RADIUS * 2 + 2;
+
+#[derive(Clone, Copy)]
+struct SeparableTap {
+    coordinate: i64,
+    weight: f32,
+}
+
+const EMPTY_SEPARABLE_TAP: SeparableTap = SeparableTap {
+    coordinate: 0,
+    weight: 0.0,
+};
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SampleEdge {
     Transparent,
@@ -164,7 +180,7 @@ pub fn sample_filtered(
             })
         }
         SampleFilter::Lanczos { lobes } => {
-            let lobes = finite_or(lobes, 3.0).clamp(1.0, 8.0);
+            let lobes = finite_or(lobes, 3.0).clamp(1.0, MAX_SEPARABLE_RADIUS as f32);
             sample_separable(pixels, width, height, x, y, edge, lobes, |d| {
                 lanczos_weight(d, lobes)
             })
@@ -201,6 +217,66 @@ where
     if width == 0 || height == 0 || !coordinates_are_safe(x, y) {
         return TRANSPARENT;
     }
+    let min_x = (x - radius).floor() as i64;
+    let max_x = (x + radius).ceil() as i64;
+    let min_y = (y - radius).floor() as i64;
+    let max_y = (y + radius).ceil() as i64;
+    let x_tap_count = max_x.saturating_sub(min_x).saturating_add(1);
+    let Ok(x_tap_count) = usize::try_from(x_tap_count) else {
+        return sample_separable_uncached(pixels, width, height, x, y, edge, radius, &weight);
+    };
+    if x_tap_count > MAX_SEPARABLE_TAPS {
+        // At very large f32 coordinates, rounding can make x +/- radius span
+        // more integer taps than the nominal kernel diameter. Preserve the
+        // previous behavior without allocating or indexing past the stack.
+        return sample_separable_uncached(pixels, width, height, x, y, edge, radius, &weight);
+    }
+
+    let mut x_taps = [EMPTY_SEPARABLE_TAP; MAX_SEPARABLE_TAPS];
+    for (tap, sx) in x_taps.iter_mut().zip(min_x..=max_x) {
+        *tap = SeparableTap {
+            coordinate: sx,
+            weight: weight(x - sx as f32),
+        };
+    }
+
+    let mut sum = TRANSPARENT;
+    let mut weight_sum = 0.0;
+    for sy in min_y..=max_y {
+        let wy = weight(y - sy as f32);
+        if wy == 0.0 {
+            continue;
+        }
+        for tap in &x_taps[..x_tap_count] {
+            let sample_weight = wy * tap.weight;
+            if sample_weight == 0.0 || !sample_weight.is_finite() {
+                continue;
+            }
+            add_weighted(
+                &mut sum,
+                sample_integer(pixels, width, height, tap.coordinate, sy, edge),
+                sample_weight,
+            );
+            weight_sum += sample_weight;
+        }
+    }
+    normalized_pixel(sum, weight_sum)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn sample_separable_uncached<F>(
+    pixels: &[PixelF32],
+    width: usize,
+    height: usize,
+    x: f32,
+    y: f32,
+    edge: SampleEdge,
+    radius: f32,
+    weight: &F,
+) -> PixelF32
+where
+    F: Fn(f32) -> f32,
+{
     let min_x = (x - radius).floor() as i64;
     let max_x = (x + radius).ceil() as i64;
     let min_y = (y - radius).floor() as i64;
@@ -410,6 +486,7 @@ fn resolve_coordinate(value: i64, length: usize, edge: SampleEdge) -> Option<usi
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::Cell;
 
     fn pixel(value: f32) -> PixelF32 {
         PixelF32 {
@@ -417,6 +494,53 @@ mod tests {
             red: value,
             green: value,
             blue: value,
+        }
+    }
+
+    fn assert_pixel_bits_eq(actual: PixelF32, expected: PixelF32) {
+        assert_eq!(actual.alpha.to_bits(), expected.alpha.to_bits(), "alpha");
+        assert_eq!(actual.red.to_bits(), expected.red.to_bits(), "red");
+        assert_eq!(actual.green.to_bits(), expected.green.to_bits(), "green");
+        assert_eq!(actual.blue.to_bits(), expected.blue.to_bits(), "blue");
+    }
+
+    fn sample_filtered_uncached(
+        pixels: &[PixelF32],
+        width: usize,
+        height: usize,
+        x: f32,
+        y: f32,
+        edge: SampleEdge,
+        filter: SampleFilter,
+    ) -> PixelF32 {
+        match filter {
+            SampleFilter::Bicubic => {
+                sample_separable_uncached(pixels, width, height, x, y, edge, 2.0, &|d| {
+                    cubic_keys_weight(d, -0.5)
+                })
+            }
+            SampleFilter::Mitchell { b, c } => {
+                sample_separable_uncached(pixels, width, height, x, y, edge, 2.0, &|d| {
+                    mitchell_weight(d, b, c)
+                })
+            }
+            SampleFilter::Lanczos { lobes } => {
+                let lobes = finite_or(lobes, 3.0).clamp(1.0, MAX_SEPARABLE_RADIUS as f32);
+                sample_separable_uncached(pixels, width, height, x, y, edge, lobes, &|d| {
+                    lanczos_weight(d, lobes)
+                })
+            }
+            SampleFilter::CubicBSpline => sample_separable_uncached(
+                pixels,
+                width,
+                height,
+                x,
+                y,
+                edge,
+                2.0,
+                &cubic_bspline_weight,
+            ),
+            _ => panic!("test helper only supports separable filters"),
         }
     }
 
@@ -487,5 +611,71 @@ mod tests {
             assert!((result.red - 0.625).abs() < 1.0e-5, "{filter:?}");
             assert!((result.alpha - 1.0).abs() < 1.0e-5, "{filter:?}");
         }
+    }
+
+    #[test]
+    fn cached_separable_taps_are_bitwise_identical_to_previous_loop() {
+        let pixels = (0..35)
+            .map(|index| PixelF32 {
+                alpha: 0.25 + index as f32 * 0.017,
+                red: ((index * 17 + 3) % 29) as f32 / 19.0,
+                green: ((index * 11 + 5) % 31) as f32 / 23.0,
+                blue: ((index * 7 + 13) % 37) as f32 / 17.0,
+            })
+            .collect::<Vec<_>>();
+        let filters = [
+            SampleFilter::Bicubic,
+            SampleFilter::Mitchell { b: 0.21, c: 0.47 },
+            SampleFilter::Lanczos { lobes: 1.0 },
+            SampleFilter::Lanczos { lobes: 3.0 },
+            SampleFilter::Lanczos { lobes: 8.0 },
+            SampleFilter::CubicBSpline,
+        ];
+        let coordinates = [
+            (-2.25, -1.75),
+            (-0.5, 0.0),
+            (0.125, 0.875),
+            (2.5, 3.25),
+            (5.75, 4.5),
+            (8.25, 7.125),
+        ];
+
+        for edge in [
+            SampleEdge::Transparent,
+            SampleEdge::Clamp,
+            SampleEdge::Tile,
+            SampleEdge::Mirror,
+        ] {
+            for filter in filters {
+                for (x, y) in coordinates {
+                    let actual = sample_filtered(&pixels, 7, 5, x, y, edge, filter);
+                    let expected = sample_filtered_uncached(&pixels, 7, 5, x, y, edge, filter);
+                    assert_pixel_bits_eq(actual, expected);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn separable_x_kernel_is_evaluated_once_per_tap() {
+        let pixels = vec![pixel(0.5); 25];
+        let evaluations = Cell::new(0);
+        let _ = sample_separable(
+            &pixels,
+            5,
+            5,
+            2.25,
+            1.75,
+            SampleEdge::Clamp,
+            2.0,
+            |distance| {
+                evaluations.set(evaluations.get() + 1);
+                cubic_keys_weight(distance, -0.5)
+            },
+        );
+
+        let x_taps = ((2.25_f32 + 2.0).ceil() - (2.25_f32 - 2.0).floor()) as usize + 1;
+        let y_taps = ((1.75_f32 + 2.0).ceil() - (1.75_f32 - 2.0).floor()) as usize + 1;
+        assert_eq!(evaluations.get(), x_taps + y_taps);
     }
 }

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -2,6 +2,7 @@ use ae::sys::{PF_Pixel, PF_PixelFloat};
 use ae::{Pixel8, Pixel16, PixelF32};
 use after_effects as ae;
 
+pub mod image;
 #[cfg(feature = "spectral")]
 pub mod spectral;
 #[cfg(feature = "spectral_wgpu")]

--- a/docs/catalog/generator.md
+++ b/docs/catalog/generator.md
@@ -39,6 +39,26 @@
 - `Gain`、`Bias`、`Clamp`: 出力のコントラスト、基準値、範囲を調整します。
 - `Use Original Alpha`: 入力レイヤーのアルファを保持します。
 
+## AOD_RainbowGenerate
+
+- **分類:** G：生成用キャンバス
+
+![AOD_RainbowGenerate](assets/previews/rainbow-generate.png)
+
+2点アンカーまたは中心・角度から得た座標を、OKLCH／HSV／HSL／CIELCh(ab)／CIELCh(uv)／JzCzHz／IPT IChの色成分へ直接変換して虹を生成します。
+
+### パラメーター
+
+- `Shape`、`Coordinates`: Linear、Reflected Linear、Radial (L2)、Diamond (L1)、Box (L∞)、Minkowski (Lp)、Conic、Spiral、Starburstと、Two Points／Parametric指定を切り替えます。
+- `Start/Center`、`End/Radius`または`Center/Angle/Length`: グラデーションの基準座標を設定します。
+- `Aspect (-Vertical / +Horizontal)`: `-1..1`の対称値を、縦方向／横方向の対数ストレッチへ変換します。
+- `Minkowski Exponent`、`Spiral Turns`、`Ray Count`: 選択したプロシージャル形状を数値で調整します。
+- `Color Model`: 虹を直接生成するOKLCH、HSV、HSL、CIELCh(ab)、CIELCh(uv)、JzCzHz、IPT IChを選択します。二色のカラーピッカーは使用しません。従来の先頭3モードは番号と挙動を維持しています。
+- `Hue`と`Saturation/Chroma`、`Brightness/Lightness/Jz/Intensity`の各`Scale/Offset`: `成分(t) = Offset + Scale × t`として虹全体を制御します。Hue Scale 100%は色相1周です。知覚系モデルのChroma 100%は、OKLCH `0.2`、CIELCh(ab) `C*=80`、CIELCh(uv) `C*=100`、JzCzHz `Cz=0.08`、IPT ICh `C=0.30`に対応します。JzCzHzのLightness 100%は100 nit D65白の`Jz=0.167174`です。
+- `Split Range Start / End`: Scale／Offset UIを明示的な始点・終点成分へ切り替えます。色相値は複数周や逆方向も指定できます。
+- `Preset`、`Bezier X1/Y1/X2/Y2`: 補間カーブのプリセットまたはカスタム3次ベジェを設定します。
+- `Extend`、`Clamp to Display Gamut`、`Mix`、`Preserve Input Alpha`: 範囲外の繰り返し、色域、入力との合成を制御します。
+
 ## AOD_VoronoiGenerate
 
 - **分類:** G：生成用キャンバス（補助入力: D）

--- a/docs/catalog/generator.md
+++ b/docs/catalog/generator.md
@@ -45,15 +45,18 @@
 
 ![AOD_RainbowGenerate](assets/previews/rainbow-generate.png)
 
-2点アンカーまたは中心・角度から得た座標を、OKLCH／HSV／HSL／CIELCh(ab)／CIELCh(uv)／JzCzHz／IPT IChの色成分へ直接変換して虹を生成します。
+2点アンカーまたは中心・角度から得た座標を、多様な知覚・円筒色空間へ変換して虹を生成します。パラメトリック生成を標準とし、二色補間にも切り替えられます。
 
 ### パラメーター
 
 - `Shape`、`Coordinates`: Linear、Reflected Linear、Radial (L2)、Diamond (L1)、Box (L∞)、Minkowski (Lp)、Conic、Spiral、Starburstと、Two Points／Parametric指定を切り替えます。
 - `Start/Center`、`End/Radius`または`Center/Angle/Length`: グラデーションの基準座標を設定します。
 - `Aspect (-Vertical / +Horizontal)`: `-1..1`の対称値を、縦方向／横方向の対数ストレッチへ変換します。
+- `Skew`: 全形状を水平方向へシアー変形します。`0%`では従来の形状を維持します。
 - `Minkowski Exponent`、`Spiral Turns`、`Ray Count`: 選択したプロシージャル形状を数値で調整します。
-- `Color Model`: 虹を直接生成するOKLCH、HSV、HSL、CIELCh(ab)、CIELCh(uv)、JzCzHz、IPT IChを選択します。二色のカラーピッカーは使用しません。従来の先頭3モードは番号と挙動を維持しています。
+- `Generation Mode`: 標準の`Parametric`と、始点／終点カラーを使う`Two Color`を切り替えます。
+- `Color Model`: ParametricではOKLCH、HSV、HSL、CIELCh(ab)、CIELCh(uv)、JzCzHz、IPT ICh、OkHSL、OkHSV、CAM16-UCS J'M'h'を選択します。既存7モードの番号と挙動は維持しています。
+- `Two Color Space`、`Start/End Color`: OKLab、OKLCH、CAM16-UCS J'a'b'、CAM16-UCS J'M'h'で二色を補間します。円筒空間では最短色相経路を使用します。
 - `Hue`と`Saturation/Chroma`、`Brightness/Lightness/Jz/Intensity`の各`Scale/Offset`: `成分(t) = Offset + Scale × t`として虹全体を制御します。Hue Scale 100%は色相1周です。知覚系モデルのChroma 100%は、OKLCH `0.2`、CIELCh(ab) `C*=80`、CIELCh(uv) `C*=100`、JzCzHz `Cz=0.08`、IPT ICh `C=0.30`に対応します。JzCzHzのLightness 100%は100 nit D65白の`Jz=0.167174`です。
 - `Split Range Start / End`: Scale／Offset UIを明示的な始点・終点成分へ切り替えます。色相値は複数周や逆方向も指定できます。
 - `Preset`、`Bezier X1/Y1/X2/Y2`: 補間カーブのプリセットまたはカスタム3次ベジェを設定します。

--- a/docs/catalog/map-data.md
+++ b/docs/catalog/map-data.md
@@ -52,3 +52,27 @@ RGBA各出力チャンネルを、入力チャンネル・定数・別レイヤ�
 ### 補足
 
 プレビューは入力未接続時のニュートラル表示です。実用時は同じ条件で書き出した`AOD_FFT`のReal／Imaginaryレイヤーを接続し、32bpc Raw Modeを推奨します。
+
+## AOD_SpaceConvert
+
+- **分類:** D：データ・マップ画像
+
+![AOD_SpaceConvert](assets/previews/space-convert.png)
+
+画像を極座標、曲線座標、円盤写像、Radon、直線Houghなどの表現へ変換し、対応モードでは逆変換します。
+
+### パラメーター
+
+- `Space`、`Direction`: Polar、Log-Polar、Spiral Polar、Square-Disc、Elliptic、Parabolic、Bipolar、Radon、Line HoughとForward／Inverseを選択します。
+- `Center`、`Custom Center`、`Radius`、`Custom Radius`、`Angle Offset`: Polar／Log-Polar系の座標範囲を設定します。
+- `Spiral Turns`、`Focus / Radius`、`Coordinate Extent`: Spiral、Elliptic、Bipolar固有の座標形状を設定します。
+- `Angle Samples`、`Detector Samples`、`Samples per Ray`: 積分変換の内部解析解像度を指定します。
+- `Edge Threshold`、`Weighted Votes`: Hough変換のエッジ投票条件を設定します。
+- `Line Hough Channels`: 従来のLuminance、RGBA独立処理、R／G／B／A単独表示・逆変換を選択します。
+- `Ram-Lak Radius`: Radon逆変換のフィルター付き逆投影カーネルを設定します。
+- `Interpolation`、`Edge`、`Output Gain/Bias`、`Clamp Output`: 再サンプリングとデータ出力を制御します。
+- `Post Transform`: 変換後空間へ`Anchor Point`、`Position`、統合／分離`Scale`、`Rotation`、`Skew`、`Skew Axis`を適用します。変換済み画像をtileするのではなく、逆Transformした座標で各空間式を直接評価するため、対応する空間では表示範囲外も連続して描画できます。
+
+### 補足
+
+RadonのInverseは離散フィルター付き逆投影、HoughのInverseは検出線の可視化を目的とした逆投影です。後者は厳密な元画像復元ではありません。

--- a/plugins/glass-displace/Cargo.toml
+++ b/plugins/glass-displace/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "glass_displace"
+description = "Applies map-driven glass refraction with parametric fractures and spectral dispersion."
+version = "0.3.0"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib"]
+
+[features]
+default = []
+catch-panics = []
+
+[dependencies]
+after-effects = { workspace = true }
+utils = { path = "../../crates/utils" }
+
+
+[dev-dependencies]
+pipl = { workspace = true }
+
+[build-dependencies]
+chrono.workspace = true
+pipl.workspace = true
+winres = "0.1.12"
+
+[lints]
+workspace = true

--- a/plugins/glass-displace/Cargo.toml
+++ b/plugins/glass-displace/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "glass_displace"
 description = "Applies map-driven glass refraction with parametric fractures and spectral dispersion."
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 
 [lib]

--- a/plugins/glass-displace/Justfile
+++ b/plugins/glass-displace/Justfile
@@ -1,0 +1,12 @@
+# Read package.name from Cargo.toml for build naming.
+CrateName := if os() == "windows" {
+    `$inPackage = $false; foreach ($line in Get-Content -Path Cargo.toml) { if ($line -match '^\s*\[package\]\s*$') { $inPackage = $true; continue }; if ($line -match '^\s*\[.+\]\s*$') { if ($inPackage) { break } }; if ($inPackage -and $line -match '^\s*name\s*=\s*"([^"]+)"') { $matches[1]; break } }`
+} else {
+    `awk -F'"' 'BEGIN{in_pkg=0} /^[[:space:]]*\[package\][[:space:]]*$/{in_pkg=1;next} /^[[:space:]]*\[/{if(in_pkg)exit} in_pkg && /^[[:space:]]*name[[:space:]]*=/ {print $2; exit}' Cargo.toml`
+}
+
+PluginName       := "AOD_GlassDisplace"
+BundleIdentifier := "com.aodaruma." + PluginName
+BinaryName       := snakecase(CrateName)
+
+import "../../AdobePlugin.just"

--- a/plugins/glass-displace/README.md
+++ b/plugins/glass-displace/README.md
@@ -1,0 +1,26 @@
+# glass-displace ( AOD_GlassDisplace )
+
+Applies map-driven glass refraction with configurable fracture fields, impact cracks, and spectral dispersion.
+
+This is the After Effects plugin **AOD_GlassDisplace**, which provides the **AOD_GlassDisplace.aex** plugin file for Adobe After Effects.
+
+## Controls
+
+- **Height Map**: Generate a Sphere, Rounded Rectangle, Diamond, Ring, full-frame Facet Field, full-frame Fractured Field, or bounded Impact Glass height field; use a custom layer map; or derive height from input luma/alpha. Map channel, levels, and inversion are configurable.
+- **Procedural Geometry**: Cell Size controls the actual tessellation scale. Facet Relief controls deterministic per-cell optical depth and Cell Irregularity perturbs the cell sites. Facet and Fractured fields are no longer clipped by the unrelated Size circle; Size is used by bounded shapes and as the Impact Glass diameter.
+- **Fracture Detail**: Fractured Field adds adjustable cell-boundary crack width and depth. Impact Glass combines deterministic jagged radial cracks, probabilistic branches, interrupted concentric stress rings, a crushed strike zone, and finer Voronoi seams. Radial count, branching, jitter, ring count/irregularity, edge falloff, and seed are parametric.
+- **Refraction**: Central differences convert the height field into a 3D interface normal. Each camera ray is refracted from air into BK7-equivalent optical glass with the vector form of Snell's law, then projected onto the source plane. **Refraction** is calibrated in pixels at a 45-degree surface slope, so stronger slopes can produce substantially larger, nonlinear displacement instead of saturating at the normal's XY component. Nearest and bilinear sampling plus transparent/clamp/tile/mirror edge handling remain available.
+- **Spectral Dispersion**: The effect integrates 380–780 nm visible light using wavelength-dependent N-BK7 Sellmeier indices and a CIE 1931 observer response converted to linear sRGB. This produces continuously overlapping spectral fringes instead of three separated channel copies. **Auto Spectral Steps** (enabled by default) selects 6–32 samples from the estimated spectral travel, refraction magnitude, height slope, render resolution, and sampling mode. While it is enabled, **Spectral Steps (Manual)** is visibly disabled; turn Auto off to use a fixed 3–32 samples (default 8).
+- **Output**: Mix and alpha controls plus Height, Normal, Displacement, and Facet ID diagnostic views.
+
+Controls that do not apply to the selected height source or shape are hidden dynamically.
+
+## Compatibility
+
+The original parameter order and the first six Shape popup values are retained so existing projects continue to map to the same controls. New controls are appended after the original parameter block; **Auto Spectral Steps** is appended after the existing manual spectral-step control. Existing **Facets** and **Shards** values appear as **Facet Field** and **Fractured Field** and now share the same tessellation controls; Fractured Field adds crack controls. The previous circular envelope in those two modes is intentionally removed.
+
+All image sampling is performed in unpremultiplied RGB and associated again before output. Alpha is spectrally weighted unless **Preserve Input Alpha** is enabled, and the same floating-point render path feeds 8, 16, and 32 bpc output conversion.
+
+## Building the Plugin
+
+See the [main README](../../README.md) for instructions on how to build the plugin.

--- a/plugins/glass-displace/build.rs
+++ b/plugins/glass-displace/build.rs
@@ -1,0 +1,98 @@
+use chrono::Datelike;
+use pipl::*;
+
+const PF_PLUG_IN_VERSION: u16 = 13;
+const PF_PLUG_IN_SUBVERS: u16 = 28;
+
+#[cfg(target_os = "windows")]
+fn embed_binary_safe_pipl(pipl: &[u8]) {
+    let out_dir = std::path::PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR is set"));
+    let pipl_path = out_dir.join("glass_displace.pipl");
+    std::fs::write(&pipl_path, pipl).expect("write binary PiPL resource");
+
+    let escaped_path = pipl_path.to_string_lossy().replace('\\', "\\\\");
+    let mut resource = winres::WindowsResource::new();
+    resource.append_rc_content(&format!("16000 PiPL DISCARDABLE \"{escaped_path}\""));
+    resource.compile().expect("compile binary PiPL resource");
+}
+
+#[rustfmt::skip]
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(does_dialog)");
+    println!("cargo::rustc-check-cfg=cfg(threaded_rendering)");
+
+    let current_year = chrono::Local::now().year();
+    println!("cargo:rustc-env=BUILD_YEAR={}", current_year);
+
+    let pkg_version = env!("CARGO_PKG_VERSION");
+    let version_parts: Vec<&str> = pkg_version.split('.').collect();
+    if version_parts.len() != 3 {
+        panic!("CARGO_PKG_VERSION must be in the format 'major.minor.patch'");
+    }
+    let major: u32 = version_parts[0].parse().expect("Invalid major version");
+    let minor: u32 = version_parts[1].parse().expect("Invalid minor version");
+    let patch: u32 = version_parts[2].parse().expect("Invalid patch version");
+
+    // Determine the stage based on building whether debug or release
+    /*
+    // pipl load error occured when stage = Stage::Release in pipl == v0.1.1, so temporarily fixed to Develop
+    let stage = if cfg!(debug_assertions) {
+        Stage::Develop
+    } else {
+        Stage::Release
+    };
+    */
+    let stage = Stage::Develop;
+
+    // --------------------------------------------------
+    // Build the plugin with PiPL
+    let properties = || vec![
+        Property::Kind(PIPLType::AEEffect),
+        Property::Name("AOD_GlassDisplace"),
+        Property::Category("Aodaruma"),
+
+        #[cfg(target_os = "windows")]
+        Property::CodeWin64X86("EffectMain"),
+        #[cfg(target_os = "macos")]
+        Property::CodeMacIntel64("EffectMain"),
+        #[cfg(target_os = "macos")]
+        Property::CodeMacARM64("EffectMain"),
+
+        Property::AE_PiPL_Version { major: 2, minor: 0 },
+        Property::AE_Effect_Spec_Version { major: PF_PLUG_IN_VERSION, minor: PF_PLUG_IN_SUBVERS },
+        Property::AE_Effect_Version {
+            version: major,
+            subversion: minor,
+            bugversion: patch,
+            stage,
+            build: 1,
+        },
+        Property::AE_Effect_Info_Flags(0),
+        Property::AE_Effect_Global_OutFlags(
+            // set up from https://docs.rs/pipl/latest/pipl/struct.OutFlags.html
+            OutFlags::UseOutputExtent
+            | OutFlags::DeepColorAware
+            | OutFlags::WideTimeInput
+            | OutFlags::SendUpdateParamsUI
+            ,
+        ),
+        Property::AE_Effect_Global_OutFlags_2(
+            // set up from https://docs.rs/pipl/latest/pipl/struct.OutFlags2.html
+            OutFlags2::FloatColorAware
+            | OutFlags2::SupportsThreadedRendering
+            | OutFlags2::AutomaticWideTimeInput
+            | OutFlags2::SupportsSmartRender
+            | OutFlags2::RevealsZeroAlpha
+            | OutFlags2::ParamGroupStartCollapsedFlag
+            // | OutFlags2::SupportsGpuRenderF32
+            ,
+        ),
+        Property::AE_Effect_Match_Name("GlassDisplace"),
+        Property::AE_Reserved_Info(8),
+        Property::AE_Effect_Support_URL("https://github.com/Aodaruma/aod-AE-plugin"),
+    ];
+
+    pipl::plugin_build(properties());
+    #[cfg(target_os = "windows")]
+    embed_binary_safe_pipl(&pipl::build_pipl(properties()).expect("build PiPL"));
+}

--- a/plugins/glass-displace/src/glass.rs
+++ b/plugins/glass-displace/src/glass.rs
@@ -1,5 +1,10 @@
 use std::f32::consts::TAU;
 
+#[cfg(test)]
+thread_local! {
+    static PREPARED_PROCEDURAL_BUILDS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum HeightSource {
     Procedural,
@@ -80,48 +85,154 @@ pub(crate) struct HeightSample {
     pub facet_id: u32,
 }
 
-pub(crate) fn procedural_height(x: f32, y: f32, settings: ProceduralSettings) -> HeightSample {
-    let half_width = (settings.size * 0.5).max(1.0e-4);
-    let half_height = (half_width / settings.aspect.max(1.0e-4)).max(1.0e-4);
-    let dx = x - settings.center[0];
-    let dy = y - settings.center[1];
-    let cos = settings.rotation.cos();
-    let sin = settings.rotation.sin();
-    let local_x = dx * cos + dy * sin;
-    let local_y = -dx * sin + dy * cos;
-    let nx = local_x / half_width;
-    let ny = local_y / half_height;
-    let radius = nx.hypot(ny);
+#[derive(Clone, Debug)]
+pub(crate) struct PreparedProcedural {
+    settings: ProceduralSettings,
+    half_width: f32,
+    half_height: f32,
+    rotation_cos: f32,
+    rotation_sin: f32,
+    rounded_exponent: f32,
+    ring_half_band: f32,
+    facet_cell_size: f32,
+    facet_jitter: f32,
+    facet_relief: f32,
+    crack_depth: f32,
+    impact_radius: f32,
+    impact_aspect: f32,
+    impact_falloff: f32,
+    impact_crack_width: f32,
+    impact_sector: f32,
+    impact_jitter: f32,
+    impact_branching: f32,
+    impact_ring_count: u32,
+    impact_ring_spacing: f32,
+    impact_ring_jitter: f32,
+}
 
-    match settings.shape {
-        Shape::Sphere => HeightSample {
-            value: (1.0 - radius * radius).max(0.0).sqrt(),
-            facet_id: 0,
-        },
-        Shape::RoundedRectangle => {
-            // A larger UI roundness value should make corners rounder, not
-            // squarer. p=16 approaches a rectangle while p=2 is elliptical.
-            let exponent = 16.0 - settings.roundness.clamp(0.0, 1.0) * 14.0;
-            let distance = (nx.abs().powf(exponent) + ny.abs().powf(exponent)).powf(1.0 / exponent);
-            HeightSample {
-                value: (1.0 - distance).clamp(0.0, 1.0),
-                facet_id: 0,
-            }
+impl PreparedProcedural {
+    pub(crate) fn new(settings: ProceduralSettings) -> Self {
+        #[cfg(test)]
+        PREPARED_PROCEDURAL_BUILDS.with(|builds| builds.set(builds.get() + 1));
+        let half_width = (settings.size * 0.5).max(1.0e-4);
+        let half_height = (half_width / settings.aspect.max(1.0e-4)).max(1.0e-4);
+        let rotation_cos = settings.rotation.cos();
+        let rotation_sin = settings.rotation.sin();
+        let rounded_exponent = 16.0 - settings.roundness.clamp(0.0, 1.0) * 14.0;
+        let ring_half_band = settings.ring_width.clamp(0.01, 1.0) * 0.5;
+        let facet_cell_size = settings.facet_size.max(1.0);
+        let facet_jitter = settings.facet_jitter.clamp(0.0, 1.0);
+        let facet_relief = settings.facet_amount.clamp(0.0, 1.0);
+        let crack_depth = settings.crack_depth.clamp(0.0, 1.0);
+        let impact_radius = (settings.size * 0.5).max(1.0e-4);
+        let impact_aspect = settings.aspect.max(1.0e-4);
+        let impact_falloff = settings.impact_falloff.clamp(0.0, 1.0);
+        let impact_crack_width = settings.crack_width.max(0.0);
+        let impact_ray_count = settings.radial_cracks.clamp(3, 96) as f32;
+        let impact_sector = TAU / impact_ray_count;
+        let impact_jitter = settings.crack_jitter.clamp(0.0, 1.0);
+        let impact_branching = settings.crack_branching.clamp(0.0, 1.0);
+        let impact_ring_count = settings.stress_rings.min(32);
+        let impact_ring_spacing = impact_radius / (impact_ring_count + 1) as f32;
+        let impact_ring_jitter = settings.ring_jitter.clamp(0.0, 1.0);
+        Self {
+            settings,
+            half_width,
+            half_height,
+            rotation_cos,
+            rotation_sin,
+            rounded_exponent,
+            ring_half_band,
+            facet_cell_size,
+            facet_jitter,
+            facet_relief,
+            crack_depth,
+            impact_radius,
+            impact_aspect,
+            impact_falloff,
+            impact_crack_width,
+            impact_sector,
+            impact_jitter,
+            impact_branching,
+            impact_ring_count,
+            impact_ring_spacing,
+            impact_ring_jitter,
         }
-        Shape::Diamond => HeightSample {
-            value: (1.0 - nx.abs() - ny.abs()).clamp(0.0, 1.0),
-            facet_id: 0,
-        },
-        Shape::Ring => {
-            let half_band = settings.ring_width.clamp(0.01, 1.0) * 0.5;
-            let distance = (radius - 0.65).abs();
-            HeightSample {
-                value: (1.0 - distance / half_band).clamp(0.0, 1.0),
-                facet_id: 0,
+    }
+
+    pub(crate) fn height(&self, x: f32, y: f32) -> HeightSample {
+        let dx = x - self.settings.center[0];
+        let dy = y - self.settings.center[1];
+        let local_x = dx * self.rotation_cos + dy * self.rotation_sin;
+        let local_y = -dx * self.rotation_sin + dy * self.rotation_cos;
+
+        match self.settings.shape {
+            Shape::Sphere => {
+                let nx = local_x / self.half_width;
+                let ny = local_y / self.half_height;
+                let radius = nx.hypot(ny);
+                HeightSample {
+                    value: (1.0 - radius * radius).max(0.0).sqrt(),
+                    facet_id: 0,
+                }
             }
+            Shape::RoundedRectangle => {
+                let nx = local_x / self.half_width;
+                let ny = local_y / self.half_height;
+                let distance = (nx.abs().powf(self.rounded_exponent)
+                    + ny.abs().powf(self.rounded_exponent))
+                .powf(1.0 / self.rounded_exponent);
+                HeightSample {
+                    value: (1.0 - distance).clamp(0.0, 1.0),
+                    facet_id: 0,
+                }
+            }
+            Shape::Diamond => {
+                let nx = local_x / self.half_width;
+                let ny = local_y / self.half_height;
+                HeightSample {
+                    value: (1.0 - nx.abs() - ny.abs()).clamp(0.0, 1.0),
+                    facet_id: 0,
+                }
+            }
+            Shape::Ring => {
+                let nx = local_x / self.half_width;
+                let ny = local_y / self.half_height;
+                let distance = (nx.hypot(ny) - 0.65).abs();
+                HeightSample {
+                    value: (1.0 - distance / self.ring_half_band).clamp(0.0, 1.0),
+                    facet_id: 0,
+                }
+            }
+            Shape::Facets | Shape::Shards => fracture_field_prepared(local_x, local_y, self),
+            Shape::ImpactGlass => impact_glass_prepared(local_x, local_y, self),
         }
-        Shape::Facets | Shape::Shards => fracture_field(local_x, local_y, settings),
-        Shape::ImpactGlass => impact_glass(local_x, local_y, settings),
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn procedural_height(x: f32, y: f32, settings: ProceduralSettings) -> HeightSample {
+    PreparedProcedural::new(settings).height(x, y)
+}
+
+fn fracture_field_prepared(x: f32, y: f32, prepared: &PreparedProcedural) -> HeightSample {
+    let settings = prepared.settings;
+    let cell = voronoi_prepared(
+        x,
+        y,
+        prepared.facet_cell_size,
+        prepared.facet_jitter,
+        settings.seed,
+    );
+    let random_height = 0.2 + hash01(cell.id ^ 0xA511_E9B3) * 0.8;
+    let mut height = 1.0 + (random_height - 1.0) * prepared.facet_relief;
+    if settings.shape == Shape::Shards && settings.crack_width > 0.0 {
+        let crack = cell_boundary_crack(cell, settings.crack_width);
+        height *= 1.0 - crack * prepared.crack_depth;
+    }
+    HeightSample {
+        value: finite(height).clamp(0.0, 1.0),
+        facet_id: cell.id,
     }
 }
 
@@ -130,6 +241,7 @@ pub(crate) fn procedural_height(x: f32, y: f32, settings: ProceduralSettings) ->
 /// Cell Size is the only spatial scale for these two modes. This preserves the
 /// old popup indices while making the two modes a coherent uncracked/cracked
 /// pair.
+#[cfg(test)]
 fn fracture_field(x: f32, y: f32, settings: ProceduralSettings) -> HeightSample {
     let cell = voronoi(
         x,
@@ -155,12 +267,13 @@ fn fracture_field(x: f32, y: f32, settings: ProceduralSettings) -> HeightSample 
 /// cracked glass: primary radial cracks, shorter branches, and interrupted
 /// concentric stress rings. A Voronoi relief underneath them gives each
 /// resulting region a stable, deterministic optical normal.
-fn impact_glass(x: f32, y: f32, settings: ProceduralSettings) -> HeightSample {
-    let impact_radius = (settings.size * 0.5).max(1.0e-4);
+fn impact_glass_prepared(x: f32, y: f32, prepared: &PreparedProcedural) -> HeightSample {
+    let settings = prepared.settings;
+    let impact_radius = prepared.impact_radius;
     // Work in an isotropic impact space. Aspect changes the ellipse in image
     // space without making crack widths or radial density direction-dependent.
     let impact_x = x;
-    let impact_y = y * settings.aspect.max(1.0e-4);
+    let impact_y = y * prepared.impact_aspect;
     let radius = impact_x.hypot(impact_y);
     let normalized_radius = radius / impact_radius;
     if normalized_radius >= 1.0 {
@@ -170,32 +283,31 @@ fn impact_glass(x: f32, y: f32, settings: ProceduralSettings) -> HeightSample {
         };
     }
 
-    let cell = voronoi(
+    let cell = voronoi_prepared(
         impact_x,
         impact_y,
-        settings.facet_size,
-        settings.facet_jitter,
+        prepared.facet_cell_size,
+        prepared.facet_jitter,
         settings.seed,
     );
     let random_height = 0.2 + hash01(cell.id ^ 0xA511_E9B3) * 0.8;
-    let relief = settings.facet_amount.clamp(0.0, 1.0);
-    let facet_height = 1.0 + (random_height - 1.0) * relief;
+    let facet_height = 1.0 + (random_height - 1.0) * prepared.facet_relief;
 
-    let edge_falloff = settings.impact_falloff.clamp(0.0, 1.0);
+    let edge_falloff = prepared.impact_falloff;
     let envelope = if edge_falloff <= 1.0e-5 {
         1.0
     } else {
         1.0 - smoothstep(1.0 - edge_falloff, 1.0, normalized_radius)
     };
 
-    let structural_crack = impact_crack_mask(impact_x, impact_y, impact_radius, settings);
+    let structural_crack = impact_crack_mask_prepared(impact_x, impact_y, prepared);
     // Fine polygon boundaries are strongest near the strike and become only
     // subtle facet seams toward the edge.
     let cell_crack = cell_boundary_crack(cell, settings.crack_width * 0.7)
         * (1.0 - normalized_radius).sqrt()
         * 0.45;
     let crack = structural_crack.max(cell_crack).clamp(0.0, 1.0);
-    let height = envelope * facet_height * (1.0 - crack * settings.crack_depth.clamp(0.0, 1.0));
+    let height = envelope * facet_height * (1.0 - crack * prepared.crack_depth);
 
     HeightSample {
         value: finite(height).clamp(0.0, 1.0),
@@ -203,20 +315,21 @@ fn impact_glass(x: f32, y: f32, settings: ProceduralSettings) -> HeightSample {
     }
 }
 
-fn impact_crack_mask(x: f32, y: f32, impact_radius: f32, settings: ProceduralSettings) -> f32 {
+fn impact_crack_mask_prepared(x: f32, y: f32, prepared: &PreparedProcedural) -> f32 {
+    let settings = prepared.settings;
+    let impact_radius = prepared.impact_radius;
     let radius = x.hypot(y);
     let theta = y.atan2(x);
-    let crack_width = settings.crack_width.max(0.0);
+    let crack_width = prepared.impact_crack_width;
     if crack_width <= 1.0e-5 {
         return 0.0;
     }
 
-    let ray_count = settings.radial_cracks.clamp(3, 96) as f32;
-    let sector = TAU / ray_count;
+    let sector = prepared.impact_sector;
     let center_ray = (theta / sector).round() as i32;
     let normalized_radius = (radius / impact_radius).clamp(0.0, 1.0);
-    let jitter = settings.crack_jitter.clamp(0.0, 1.0);
-    let branching = settings.crack_branching.clamp(0.0, 1.0);
+    let jitter = prepared.impact_jitter;
+    let branching = prepared.impact_branching;
     let mut mask: f32 = 0.0;
 
     // Only nearby angular sectors can affect the pixel, which keeps the
@@ -279,10 +392,10 @@ fn impact_crack_mask(x: f32, y: f32, impact_radius: f32, settings: ProceduralSet
         }
     }
 
-    let ring_count = settings.stress_rings.min(32);
+    let ring_count = prepared.impact_ring_count;
     if ring_count > 0 {
-        let spacing = impact_radius / (ring_count + 1) as f32;
-        let ring_jitter = settings.ring_jitter.clamp(0.0, 1.0);
+        let spacing = prepared.impact_ring_spacing;
+        let ring_jitter = prepared.impact_ring_jitter;
         for ring in 1..=ring_count {
             let ring_id = cell_hash(ring as i32, 1, settings.seed ^ 0x243F_6A88);
             let base_radius = impact_radius * (ring as f32 / (ring_count + 1) as f32).powf(0.82);
@@ -384,8 +497,14 @@ struct Voronoi {
     id: u32,
 }
 
+#[cfg(test)]
 fn voronoi(x: f32, y: f32, cell_size: f32, jitter: f32, seed: u32) -> Voronoi {
     let cell_size = cell_size.max(1.0);
+    let jitter = jitter.clamp(0.0, 1.0);
+    voronoi_prepared(x, y, cell_size, jitter, seed)
+}
+
+fn voronoi_prepared(x: f32, y: f32, cell_size: f32, jitter: f32, seed: u32) -> Voronoi {
     let gx = x / cell_size;
     let gy = y / cell_size;
     let base_x = gx.floor() as i32;
@@ -399,7 +518,7 @@ fn voronoi(x: f32, y: f32, cell_size: f32, jitter: f32, seed: u32) -> Voronoi {
             let cy = base_y + oy;
             let id = cell_hash(cx, cy, seed);
             let angle = hash01(id ^ 0x9E37_79B9) * TAU;
-            let distance = hash01(id ^ 0xD1B5_4A35) * 0.5 * jitter.clamp(0.0, 1.0);
+            let distance = hash01(id ^ 0xD1B5_4A35) * 0.5 * jitter;
             let feature_x = cx as f32 + 0.5 + angle.cos() * distance;
             let feature_y = cy as f32 + 0.5 + angle.sin() * distance;
             let d = (gx - feature_x).hypot(gy - feature_y) * cell_size;
@@ -471,6 +590,145 @@ mod tests {
             impact_falloff: 0.2,
             seed: 42,
         }
+    }
+
+    fn legacy_procedural_height(x: f32, y: f32, settings: ProceduralSettings) -> HeightSample {
+        let half_width = (settings.size * 0.5).max(1.0e-4);
+        let half_height = (half_width / settings.aspect.max(1.0e-4)).max(1.0e-4);
+        let dx = x - settings.center[0];
+        let dy = y - settings.center[1];
+        let cos = settings.rotation.cos();
+        let sin = settings.rotation.sin();
+        let local_x = dx * cos + dy * sin;
+        let local_y = -dx * sin + dy * cos;
+        let nx = local_x / half_width;
+        let ny = local_y / half_height;
+        let radius = nx.hypot(ny);
+
+        match settings.shape {
+            Shape::Sphere => HeightSample {
+                value: (1.0 - radius * radius).max(0.0).sqrt(),
+                facet_id: 0,
+            },
+            Shape::RoundedRectangle => {
+                let exponent = 16.0 - settings.roundness.clamp(0.0, 1.0) * 14.0;
+                let distance =
+                    (nx.abs().powf(exponent) + ny.abs().powf(exponent)).powf(1.0 / exponent);
+                HeightSample {
+                    value: (1.0 - distance).clamp(0.0, 1.0),
+                    facet_id: 0,
+                }
+            }
+            Shape::Diamond => HeightSample {
+                value: (1.0 - nx.abs() - ny.abs()).clamp(0.0, 1.0),
+                facet_id: 0,
+            },
+            Shape::Ring => {
+                let half_band = settings.ring_width.clamp(0.01, 1.0) * 0.5;
+                let distance = (radius - 0.65).abs();
+                HeightSample {
+                    value: (1.0 - distance / half_band).clamp(0.0, 1.0),
+                    facet_id: 0,
+                }
+            }
+            Shape::Facets | Shape::Shards => fracture_field(local_x, local_y, settings),
+            Shape::ImpactGlass => legacy_impact_glass(local_x, local_y, settings),
+        }
+    }
+
+    fn legacy_impact_glass(x: f32, y: f32, settings: ProceduralSettings) -> HeightSample {
+        let impact_radius = (settings.size * 0.5).max(1.0e-4);
+        let impact_x = x;
+        let impact_y = y * settings.aspect.max(1.0e-4);
+        let radius = impact_x.hypot(impact_y);
+        let normalized_radius = radius / impact_radius;
+        if normalized_radius >= 1.0 {
+            return HeightSample {
+                value: 0.0,
+                facet_id: 0,
+            };
+        }
+
+        let cell = voronoi(
+            impact_x,
+            impact_y,
+            settings.facet_size,
+            settings.facet_jitter,
+            settings.seed,
+        );
+        let random_height = 0.2 + hash01(cell.id ^ 0xA511_E9B3) * 0.8;
+        let relief = settings.facet_amount.clamp(0.0, 1.0);
+        let facet_height = 1.0 + (random_height - 1.0) * relief;
+        let edge_falloff = settings.impact_falloff.clamp(0.0, 1.0);
+        let envelope = if edge_falloff <= 1.0e-5 {
+            1.0
+        } else {
+            1.0 - smoothstep(1.0 - edge_falloff, 1.0, normalized_radius)
+        };
+        let structural_crack =
+            impact_crack_mask_prepared(impact_x, impact_y, &PreparedProcedural::new(settings));
+        let cell_crack = cell_boundary_crack(cell, settings.crack_width * 0.7)
+            * (1.0 - normalized_radius).sqrt()
+            * 0.45;
+        let crack = structural_crack.max(cell_crack).clamp(0.0, 1.0);
+        let height = envelope * facet_height * (1.0 - crack * settings.crack_depth.clamp(0.0, 1.0));
+        HeightSample {
+            value: finite(height).clamp(0.0, 1.0),
+            facet_id: cell.id,
+        }
+    }
+
+    #[test]
+    fn prepared_procedural_is_bitwise_equivalent_to_legacy_shape_math() {
+        for shape in [
+            Shape::Sphere,
+            Shape::RoundedRectangle,
+            Shape::Diamond,
+            Shape::Ring,
+            Shape::Facets,
+            Shape::Shards,
+            Shape::ImpactGlass,
+        ] {
+            let mut controls = settings(shape);
+            controls.aspect = 1.37;
+            controls.rotation = 0.43;
+            controls.roundness = 0.63;
+            controls.ring_width = 0.31;
+            let prepared = PreparedProcedural::new(controls);
+            for [x, y] in [
+                [3.25, -7.5],
+                [36.125, 41.75],
+                [50.0, 50.0],
+                [63.5, 57.25],
+                [112.0, 91.0],
+            ] {
+                let expected = legacy_procedural_height(x, y, controls);
+                let actual = prepared.height(x, y);
+                assert_eq!(
+                    actual.value.to_bits(),
+                    expected.value.to_bits(),
+                    "{shape:?}"
+                );
+                assert_eq!(actual.facet_id, expected.facet_id, "{shape:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn prepared_procedural_builds_render_constants_once() {
+        let controls = settings(Shape::ImpactGlass);
+        PREPARED_PROCEDURAL_BUILDS.with(|builds| builds.set(0));
+        let prepared = PreparedProcedural::new(controls);
+        for x in 0..16 {
+            let _ = prepared.height(x as f32 * 3.25, 42.0);
+        }
+        PREPARED_PROCEDURAL_BUILDS.with(|builds| assert_eq!(builds.get(), 1));
+
+        PREPARED_PROCEDURAL_BUILDS.with(|builds| builds.set(0));
+        for x in 0..16 {
+            let _ = procedural_height(x as f32 * 3.25, 42.0, controls);
+        }
+        PREPARED_PROCEDURAL_BUILDS.with(|builds| assert_eq!(builds.get(), 16));
     }
 
     #[test]

--- a/plugins/glass-displace/src/glass.rs
+++ b/plugins/glass-displace/src/glass.rs
@@ -1,0 +1,564 @@
+use std::f32::consts::TAU;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum HeightSource {
+    Procedural,
+    CustomMap,
+    InputLuma,
+    InputAlpha,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum Shape {
+    Sphere,
+    RoundedRectangle,
+    Diamond,
+    Ring,
+    Facets,
+    Shards,
+    ImpactGlass,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum MapChannel {
+    Luma,
+    Alpha,
+    Red,
+    Green,
+    Blue,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum Sampling {
+    Nearest,
+    Bilinear,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum EdgeMode {
+    Transparent,
+    Clamp,
+    Tile,
+    Mirror,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum DebugView {
+    Final,
+    Height,
+    Normal,
+    Displacement,
+    FacetId,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ProceduralSettings {
+    pub shape: Shape,
+    pub center: [f32; 2],
+    pub size: f32,
+    pub aspect: f32,
+    pub rotation: f32,
+    pub roundness: f32,
+    pub ring_width: f32,
+    pub facet_size: f32,
+    pub facet_amount: f32,
+    pub facet_jitter: f32,
+    pub crack_width: f32,
+    pub crack_depth: f32,
+    pub radial_cracks: u32,
+    pub crack_branching: f32,
+    pub crack_jitter: f32,
+    pub stress_rings: u32,
+    pub ring_jitter: f32,
+    pub impact_falloff: f32,
+    pub seed: u32,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct HeightSample {
+    pub value: f32,
+    pub facet_id: u32,
+}
+
+pub(crate) fn procedural_height(x: f32, y: f32, settings: ProceduralSettings) -> HeightSample {
+    let half_width = (settings.size * 0.5).max(1.0e-4);
+    let half_height = (half_width / settings.aspect.max(1.0e-4)).max(1.0e-4);
+    let dx = x - settings.center[0];
+    let dy = y - settings.center[1];
+    let cos = settings.rotation.cos();
+    let sin = settings.rotation.sin();
+    let local_x = dx * cos + dy * sin;
+    let local_y = -dx * sin + dy * cos;
+    let nx = local_x / half_width;
+    let ny = local_y / half_height;
+    let radius = nx.hypot(ny);
+
+    match settings.shape {
+        Shape::Sphere => HeightSample {
+            value: (1.0 - radius * radius).max(0.0).sqrt(),
+            facet_id: 0,
+        },
+        Shape::RoundedRectangle => {
+            // A larger UI roundness value should make corners rounder, not
+            // squarer. p=16 approaches a rectangle while p=2 is elliptical.
+            let exponent = 16.0 - settings.roundness.clamp(0.0, 1.0) * 14.0;
+            let distance = (nx.abs().powf(exponent) + ny.abs().powf(exponent)).powf(1.0 / exponent);
+            HeightSample {
+                value: (1.0 - distance).clamp(0.0, 1.0),
+                facet_id: 0,
+            }
+        }
+        Shape::Diamond => HeightSample {
+            value: (1.0 - nx.abs() - ny.abs()).clamp(0.0, 1.0),
+            facet_id: 0,
+        },
+        Shape::Ring => {
+            let half_band = settings.ring_width.clamp(0.01, 1.0) * 0.5;
+            let distance = (radius - 0.65).abs();
+            HeightSample {
+                value: (1.0 - distance / half_band).clamp(0.0, 1.0),
+                facet_id: 0,
+            }
+        }
+        Shape::Facets | Shape::Shards => fracture_field(local_x, local_y, settings),
+        Shape::ImpactGlass => impact_glass(local_x, local_y, settings),
+    }
+}
+
+/// A full-frame tessellated height field shared by the legacy Facets and
+/// Shards popup values. `Size` no longer creates an unrelated circular mask;
+/// Cell Size is the only spatial scale for these two modes. This preserves the
+/// old popup indices while making the two modes a coherent uncracked/cracked
+/// pair.
+fn fracture_field(x: f32, y: f32, settings: ProceduralSettings) -> HeightSample {
+    let cell = voronoi(
+        x,
+        y,
+        settings.facet_size,
+        settings.facet_jitter,
+        settings.seed,
+    );
+    let random_height = 0.2 + hash01(cell.id ^ 0xA511_E9B3) * 0.8;
+    let relief = settings.facet_amount.clamp(0.0, 1.0);
+    let mut height = 1.0 + (random_height - 1.0) * relief;
+    if settings.shape == Shape::Shards && settings.crack_width > 0.0 {
+        let crack = cell_boundary_crack(cell, settings.crack_width);
+        height *= 1.0 - crack * settings.crack_depth.clamp(0.0, 1.0);
+    }
+    HeightSample {
+        value: finite(height).clamp(0.0, 1.0),
+        facet_id: cell.id,
+    }
+}
+
+/// Produces an impact-origin fracture field from three structures seen in
+/// cracked glass: primary radial cracks, shorter branches, and interrupted
+/// concentric stress rings. A Voronoi relief underneath them gives each
+/// resulting region a stable, deterministic optical normal.
+fn impact_glass(x: f32, y: f32, settings: ProceduralSettings) -> HeightSample {
+    let impact_radius = (settings.size * 0.5).max(1.0e-4);
+    // Work in an isotropic impact space. Aspect changes the ellipse in image
+    // space without making crack widths or radial density direction-dependent.
+    let impact_x = x;
+    let impact_y = y * settings.aspect.max(1.0e-4);
+    let radius = impact_x.hypot(impact_y);
+    let normalized_radius = radius / impact_radius;
+    if normalized_radius >= 1.0 {
+        return HeightSample {
+            value: 0.0,
+            facet_id: 0,
+        };
+    }
+
+    let cell = voronoi(
+        impact_x,
+        impact_y,
+        settings.facet_size,
+        settings.facet_jitter,
+        settings.seed,
+    );
+    let random_height = 0.2 + hash01(cell.id ^ 0xA511_E9B3) * 0.8;
+    let relief = settings.facet_amount.clamp(0.0, 1.0);
+    let facet_height = 1.0 + (random_height - 1.0) * relief;
+
+    let edge_falloff = settings.impact_falloff.clamp(0.0, 1.0);
+    let envelope = if edge_falloff <= 1.0e-5 {
+        1.0
+    } else {
+        1.0 - smoothstep(1.0 - edge_falloff, 1.0, normalized_radius)
+    };
+
+    let structural_crack = impact_crack_mask(impact_x, impact_y, impact_radius, settings);
+    // Fine polygon boundaries are strongest near the strike and become only
+    // subtle facet seams toward the edge.
+    let cell_crack = cell_boundary_crack(cell, settings.crack_width * 0.7)
+        * (1.0 - normalized_radius).sqrt()
+        * 0.45;
+    let crack = structural_crack.max(cell_crack).clamp(0.0, 1.0);
+    let height = envelope * facet_height * (1.0 - crack * settings.crack_depth.clamp(0.0, 1.0));
+
+    HeightSample {
+        value: finite(height).clamp(0.0, 1.0),
+        facet_id: cell.id,
+    }
+}
+
+fn impact_crack_mask(x: f32, y: f32, impact_radius: f32, settings: ProceduralSettings) -> f32 {
+    let radius = x.hypot(y);
+    let theta = y.atan2(x);
+    let crack_width = settings.crack_width.max(0.0);
+    if crack_width <= 1.0e-5 {
+        return 0.0;
+    }
+
+    let ray_count = settings.radial_cracks.clamp(3, 96) as f32;
+    let sector = TAU / ray_count;
+    let center_ray = (theta / sector).round() as i32;
+    let normalized_radius = (radius / impact_radius).clamp(0.0, 1.0);
+    let jitter = settings.crack_jitter.clamp(0.0, 1.0);
+    let branching = settings.crack_branching.clamp(0.0, 1.0);
+    let mut mask: f32 = 0.0;
+
+    // Only nearby angular sectors can affect the pixel, which keeps the
+    // procedural field practical even with dozens of radial cracks.
+    for candidate in (center_ray - 2)..=(center_ray + 2) {
+        let ray_id = cell_hash(candidate, 0, settings.seed ^ 0xD816_3841);
+        let base_angle = candidate as f32 * sector
+            + (hash01(ray_id ^ 0xB529_7A4D) - 0.5) * sector * jitter * 0.85;
+        let phase = hash01(ray_id ^ 0x68E3_1DA4) * TAU;
+        let frequency = 1.5 + hash01(ray_id ^ 0x1B56_C4E9) * 3.5;
+        let wobble = (normalized_radius * frequency * TAU + phase).sin()
+            * sector
+            * jitter
+            * 0.11
+            * (0.25 + normalized_radius * 0.75);
+        let ray_angle = base_angle + wobble;
+        let angular_distance = wrap_angle(theta - ray_angle).abs() * radius;
+        let ray_length = impact_radius * (0.58 + hash01(ray_id ^ 0xC2B2_AE35) * 0.42);
+        let length_gate = 1.0
+            - smoothstep(
+                (ray_length - crack_width * 2.0).max(0.0),
+                ray_length + crack_width,
+                radius,
+            );
+        mask = mask.max(crack_profile(angular_distance, crack_width) * length_gate);
+
+        // Two deterministic branch opportunities per primary ray. Branching
+        // controls both how many become active and their reach.
+        for branch_index in 0..2_u32 {
+            let branch_id = ray_id ^ branch_index.wrapping_mul(0x9E37_79B9) ^ 0xA24B_AED4;
+            let threshold = 0.12 + hash01(branch_id ^ 0x91E1_0DA5) * 0.72;
+            let activation = smoothstep(threshold, (threshold + 0.22).min(1.0), branching);
+            if activation <= 0.0 {
+                continue;
+            }
+            let start_radius = impact_radius * (0.18 + hash01(branch_id ^ 0xDB4F_0B91) * 0.48);
+            let start_wobble = (start_radius / impact_radius * frequency * TAU + phase).sin()
+                * sector
+                * jitter
+                * 0.11;
+            let start_angle = base_angle + start_wobble;
+            let start = [
+                start_angle.cos() * start_radius,
+                start_angle.sin() * start_radius,
+            ];
+            let direction_sign = if (branch_id & 1) == 0 { -1.0 } else { 1.0 };
+            let branch_angle = start_angle
+                + direction_sign
+                    * (0.16 + hash01(branch_id ^ 0xBB67_AE85) * 0.48)
+                    * (0.55 + branching * 0.45);
+            let branch_length = impact_radius
+                * (0.08 + hash01(branch_id ^ 0x3C6E_F372) * 0.28)
+                * (0.45 + branching * 0.55);
+            let end = [
+                start[0] + branch_angle.cos() * branch_length,
+                start[1] + branch_angle.sin() * branch_length,
+            ];
+            let distance = point_segment_distance([x, y], start, end);
+            mask = mask.max(crack_profile(distance, crack_width * 0.72) * activation);
+        }
+    }
+
+    let ring_count = settings.stress_rings.min(32);
+    if ring_count > 0 {
+        let spacing = impact_radius / (ring_count + 1) as f32;
+        let ring_jitter = settings.ring_jitter.clamp(0.0, 1.0);
+        for ring in 1..=ring_count {
+            let ring_id = cell_hash(ring as i32, 1, settings.seed ^ 0x243F_6A88);
+            let base_radius = impact_radius * (ring as f32 / (ring_count + 1) as f32).powf(0.82);
+            let offset = (hash01(ring_id ^ 0x85A3_08D3) - 0.5) * spacing * ring_jitter * 0.65;
+            let lobes = 3.0 + (ring_id % 6) as f32;
+            let phase = hash01(ring_id ^ 0x1319_8A2E) * TAU;
+            let wave = (theta * lobes + phase).sin() * spacing * ring_jitter * 0.22;
+            let ring_distance = (radius - base_radius - offset - wave).abs();
+
+            // Break perfect circles into irregular arcs. Adjacent angular
+            // segments share a deterministic on/off value.
+            let arc_count = 7 + (ring_id % 8) as i32;
+            let arc = (((theta + std::f32::consts::PI) / TAU) * arc_count as f32).floor() as i32;
+            let arc_id = cell_hash(arc, ring as i32, settings.seed ^ 0x9E37_79B9);
+            let arc_gate = smoothstep(0.12, 0.38, hash01(arc_id));
+            mask = mask.max(crack_profile(ring_distance, crack_width * 0.72) * arc_gate);
+        }
+    }
+
+    // A small crushed zone anchors all radial cracks at the strike point.
+    let center_radius = impact_radius * (0.012 + 0.025 * jitter);
+    mask.max(1.0 - smoothstep(center_radius * 0.35, center_radius, radius))
+        .clamp(0.0, 1.0)
+}
+
+fn cell_boundary_crack(cell: Voronoi, width: f32) -> f32 {
+    if width <= 1.0e-5 {
+        return 0.0;
+    }
+    let boundary_gap = (cell.second_distance - cell.nearest_distance).max(0.0);
+    1.0 - smoothstep(0.0, width, boundary_gap)
+}
+
+fn crack_profile(distance: f32, width: f32) -> f32 {
+    if width <= 1.0e-5 {
+        return 0.0;
+    }
+    1.0 - smoothstep(width * 0.2, width, distance)
+}
+
+fn point_segment_distance(point: [f32; 2], start: [f32; 2], end: [f32; 2]) -> f32 {
+    let segment = [end[0] - start[0], end[1] - start[1]];
+    let length_squared = segment[0].mul_add(segment[0], segment[1] * segment[1]);
+    if length_squared <= 1.0e-8 {
+        return (point[0] - start[0]).hypot(point[1] - start[1]);
+    }
+    let offset = [point[0] - start[0], point[1] - start[1]];
+    let t = ((offset[0] * segment[0] + offset[1] * segment[1]) / length_squared).clamp(0.0, 1.0);
+    (point[0] - (start[0] + segment[0] * t)).hypot(point[1] - (start[1] + segment[1] * t))
+}
+
+fn wrap_angle(angle: f32) -> f32 {
+    (angle + std::f32::consts::PI).rem_euclid(TAU) - std::f32::consts::PI
+}
+
+pub(crate) fn central_difference<F>(
+    x: f32,
+    y: f32,
+    radius: f32,
+    strength: f32,
+    mut height_at: F,
+) -> [f32; 2]
+where
+    F: FnMut(f32, f32) -> f32,
+{
+    let radius = radius.max(0.25);
+    let dx = (height_at(x + radius, y) - height_at(x - radius, y)) / (2.0 * radius);
+    let dy = (height_at(x, y + radius) - height_at(x, y - radius)) / (2.0 * radius);
+    let nx = -dx * strength;
+    let ny = -dy * strength;
+    [finite(nx), finite(ny)]
+}
+
+pub(crate) fn map_level(value: f32, black: f32, white: f32, invert: bool) -> f32 {
+    let denominator = white - black;
+    let mut normalized = if denominator.abs() <= 1.0e-6 {
+        if value >= white { 1.0 } else { 0.0 }
+    } else {
+        ((value - black) / denominator).clamp(0.0, 1.0)
+    };
+    if invert {
+        normalized = 1.0 - normalized;
+    }
+    finite(normalized).clamp(0.0, 1.0)
+}
+
+pub(crate) fn facet_color(id: u32) -> [f32; 3] {
+    [
+        hash01(id ^ 0x68BC_21EB),
+        hash01(id ^ 0x02E5_BE93),
+        hash01(id ^ 0x967A_889B),
+    ]
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Voronoi {
+    nearest_distance: f32,
+    second_distance: f32,
+    id: u32,
+}
+
+fn voronoi(x: f32, y: f32, cell_size: f32, jitter: f32, seed: u32) -> Voronoi {
+    let cell_size = cell_size.max(1.0);
+    let gx = x / cell_size;
+    let gy = y / cell_size;
+    let base_x = gx.floor() as i32;
+    let base_y = gy.floor() as i32;
+    let mut nearest = f32::INFINITY;
+    let mut second = f32::INFINITY;
+    let mut nearest_id = 0;
+    for oy in -1..=1 {
+        for ox in -1..=1 {
+            let cx = base_x + ox;
+            let cy = base_y + oy;
+            let id = cell_hash(cx, cy, seed);
+            let angle = hash01(id ^ 0x9E37_79B9) * TAU;
+            let distance = hash01(id ^ 0xD1B5_4A35) * 0.5 * jitter.clamp(0.0, 1.0);
+            let feature_x = cx as f32 + 0.5 + angle.cos() * distance;
+            let feature_y = cy as f32 + 0.5 + angle.sin() * distance;
+            let d = (gx - feature_x).hypot(gy - feature_y) * cell_size;
+            if d < nearest {
+                second = nearest;
+                nearest = d;
+                nearest_id = id;
+            } else if d < second {
+                second = d;
+            }
+        }
+    }
+    Voronoi {
+        nearest_distance: nearest,
+        second_distance: second,
+        id: nearest_id,
+    }
+}
+
+fn cell_hash(x: i32, y: i32, seed: u32) -> u32 {
+    let mut value =
+        seed ^ (x as u32).wrapping_mul(0x9E37_79B9) ^ (y as u32).wrapping_mul(0x85EB_CA6B);
+    value ^= value >> 16;
+    value = value.wrapping_mul(0x7FEB_352D);
+    value ^= value >> 15;
+    value = value.wrapping_mul(0x846C_A68B);
+    value ^ (value >> 16)
+}
+
+fn hash01(value: u32) -> f32 {
+    (cell_hash(value as i32, (value >> 16) as i32, 0xC2B2_AE35) as f64 / u32::MAX as f64) as f32
+}
+
+fn smoothstep(edge0: f32, edge1: f32, value: f32) -> f32 {
+    if (edge1 - edge0).abs() <= 1.0e-6 {
+        return if value < edge0 { 0.0 } else { 1.0 };
+    }
+    let t = ((value - edge0) / (edge1 - edge0)).clamp(0.0, 1.0);
+    t * t * (3.0 - 2.0 * t)
+}
+
+fn finite(value: f32) -> f32 {
+    if value.is_finite() { value } else { 0.0 }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn settings(shape: Shape) -> ProceduralSettings {
+        ProceduralSettings {
+            shape,
+            center: [50.0, 50.0],
+            size: 100.0,
+            aspect: 1.0,
+            rotation: 0.0,
+            roundness: 0.5,
+            ring_width: 0.25,
+            facet_size: 12.0,
+            facet_amount: 1.0,
+            facet_jitter: 0.8,
+            crack_width: 2.0,
+            crack_depth: 0.9,
+            radial_cracks: 18,
+            crack_branching: 0.55,
+            crack_jitter: 0.45,
+            stress_rings: 6,
+            ring_jitter: 0.35,
+            impact_falloff: 0.2,
+            seed: 42,
+        }
+    }
+
+    #[test]
+    fn bounded_shapes_are_high_at_center_and_zero_outside() {
+        for shape in [Shape::Sphere, Shape::RoundedRectangle, Shape::Diamond] {
+            let controls = settings(shape);
+            assert!(procedural_height(50.0, 50.0, controls).value > 0.9);
+            assert_eq!(procedural_height(200.0, 50.0, controls).value, 0.0);
+        }
+    }
+
+    #[test]
+    fn ring_peaks_away_from_center() {
+        let controls = settings(Shape::Ring);
+        assert_eq!(procedural_height(50.0, 50.0, controls).value, 0.0);
+        assert!(procedural_height(82.5, 50.0, controls).value > 0.99);
+    }
+
+    #[test]
+    fn flat_height_has_zero_normal() {
+        let normal = central_difference(10.0, 20.0, 1.0, 100.0, |_, _| 0.5);
+        assert_eq!(normal, [0.0, 0.0]);
+    }
+
+    #[test]
+    fn central_difference_detects_ramp_direction() {
+        let normal = central_difference(0.0, 0.0, 1.0, 2.0, |x, y| x + y * 2.0);
+        assert!((normal[0] + 2.0).abs() < 1.0e-6);
+        assert!((normal[1] + 4.0).abs() < 1.0e-6);
+    }
+
+    #[test]
+    fn voronoi_is_deterministic() {
+        let controls = settings(Shape::Facets);
+        let first = procedural_height(40.25, 60.75, controls);
+        let second = procedural_height(40.25, 60.75, controls);
+        assert_eq!(first.value.to_bits(), second.value.to_bits());
+        assert_eq!(first.facet_id, second.facet_id);
+    }
+
+    #[test]
+    fn facets_follow_the_procedural_center() {
+        let controls = settings(Shape::Facets);
+        let first = procedural_height(40.25, 60.75, controls);
+        let mut moved = controls;
+        moved.center = [70.0, 80.0];
+        let second = procedural_height(60.25, 90.75, moved);
+        assert_eq!(first.value.to_bits(), second.value.to_bits());
+        assert_eq!(first.facet_id, second.facet_id);
+    }
+
+    #[test]
+    fn facet_field_is_not_clipped_by_the_size_circle() {
+        let controls = settings(Shape::Facets);
+        let far_away = procedural_height(5_000.0, -3_000.0, controls);
+        assert!(far_away.value > 0.0);
+        assert_ne!(far_away.facet_id, 0);
+    }
+
+    #[test]
+    fn impact_glass_is_bounded_and_deterministic() {
+        let controls = settings(Shape::ImpactGlass);
+        let first = procedural_height(72.0, 61.0, controls);
+        let second = procedural_height(72.0, 61.0, controls);
+        assert_eq!(first.value.to_bits(), second.value.to_bits());
+        assert_eq!(first.facet_id, second.facet_id);
+        assert_ne!(first.facet_id, 0);
+        assert_eq!(procedural_height(200.0, 50.0, controls).value, 0.0);
+    }
+
+    #[test]
+    fn impact_cracks_start_at_the_strike_point() {
+        let controls = settings(Shape::ImpactGlass);
+        let center = procedural_height(50.0, 50.0, controls);
+        assert!(center.value < 0.2);
+    }
+
+    #[test]
+    fn map_levels_support_inversion_and_reversed_range() {
+        assert!((map_level(0.5, 0.0, 1.0, false) - 0.5).abs() < 1.0e-6);
+        assert!((map_level(0.25, 0.0, 1.0, true) - 0.75).abs() < 1.0e-6);
+        assert!((map_level(0.25, 1.0, 0.0, false) - 0.75).abs() < 1.0e-6);
+    }
+
+    #[test]
+    fn facet_debug_color_is_stable_and_bounded() {
+        let color = facet_color(1234);
+        assert!(color.iter().all(|value| (0.0..=1.0).contains(value)));
+        assert_eq!(color, facet_color(1234));
+    }
+}

--- a/plugins/glass-displace/src/lib.rs
+++ b/plugins/glass-displace/src/lib.rs
@@ -1,0 +1,6 @@
+#![allow(clippy::drop_non_drop, clippy::question_mark)]
+
+mod glass;
+mod params;
+mod plugin;
+mod render;

--- a/plugins/glass-displace/src/params.rs
+++ b/plugins/glass-displace/src/params.rs
@@ -1,0 +1,524 @@
+use ae::Error;
+use ae::pf::*;
+use after_effects as ae;
+
+#[derive(Eq, PartialEq, Hash, Clone, Copy, Debug)]
+pub(crate) enum Params {
+    HeightStart,
+    HeightSource,
+    Shape,
+    MapLayer,
+    MapChannel,
+    InvertMap,
+    MapBlack,
+    MapWhite,
+    HeightEnd,
+    GeometryStart,
+    Center,
+    Size,
+    Aspect,
+    Rotation,
+    Roundness,
+    RingWidth,
+    FacetSize,
+    FacetAmount,
+    FacetJitter,
+    CrackWidth,
+    Seed,
+    GeometryEnd,
+    RefractionStart,
+    HeightStrength,
+    NormalRadius,
+    Refraction,
+    Dispersion,
+    Sampling,
+    Edge,
+    RefractionEnd,
+    OutputStart,
+    Mix,
+    PreserveAlpha,
+    Debug,
+    Clamp32,
+    OutputEnd,
+    // New controls are intentionally appended after every v0.1 parameter.
+    // AE persists effects by parameter index, so inserting them above would
+    // reinterpret existing projects.
+    FractureStart,
+    CrackDepth,
+    RadialCracks,
+    CrackBranching,
+    CrackJitter,
+    StressRings,
+    RingJitter,
+    ImpactFalloff,
+    FractureEnd,
+    SpectralStart,
+    DispersionSteps,
+    // Appended after the v0.2 spectral step control to preserve its index.
+    AutoSpectralSteps,
+    SpectralEnd,
+}
+
+pub(crate) fn setup(params: &mut ae::Parameters<Params>) -> Result<(), Error> {
+    params.add_group(
+        Params::HeightStart,
+        Params::HeightEnd,
+        "Height Map",
+        false,
+        |params| {
+            params.add_with_flags(
+                Params::HeightSource,
+                "Height Source",
+                PopupDef::setup(|d| {
+                    d.set_options(&["Procedural", "Custom Map", "Input Luma", "Input Alpha"]);
+                    d.set_default(1);
+                }),
+                ae::ParamFlag::SUPERVISE,
+                ae::ParamUIFlags::empty(),
+            )?;
+            params.add_with_flags(
+                Params::Shape,
+                "Shape",
+                PopupDef::setup(|d| {
+                    d.set_options(&[
+                        "Sphere",
+                        "Rounded Rectangle",
+                        "Diamond",
+                        "Ring",
+                        "Facet Field",
+                        "Fractured Field",
+                        "Impact Glass",
+                    ]);
+                    d.set_default(1);
+                }),
+                ae::ParamFlag::SUPERVISE,
+                ae::ParamUIFlags::empty(),
+            )?;
+            params.add_with_flags(
+                Params::MapLayer,
+                "Custom Map Layer",
+                LayerDef::new(),
+                ae::ParamFlag::empty(),
+                ae::ParamUIFlags::INVISIBLE,
+            )?;
+            params.add_with_flags(
+                Params::MapChannel,
+                "Map Channel",
+                PopupDef::setup(|d| {
+                    d.set_options(&["Luma", "Alpha", "Red", "Green", "Blue"]);
+                    d.set_default(1);
+                }),
+                ae::ParamFlag::empty(),
+                ae::ParamUIFlags::INVISIBLE,
+            )?;
+            params.add_with_flags(
+                Params::InvertMap,
+                "Invert Map",
+                CheckBoxDef::setup(|d| {
+                    d.set_default(false);
+                }),
+                ae::ParamFlag::empty(),
+                ae::ParamUIFlags::INVISIBLE,
+            )?;
+            for (id, name, default) in [
+                (Params::MapBlack, "Map Black", 0.0),
+                (Params::MapWhite, "Map White", 1.0),
+            ] {
+                params.add_with_flags(
+                    id,
+                    name,
+                    FloatSliderDef::setup(|d| {
+                        d.set_valid_min(-16.0);
+                        d.set_valid_max(16.0);
+                        d.set_slider_min(0.0);
+                        d.set_slider_max(1.0);
+                        d.set_default(default);
+                        d.set_precision(3);
+                    }),
+                    ae::ParamFlag::empty(),
+                    ae::ParamUIFlags::INVISIBLE,
+                )?;
+            }
+            Ok(())
+        },
+    )?;
+
+    params.add_group(
+        Params::GeometryStart,
+        Params::GeometryEnd,
+        "Procedural Geometry",
+        false,
+        |params| {
+            params.add(
+                Params::Center,
+                "Center",
+                PointDef::setup(|d| {
+                    d.set_default((50.0, 50.0));
+                }),
+            )?;
+            params.add(
+                Params::Size,
+                "Size / Impact Diameter (px)",
+                FloatSliderDef::setup(|d| {
+                    d.set_valid_min(0.01);
+                    d.set_valid_max(32768.0);
+                    d.set_slider_min(1.0);
+                    d.set_slider_max(2048.0);
+                    d.set_default(500.0);
+                    d.set_precision(2);
+                }),
+            )?;
+            params.add(
+                Params::Aspect,
+                "Aspect",
+                FloatSliderDef::setup(|d| {
+                    d.set_valid_min(0.01);
+                    d.set_valid_max(100.0);
+                    d.set_slider_min(0.1);
+                    d.set_slider_max(10.0);
+                    d.set_default(1.0);
+                    d.set_precision(3);
+                }),
+            )?;
+            params.add(
+                Params::Rotation,
+                "Rotation",
+                AngleDef::setup(|d| {
+                    d.set_default(0.0);
+                }),
+            )?;
+            params.add_with_flags(
+                Params::Roundness,
+                "Corner Roundness (%)",
+                FloatSliderDef::setup(|d| {
+                    d.set_valid_min(0.0);
+                    d.set_valid_max(100.0);
+                    d.set_slider_min(0.0);
+                    d.set_slider_max(100.0);
+                    d.set_default(50.0);
+                    d.set_precision(1);
+                }),
+                ae::ParamFlag::empty(),
+                ae::ParamUIFlags::INVISIBLE,
+            )?;
+            params.add_with_flags(
+                Params::RingWidth,
+                "Ring Width (%)",
+                FloatSliderDef::setup(|d| {
+                    d.set_valid_min(1.0);
+                    d.set_valid_max(100.0);
+                    d.set_slider_min(1.0);
+                    d.set_slider_max(100.0);
+                    d.set_default(25.0);
+                    d.set_precision(1);
+                }),
+                ae::ParamFlag::empty(),
+                ae::ParamUIFlags::INVISIBLE,
+            )?;
+            params.add_with_flags(
+                Params::FacetSize,
+                "Cell Size (px)",
+                FloatSliderDef::setup(|d| {
+                    d.set_valid_min(1.0);
+                    d.set_valid_max(4096.0);
+                    d.set_slider_min(2.0);
+                    d.set_slider_max(256.0);
+                    d.set_default(48.0);
+                    d.set_precision(1);
+                }),
+                ae::ParamFlag::empty(),
+                ae::ParamUIFlags::INVISIBLE,
+            )?;
+            for (id, name, default) in [
+                (Params::FacetAmount, "Facet Relief (%)", 100.0),
+                (Params::FacetJitter, "Cell Irregularity (%)", 75.0),
+            ] {
+                params.add_with_flags(
+                    id,
+                    name,
+                    FloatSliderDef::setup(|d| {
+                        d.set_valid_min(0.0);
+                        d.set_valid_max(100.0);
+                        d.set_slider_min(0.0);
+                        d.set_slider_max(100.0);
+                        d.set_default(default);
+                        d.set_precision(1);
+                    }),
+                    ae::ParamFlag::empty(),
+                    ae::ParamUIFlags::INVISIBLE,
+                )?;
+            }
+            params.add_with_flags(
+                Params::CrackWidth,
+                "Crack Width (px)",
+                FloatSliderDef::setup(|d| {
+                    d.set_valid_min(0.0);
+                    d.set_valid_max(512.0);
+                    d.set_slider_min(0.0);
+                    d.set_slider_max(32.0);
+                    d.set_default(2.0);
+                    d.set_precision(2);
+                }),
+                ae::ParamFlag::empty(),
+                ae::ParamUIFlags::INVISIBLE,
+            )?;
+            params.add_with_flags(
+                Params::Seed,
+                "Seed",
+                FloatSliderDef::setup(|d| {
+                    d.set_valid_min(0.0);
+                    d.set_valid_max(16_777_215.0);
+                    d.set_slider_min(0.0);
+                    d.set_slider_max(10000.0);
+                    d.set_default(1.0);
+                    d.set_precision(0);
+                }),
+                ae::ParamFlag::empty(),
+                ae::ParamUIFlags::INVISIBLE,
+            )?;
+            Ok(())
+        },
+    )?;
+
+    params.add_group(
+        Params::RefractionStart,
+        Params::RefractionEnd,
+        "Refraction",
+        false,
+        |params| {
+            params.add(
+                Params::HeightStrength,
+                "Normal Strength",
+                FloatSliderDef::setup(|d| {
+                    d.set_valid_min(-1000.0);
+                    d.set_valid_max(1000.0);
+                    d.set_slider_min(-250.0);
+                    d.set_slider_max(250.0);
+                    d.set_default(100.0);
+                    d.set_precision(2);
+                }),
+            )?;
+            params.add(
+                Params::NormalRadius,
+                "Normal Radius (px)",
+                FloatSliderDef::setup(|d| {
+                    d.set_valid_min(0.25);
+                    d.set_valid_max(512.0);
+                    d.set_slider_min(0.25);
+                    d.set_slider_max(32.0);
+                    d.set_default(1.0);
+                    d.set_precision(2);
+                }),
+            )?;
+            params.add(
+                Params::Refraction,
+                "Refraction (px)",
+                FloatSliderDef::setup(|d| {
+                    d.set_valid_min(-32768.0);
+                    d.set_valid_max(32768.0);
+                    d.set_slider_min(-256.0);
+                    d.set_slider_max(256.0);
+                    d.set_default(40.0);
+                    d.set_precision(2);
+                }),
+            )?;
+            params.add_with_flags(
+                Params::Dispersion,
+                "Chromatic Dispersion (px)",
+                FloatSliderDef::setup(|d| {
+                    d.set_valid_min(-4096.0);
+                    d.set_valid_max(4096.0);
+                    d.set_slider_min(-64.0);
+                    d.set_slider_max(64.0);
+                    d.set_default(2.0);
+                    d.set_precision(2);
+                }),
+                ae::ParamFlag::SUPERVISE,
+                ae::ParamUIFlags::empty(),
+            )?;
+            params.add(
+                Params::Sampling,
+                "Sampling",
+                PopupDef::setup(|d| {
+                    d.set_options(&["Nearest", "Bilinear"]);
+                    d.set_default(2);
+                }),
+            )?;
+            params.add(
+                Params::Edge,
+                "Edge",
+                PopupDef::setup(|d| {
+                    d.set_options(&["Transparent", "Clamp", "Tile", "Mirror"]);
+                    d.set_default(2);
+                }),
+            )?;
+            Ok(())
+        },
+    )?;
+
+    params.add_group(
+        Params::OutputStart,
+        Params::OutputEnd,
+        "Output",
+        false,
+        |params| {
+            params.add(
+                Params::Mix,
+                "Mix (%)",
+                FloatSliderDef::setup(|d| {
+                    d.set_valid_min(0.0);
+                    d.set_valid_max(100.0);
+                    d.set_slider_min(0.0);
+                    d.set_slider_max(100.0);
+                    d.set_default(100.0);
+                    d.set_precision(1);
+                }),
+            )?;
+            params.add(
+                Params::PreserveAlpha,
+                "Preserve Input Alpha",
+                CheckBoxDef::setup(|d| {
+                    d.set_default(true);
+                }),
+            )?;
+            params.add(
+                Params::Debug,
+                "View",
+                PopupDef::setup(|d| {
+                    d.set_options(&["Final", "Height", "Normal", "Displacement", "Facet ID"]);
+                    d.set_default(1);
+                }),
+            )?;
+            params.add(
+                Params::Clamp32,
+                "Clamp (32bpc)",
+                CheckBoxDef::setup(|d| {
+                    d.set_default(false);
+                }),
+            )?;
+            Ok(())
+        },
+    )?;
+
+    // Appended groups keep all legacy parameter indices stable. Their
+    // controls are hidden dynamically unless the selected fracture mode uses
+    // them.
+    params.add_group(
+        Params::FractureStart,
+        Params::FractureEnd,
+        "Fracture Detail",
+        true,
+        |params| {
+            params.add_with_flags(
+                Params::CrackDepth,
+                "Crack Depth (%)",
+                FloatSliderDef::setup(|d| {
+                    d.set_valid_min(0.0);
+                    d.set_valid_max(100.0);
+                    d.set_slider_min(0.0);
+                    d.set_slider_max(100.0);
+                    d.set_default(90.0);
+                    d.set_precision(1);
+                }),
+                ae::ParamFlag::empty(),
+                ae::ParamUIFlags::INVISIBLE,
+            )?;
+            params.add_with_flags(
+                Params::RadialCracks,
+                "Radial Cracks",
+                SliderDef::setup(|d| {
+                    d.set_valid_min(3);
+                    d.set_valid_max(96);
+                    d.set_slider_min(3);
+                    d.set_slider_max(48);
+                    d.set_default(18);
+                }),
+                ae::ParamFlag::empty(),
+                ae::ParamUIFlags::INVISIBLE,
+            )?;
+            for (id, name, default) in [
+                (Params::CrackBranching, "Branching (%)", 55.0),
+                (Params::CrackJitter, "Crack Jitter (%)", 45.0),
+            ] {
+                params.add_with_flags(
+                    id,
+                    name,
+                    FloatSliderDef::setup(|d| {
+                        d.set_valid_min(0.0);
+                        d.set_valid_max(100.0);
+                        d.set_slider_min(0.0);
+                        d.set_slider_max(100.0);
+                        d.set_default(default);
+                        d.set_precision(1);
+                    }),
+                    ae::ParamFlag::empty(),
+                    ae::ParamUIFlags::INVISIBLE,
+                )?;
+            }
+            params.add_with_flags(
+                Params::StressRings,
+                "Stress Rings",
+                SliderDef::setup(|d| {
+                    d.set_valid_min(0);
+                    d.set_valid_max(32);
+                    d.set_slider_min(0);
+                    d.set_slider_max(16);
+                    d.set_default(6);
+                }),
+                ae::ParamFlag::empty(),
+                ae::ParamUIFlags::INVISIBLE,
+            )?;
+            for (id, name, default) in [
+                (Params::RingJitter, "Ring Irregularity (%)", 35.0),
+                (Params::ImpactFalloff, "Impact Edge Falloff (%)", 20.0),
+            ] {
+                params.add_with_flags(
+                    id,
+                    name,
+                    FloatSliderDef::setup(|d| {
+                        d.set_valid_min(0.0);
+                        d.set_valid_max(100.0);
+                        d.set_slider_min(0.0);
+                        d.set_slider_max(100.0);
+                        d.set_default(default);
+                        d.set_precision(1);
+                    }),
+                    ae::ParamFlag::empty(),
+                    ae::ParamUIFlags::INVISIBLE,
+                )?;
+            }
+            Ok(())
+        },
+    )?;
+
+    params.add_group(
+        Params::SpectralStart,
+        Params::SpectralEnd,
+        "Spectral Dispersion",
+        true,
+        |params| {
+            params.add(
+                Params::DispersionSteps,
+                "Spectral Steps (Manual)",
+                SliderDef::setup(|d| {
+                    d.set_valid_min(3);
+                    d.set_valid_max(32);
+                    d.set_slider_min(3);
+                    d.set_slider_max(16);
+                    d.set_default(8);
+                }),
+            )?;
+            params.add_with_flags(
+                Params::AutoSpectralSteps,
+                "Auto Spectral Steps",
+                CheckBoxDef::setup(|d| {
+                    d.set_default(true);
+                }),
+                ae::ParamFlag::SUPERVISE,
+                ae::ParamUIFlags::empty(),
+            )?;
+            Ok(())
+        },
+    )?;
+    Ok(())
+}

--- a/plugins/glass-displace/src/plugin.rs
+++ b/plugins/glass-displace/src/plugin.rs
@@ -1,0 +1,366 @@
+use after_effects as ae;
+use std::env;
+
+use ae::pf::*;
+
+use crate::glass::{HeightSource, Shape};
+use crate::params::Params;
+use crate::render::{
+    OwnedMaps, RenderLayout, read_layer_buffer, read_layer_buffer_with_rect, read_settings, render,
+    shape,
+};
+
+const SMART_INPUT_ID: u32 = 0;
+const SMART_MAP_ID: u32 = 1;
+const SMART_QUERY_ID_BASE: i32 = 100;
+
+#[derive(Clone, Copy)]
+struct SmartLayout {
+    input_rect: ae::Rect,
+    output_rect: ae::Rect,
+    map_rect: Option<ae::Rect>,
+}
+
+#[derive(Default)]
+struct Plugin {
+    aegp_id: Option<ae::aegp::PluginId>,
+}
+
+ae::define_effect!(Plugin, (), Params);
+
+const PLUGIN_DESCRIPTION: &str =
+    "Applies map-driven glass refraction with parametric fractures and spectral dispersion.";
+
+impl AdobePluginGlobal for Plugin {
+    fn params_setup(
+        &self,
+        params: &mut ae::Parameters<Params>,
+        _in_data: InData,
+        _: OutData,
+    ) -> Result<(), Error> {
+        crate::params::setup(params)
+    }
+
+    fn handle_command(
+        &mut self,
+        cmd: ae::Command,
+        in_data: InData,
+        mut out_data: OutData,
+        params: &mut ae::Parameters<Params>,
+    ) -> Result<(), ae::Error> {
+        match cmd {
+            ae::Command::About => {
+                out_data.set_return_msg(
+                    format!(
+                        "AOD_GlassDisplace - {version}\r\r{PLUGIN_DESCRIPTION}\rCopyright (c) 2026-{build_year} Aodaruma",
+                        version = env!("CARGO_PKG_VERSION"),
+                        build_year = env!("BUILD_YEAR")
+                    )
+                    .as_str(),
+                );
+            }
+            ae::Command::GlobalSetup => {
+                out_data.set_out_flag(OutFlags::DeepColorAware, true);
+                out_data.set_out_flag(OutFlags::SendUpdateParamsUi, true);
+                out_data.set_out_flag2(OutFlags2::FloatColorAware, true);
+                out_data.set_out_flag2(OutFlags2::SupportsSmartRender, true);
+                out_data.set_out_flag2(OutFlags2::RevealsZeroAlpha, true);
+                out_data.set_out_flag2(OutFlags2::ParamGroupStartCollapsedFlag, true);
+                if let Ok(suite) = ae::aegp::suites::Utility::new()
+                    && let Ok(plugin_id) = suite.register_with_aegp("AOD_GlassDisplace")
+                {
+                    self.aegp_id = Some(plugin_id);
+                }
+            }
+            ae::Command::Render {
+                in_layer,
+                out_layer,
+            } => {
+                let settings = read_settings(params, in_data)?;
+                let custom = if settings.height_source == HeightSource::CustomMap {
+                    let param = params.get(Params::MapLayer)?;
+                    let layer = param.as_layer()?.value();
+                    layer.as_ref().map(read_layer_buffer)
+                } else {
+                    None
+                };
+                render(
+                    in_data,
+                    in_layer,
+                    out_layer,
+                    settings,
+                    OwnedMaps { custom },
+                    RenderLayout::default(),
+                )?;
+            }
+            ae::Command::SmartPreRender { mut extra } => {
+                let request = extra.output_request();
+                let settings = read_settings(params, in_data)?;
+                let callbacks = extra.callbacks();
+                let input = checkout_full_smart_layer(
+                    callbacks,
+                    0,
+                    SMART_QUERY_ID_BASE + SMART_INPUT_ID as i32,
+                    SMART_INPUT_ID,
+                    &request,
+                    in_data,
+                )?;
+                let full_rect: ae::Rect = input.max_result_rect.into();
+                let _ = extra.union_result_rect(full_rect);
+                let _ = extra.union_max_result_rect(full_rect);
+                extra.set_returns_extra_pixels(true);
+
+                let mut map_rect = None;
+                if settings.height_source == HeightSource::CustomMap {
+                    let index = params
+                        .index(Params::MapLayer)
+                        .ok_or(Error::BadCallbackParameter)?;
+                    let map = checkout_full_smart_layer(
+                        callbacks,
+                        index as i32,
+                        SMART_QUERY_ID_BASE + SMART_MAP_ID as i32,
+                        SMART_MAP_ID,
+                        &request,
+                        in_data,
+                    )?;
+                    map_rect = Some(map.max_result_rect.into());
+                }
+                extra.set_pre_render_data(SmartLayout {
+                    input_rect: full_rect,
+                    output_rect: full_rect,
+                    map_rect,
+                });
+            }
+            ae::Command::SmartRender { extra } => {
+                let callbacks = extra.callbacks();
+                let settings = read_settings(params, in_data)?;
+                let layout = extra.pre_render_data::<SmartLayout>().copied();
+                let custom = if settings.height_source == HeightSource::CustomMap {
+                    let layer = callbacks.checkout_layer_pixels(SMART_MAP_ID)?;
+                    let buffer = layer.as_ref().map(|layer| {
+                        read_layer_buffer_with_rect(layer, layout.and_then(|value| value.map_rect))
+                    });
+                    callbacks.checkin_layer_pixels(SMART_MAP_ID)?;
+                    buffer
+                } else {
+                    None
+                };
+
+                let input = callbacks.checkout_layer_pixels(SMART_INPUT_ID)?;
+                let render_result: Result<(), Error> = (|| {
+                    let output = callbacks.checkout_output()?;
+                    if let (Some(input), Some(output)) = (input, output) {
+                        render(
+                            in_data,
+                            input,
+                            output,
+                            settings,
+                            OwnedMaps { custom },
+                            RenderLayout {
+                                input_rect: layout.map(|value| value.input_rect),
+                                output_rect: layout.map(|value| value.output_rect),
+                            },
+                        )?;
+                    }
+                    Ok(())
+                })();
+                let checkin_result = callbacks.checkin_layer_pixels(SMART_INPUT_ID);
+                render_result?;
+                checkin_result?;
+            }
+            ae::Command::UserChangedParam { param_index }
+                if matches!(
+                    params.type_at(param_index),
+                    Params::HeightSource
+                        | Params::Shape
+                        | Params::Dispersion
+                        | Params::AutoSpectralSteps
+                ) =>
+            {
+                out_data.set_out_flag(OutFlags::RefreshUi, true);
+            }
+            ae::Command::UpdateParamsUi => {
+                let mut copy = params.cloned();
+                self.update_params_ui(in_data, &mut copy)?;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+}
+
+impl Plugin {
+    fn update_params_ui(
+        &self,
+        in_data: InData,
+        params: &mut Parameters<Params>,
+    ) -> Result<(), Error> {
+        let source_value = params.get(Params::HeightSource)?.as_popup()?.value();
+        let source = match source_value {
+            2 => HeightSource::CustomMap,
+            3 => HeightSource::InputLuma,
+            4 => HeightSource::InputAlpha,
+            _ => HeightSource::Procedural,
+        };
+        let shape = shape(params.get(Params::Shape)?.as_popup()?.value());
+        let procedural = source == HeightSource::Procedural;
+        let custom_map = source == HeightSource::CustomMap;
+        let mapped = source != HeightSource::Procedural;
+
+        self.toggle(in_data, params, Params::Shape, procedural)?;
+        for id in [Params::MapLayer, Params::MapChannel] {
+            self.toggle(in_data, params, id, custom_map)?;
+        }
+        for id in [Params::InvertMap, Params::MapBlack, Params::MapWhite] {
+            self.toggle(in_data, params, id, mapped)?;
+        }
+        for id in [Params::Center, Params::Rotation] {
+            self.toggle(in_data, params, id, procedural)?;
+        }
+        let bounded = procedural && !matches!(shape, Shape::Facets | Shape::Shards);
+        for id in [Params::Size, Params::Aspect] {
+            self.toggle(in_data, params, id, bounded)?;
+        }
+        self.toggle(
+            in_data,
+            params,
+            Params::Roundness,
+            procedural && shape == Shape::RoundedRectangle,
+        )?;
+        self.toggle(
+            in_data,
+            params,
+            Params::RingWidth,
+            procedural && shape == Shape::Ring,
+        )?;
+        let facets =
+            procedural && matches!(shape, Shape::Facets | Shape::Shards | Shape::ImpactGlass);
+        for id in [
+            Params::FacetSize,
+            Params::FacetAmount,
+            Params::FacetJitter,
+            Params::Seed,
+        ] {
+            self.toggle(in_data, params, id, facets)?;
+        }
+        self.toggle(
+            in_data,
+            params,
+            Params::CrackWidth,
+            procedural && matches!(shape, Shape::Shards | Shape::ImpactGlass),
+        )?;
+        let cracked = procedural && matches!(shape, Shape::Shards | Shape::ImpactGlass);
+        self.toggle(in_data, params, Params::CrackDepth, cracked)?;
+        let impact = procedural && shape == Shape::ImpactGlass;
+        for id in [
+            Params::RadialCracks,
+            Params::CrackBranching,
+            Params::CrackJitter,
+            Params::StressRings,
+            Params::RingJitter,
+            Params::ImpactFalloff,
+        ] {
+            self.toggle(in_data, params, id, impact)?;
+        }
+        let dispersion = params.get(Params::Dispersion)?.as_float_slider()?.value();
+        let spectral_active = dispersion.abs() > 1.0e-6;
+        let automatic_steps = params
+            .get(Params::AutoSpectralSteps)?
+            .as_checkbox()?
+            .value();
+        self.toggle(in_data, params, Params::AutoSpectralSteps, spectral_active)?;
+        // Keep the manual value visible while Auto Spectral Steps is active,
+        // but gray it out so the active source of the step count is explicit.
+        // This is separate from `toggle`: repeatedly enabling and disabling
+        // the same control in one UI update causes unnecessary host redraws.
+        self.set_param_visible(in_data, params, Params::DispersionSteps, spectral_active)?;
+        Self::set_param_ui_flag(
+            params,
+            Params::DispersionSteps,
+            ParamUIFlags::DISABLED,
+            !spectral_active || automatic_steps,
+        )?;
+        Ok(())
+    }
+
+    fn toggle(
+        &self,
+        in_data: InData,
+        params: &mut Parameters<Params>,
+        id: Params,
+        visible: bool,
+    ) -> Result<(), Error> {
+        self.set_param_visible(in_data, params, id, visible)?;
+        Self::set_param_ui_flag(params, id, ParamUIFlags::DISABLED, !visible)
+    }
+
+    fn set_param_visible(
+        &self,
+        in_data: InData,
+        params: &mut Parameters<Params>,
+        id: Params,
+        visible: bool,
+    ) -> Result<(), Error> {
+        if in_data.is_premiere() {
+            return Self::set_param_ui_flag(params, id, ParamUIFlags::INVISIBLE, !visible);
+        }
+        if let Some(plugin_id) = self.aegp_id {
+            let effect = in_data.effect();
+            if let Some(index) = params.index(id)
+                && let Ok(effect_ref) = effect.aegp_effect(plugin_id)
+                && let Ok(stream) = effect_ref.new_stream_by_index(plugin_id, index as i32)
+            {
+                return stream.set_dynamic_stream_flag(
+                    ae::aegp::DynamicStreamFlags::Hidden,
+                    false,
+                    !visible,
+                );
+            }
+        }
+        Self::set_param_ui_flag(params, id, ParamUIFlags::INVISIBLE, !visible)
+    }
+
+    fn set_param_ui_flag(
+        params: &mut Parameters<Params>,
+        id: Params,
+        flag: ParamUIFlags,
+        status: bool,
+    ) -> Result<(), Error> {
+        let current = (params.get(id)?.ui_flags().bits() & flag.bits()) != 0;
+        if current == status {
+            return Ok(());
+        }
+        let mut param = params.get_mut(id)?;
+        param.set_ui_flag(flag, status);
+        param.update_param_ui()?;
+        Ok(())
+    }
+}
+
+fn checkout_full_smart_layer(
+    callbacks: PreRenderCallbacks,
+    param_index: i32,
+    query_id: i32,
+    checkout_id: u32,
+    request: &ae::sys::PF_RenderRequest,
+    in_data: InData,
+) -> Result<ae::sys::PF_CheckoutResult, Error> {
+    let query = callbacks.checkout_layer(
+        param_index,
+        query_id,
+        request,
+        in_data.current_time(),
+        in_data.time_step(),
+        in_data.time_scale(),
+    )?;
+    let mut full_request = *request;
+    full_request.rect = query.max_result_rect;
+    callbacks.checkout_layer(
+        param_index,
+        checkout_id as i32,
+        &full_request,
+        in_data.current_time(),
+        in_data.time_step(),
+        in_data.time_scale(),
+    )
+}

--- a/plugins/glass-displace/src/render.rs
+++ b/plugins/glass-displace/src/render.rs
@@ -1,0 +1,1057 @@
+use after_effects as ae;
+
+use ae::Error;
+use ae::pf::*;
+use utils::ToPixel;
+use utils::image::{
+    SampleEdge, finite_or, luma, read_layer, sample_bilinear, sample_nearest, sanitize_pixel,
+    unpremultiplied_rgb,
+};
+
+use crate::glass::{
+    DebugView, EdgeMode, HeightSample, HeightSource, MapChannel, ProceduralSettings, Sampling,
+    Shape, central_difference, facet_color, map_level, procedural_height,
+};
+use crate::params::Params;
+
+const SPECTRUM_MIN_NM: f32 = 380.0;
+const SPECTRUM_MAX_NM: f32 = 780.0;
+// The Fraunhofer d line is the standard reference wavelength for optical
+// glass. BK7's refractive index is approximately 1.5168 at this wavelength.
+const REFERENCE_WAVELENGTH_NM: f32 = 587.56;
+const DISPERSION_REFERENCE_WAVELENGTH_NM: f32 = SPECTRUM_MIN_NM;
+
+#[derive(Clone)]
+pub(crate) struct LayerBuffer {
+    pixels: Vec<PixelF32>,
+    width: usize,
+    height: usize,
+    origin: [f32; 2],
+}
+
+pub(crate) struct OwnedMaps {
+    pub custom: Option<LayerBuffer>,
+}
+
+#[derive(Clone, Copy, Default)]
+pub(crate) struct RenderLayout {
+    pub input_rect: Option<ae::Rect>,
+    pub output_rect: Option<ae::Rect>,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct Settings {
+    pub height_source: HeightSource,
+    map_channel: MapChannel,
+    invert_map: bool,
+    map_black: f32,
+    map_white: f32,
+    procedural: ProceduralSettings,
+    height_strength: f32,
+    normal_radius: f32,
+    refraction: f32,
+    dispersion: f32,
+    dispersion_steps: usize,
+    auto_spectral_steps: bool,
+    sampling: Sampling,
+    edge: EdgeMode,
+    mix: f32,
+    preserve_alpha: bool,
+    debug: DebugView,
+    clamp_32: bool,
+    downsample: [f32; 2],
+}
+
+#[derive(Clone, Copy, Debug)]
+struct OpticalCalibration {
+    reference_index: f32,
+    projection_scale: f32,
+    dispersion_scale: f32,
+}
+
+impl OpticalCalibration {
+    fn bk7() -> Self {
+        let reference_index = bk7_refractive_index(REFERENCE_WAVELENGTH_NM);
+        // Refraction is calibrated so its UI value is the displacement in
+        // pixels for a 45-degree height-field slope. The render still uses the
+        // full nonlinear Snell solution at every actual surface orientation.
+        let calibration_normal = surface_normal([1.0, 0.0]);
+        let reference_ray = refracted_screen_slope(calibration_normal, reference_index);
+        let blue_ray = refracted_screen_slope(
+            calibration_normal,
+            bk7_refractive_index(DISPERSION_REFERENCE_WAVELENGTH_NM),
+        );
+        Self {
+            reference_index,
+            projection_scale: 1.0 / length2(reference_ray).max(1.0e-6),
+            // Chromatic Dispersion retains pixel units: at the calibration
+            // slope, its value is the d-line-to-380 nm separation.
+            dispersion_scale: 1.0 / length2(sub2(blue_ray, reference_ray)).max(1.0e-6),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct SpectralBand {
+    refractive_index: f32,
+    rgb_response: [f32; 3],
+    luminance_response: f32,
+}
+
+impl LayerBuffer {
+    fn sample(&self, x: f32, y: f32, sampling: Sampling, edge: EdgeMode) -> PixelF32 {
+        let edge = sample_edge(edge);
+        let x = x - self.origin[0];
+        let y = y - self.origin[1];
+        match sampling {
+            Sampling::Nearest => sample_nearest(&self.pixels, self.width, self.height, x, y, edge),
+            Sampling::Bilinear => {
+                sample_bilinear(&self.pixels, self.width, self.height, x, y, edge)
+            }
+        }
+    }
+}
+
+pub(crate) fn read_layer_buffer(layer: &Layer) -> LayerBuffer {
+    read_layer_buffer_with_rect(layer, None)
+}
+
+pub(crate) fn read_layer_buffer_with_rect(
+    layer: &Layer,
+    requested_rect: Option<ae::Rect>,
+) -> LayerBuffer {
+    let origin = layer_buffer_origin(layer, requested_rect);
+    LayerBuffer {
+        pixels: read_layer(layer),
+        width: layer.width(),
+        height: layer.height(),
+        origin,
+    }
+}
+
+pub(crate) fn read_settings(
+    params: &Parameters<Params>,
+    in_data: InData,
+) -> Result<Settings, Error> {
+    let downsample = [
+        f32::from(in_data.downsample_x()).abs().max(1.0e-6),
+        f32::from(in_data.downsample_y()).abs().max(1.0e-6),
+    ];
+    let center = point_to_full(point(params, Params::Center)?, downsample);
+    Ok(Settings {
+        height_source: height_source(params.get(Params::HeightSource)?.as_popup()?.value()),
+        map_channel: map_channel(params.get(Params::MapChannel)?.as_popup()?.value()),
+        invert_map: params.get(Params::InvertMap)?.as_checkbox()?.value(),
+        map_black: slider(params, Params::MapBlack, 0.0),
+        map_white: slider(params, Params::MapWhite, 1.0),
+        procedural: ProceduralSettings {
+            shape: shape(params.get(Params::Shape)?.as_popup()?.value()),
+            center,
+            size: slider(params, Params::Size, 500.0).max(0.01),
+            aspect: slider(params, Params::Aspect, 1.0).max(0.01),
+            rotation: finite_or(
+                params.get(Params::Rotation)?.as_angle()?.float_value()? as f32,
+                0.0,
+            )
+            .to_radians(),
+            roundness: slider(params, Params::Roundness, 50.0).clamp(0.0, 100.0) * 0.01,
+            ring_width: slider(params, Params::RingWidth, 25.0).clamp(1.0, 100.0) * 0.01,
+            facet_size: slider(params, Params::FacetSize, 48.0).max(1.0),
+            facet_amount: slider(params, Params::FacetAmount, 100.0).clamp(0.0, 100.0) * 0.01,
+            facet_jitter: slider(params, Params::FacetJitter, 75.0).clamp(0.0, 100.0) * 0.01,
+            crack_width: slider(params, Params::CrackWidth, 2.0).max(0.0),
+            crack_depth: slider(params, Params::CrackDepth, 90.0).clamp(0.0, 100.0) * 0.01,
+            radial_cracks: integer_slider(params, Params::RadialCracks, 18).clamp(3, 96) as u32,
+            crack_branching: slider(params, Params::CrackBranching, 55.0).clamp(0.0, 100.0) * 0.01,
+            crack_jitter: slider(params, Params::CrackJitter, 45.0).clamp(0.0, 100.0) * 0.01,
+            stress_rings: integer_slider(params, Params::StressRings, 6).clamp(0, 32) as u32,
+            ring_jitter: slider(params, Params::RingJitter, 35.0).clamp(0.0, 100.0) * 0.01,
+            impact_falloff: slider(params, Params::ImpactFalloff, 20.0).clamp(0.0, 100.0) * 0.01,
+            seed: slider(params, Params::Seed, 1.0).round().max(0.0) as u32,
+        },
+        height_strength: slider(params, Params::HeightStrength, 100.0),
+        normal_radius: slider(params, Params::NormalRadius, 1.0).max(0.25),
+        refraction: slider(params, Params::Refraction, 40.0),
+        dispersion: slider(params, Params::Dispersion, 2.0),
+        dispersion_steps: integer_slider(params, Params::DispersionSteps, 8).clamp(3, 32) as usize,
+        auto_spectral_steps: params
+            .get(Params::AutoSpectralSteps)?
+            .as_checkbox()?
+            .value(),
+        sampling: sampling(params.get(Params::Sampling)?.as_popup()?.value()),
+        edge: edge(params.get(Params::Edge)?.as_popup()?.value()),
+        mix: slider(params, Params::Mix, 100.0).clamp(0.0, 100.0) * 0.01,
+        preserve_alpha: params.get(Params::PreserveAlpha)?.as_checkbox()?.value(),
+        debug: debug_view(params.get(Params::Debug)?.as_popup()?.value()),
+        clamp_32: params.get(Params::Clamp32)?.as_checkbox()?.value(),
+        downsample,
+    })
+}
+
+pub(crate) fn render(
+    _in_data: InData,
+    in_layer: Layer,
+    mut out_layer: Layer,
+    settings: Settings,
+    maps: OwnedMaps,
+    layout: RenderLayout,
+) -> Result<(), Error> {
+    let source = read_layer_buffer_with_rect(&in_layer, layout.input_rect);
+    let width = out_layer.width();
+    let height = out_layer.height();
+    if width == 0 || height == 0 || source.width == 0 || source.height == 0 {
+        return Ok(());
+    }
+    // Point controls already include the pre-effect origin. Use the actual
+    // PF_EffectWorld origin (with the pre-render request as a fallback) so
+    // buffer-local pixels map back into the same layer coordinate system.
+    let output_origin = layer_buffer_origin(&out_layer, layout.output_rect);
+    let origin_x = output_origin[0];
+    let origin_y = output_origin[1];
+    let out_world_type = out_layer.world_type();
+    let custom_map = maps.custom.as_ref();
+    let context = HeightContext {
+        source: &source,
+        custom_map,
+        settings,
+    };
+    let optics = OpticalCalibration::bk7();
+    let spectral_bands = build_spectral_bands(settings, optics);
+
+    out_layer.iterate(0, height as i32, None, |x, y, mut destination| {
+        let global_x = (x as f32 + origin_x) / settings.downsample[0];
+        let global_y = (y as f32 + origin_y) / settings.downsample[1];
+        let height_sample = context.height_sample(global_x, global_y);
+        let slope = central_difference(
+            global_x,
+            global_y,
+            settings.normal_radius,
+            settings.height_strength,
+            |sample_x, sample_y| context.height_sample(sample_x, sample_y).value,
+        );
+        let normal = surface_normal(slope);
+        let base = context.source_sample(global_x, global_y);
+        let output = match settings.debug {
+            DebugView::Final => refracted_pixel(
+                [global_x, global_y],
+                normal,
+                base,
+                &source,
+                settings,
+                optics,
+                &spectral_bands,
+            ),
+            DebugView::Height => opaque_gray(height_sample.value),
+            DebugView::Normal => PixelF32 {
+                alpha: 1.0,
+                red: normal[0] * 0.5 + 0.5,
+                green: normal[1] * 0.5 + 0.5,
+                blue: normal[2],
+            },
+            DebugView::Displacement => {
+                let offset = reference_refraction_offset(normal, settings.refraction, optics);
+                let magnitude = length2(offset);
+                opaque_gray((magnitude / 128.0).clamp(0.0, 1.0))
+            }
+            DebugView::FacetId => {
+                let color = facet_color(height_sample.facet_id);
+                PixelF32 {
+                    alpha: 1.0,
+                    red: color[0],
+                    green: color[1],
+                    blue: color[2],
+                }
+            }
+        };
+        let output = sanitize_associated(output, settings.clamp_32 || !is_f32(out_world_type));
+        match out_world_type {
+            ae::aegp::WorldType::U8 => destination.set_from_u8(output.to_pixel8()),
+            ae::aegp::WorldType::U15 => destination.set_from_u16(output.to_pixel16()),
+            ae::aegp::WorldType::F32 | ae::aegp::WorldType::None => {
+                destination.set_from_f32(output)
+            }
+        }
+        Ok(())
+    })?;
+    Ok(())
+}
+
+struct HeightContext<'a> {
+    source: &'a LayerBuffer,
+    custom_map: Option<&'a LayerBuffer>,
+    settings: Settings,
+}
+
+impl HeightContext<'_> {
+    fn source_sample(&self, x: f32, y: f32) -> PixelF32 {
+        self.source.sample(
+            x * self.settings.downsample[0],
+            y * self.settings.downsample[1],
+            self.settings.sampling,
+            self.settings.edge,
+        )
+    }
+
+    fn height_sample(&self, x: f32, y: f32) -> HeightSample {
+        let raw = match self.settings.height_source {
+            HeightSource::Procedural => {
+                return procedural_height(x, y, self.settings.procedural);
+            }
+            HeightSource::CustomMap => self
+                .custom_map
+                .map(|map| {
+                    let source_x = x * self.settings.downsample[0];
+                    let source_y = y * self.settings.downsample[1];
+                    let map_x = scaled_coordinate(
+                        source_x,
+                        self.source.origin[0],
+                        self.source.width,
+                        map.origin[0],
+                        map.width,
+                    );
+                    let map_y = scaled_coordinate(
+                        source_y,
+                        self.source.origin[1],
+                        self.source.height,
+                        map.origin[1],
+                        map.height,
+                    );
+                    channel_value(
+                        map.sample(map_x, map_y, self.settings.sampling, self.settings.edge),
+                        self.settings.map_channel,
+                    )
+                })
+                .unwrap_or_else(|| luma(self.source_sample(x, y))),
+            HeightSource::InputLuma => luma(self.source_sample(x, y)),
+            HeightSource::InputAlpha => self.source_sample(x, y).alpha,
+        };
+        HeightSample {
+            value: map_level(
+                finite_or(raw, 0.0),
+                self.settings.map_black,
+                self.settings.map_white,
+                self.settings.invert_map,
+            ),
+            facet_id: 0,
+        }
+    }
+}
+
+fn refracted_pixel(
+    position: [f32; 2],
+    normal: [f32; 3],
+    base: PixelF32,
+    source: &LayerBuffer,
+    settings: Settings,
+    optics: OpticalCalibration,
+    spectral_bands: &[SpectralBand],
+) -> PixelF32 {
+    let (refracted_rgb, refracted_alpha) = if spectral_bands.is_empty() {
+        let offset = reference_refraction_offset(normal, settings.refraction, optics);
+        let sample = displaced_sample(source, position[0], position[1], offset, settings);
+        (unpremultiplied_rgb(sample), sample.alpha.clamp(0.0, 1.0))
+    } else {
+        spectral_refraction(
+            position[0],
+            position[1],
+            normal,
+            source,
+            settings,
+            optics,
+            spectral_bands,
+        )
+    };
+    let refracted = PixelF32 {
+        alpha: refracted_alpha,
+        red: refracted_rgb[0] * refracted_alpha,
+        green: refracted_rgb[1] * refracted_alpha,
+        blue: refracted_rgb[2] * refracted_alpha,
+    };
+    composite_refracted(base, refracted, settings.mix, settings.preserve_alpha)
+}
+
+/// Integrates the CIE 1931 observer response across the visible range. Every
+/// wavelength follows its own BK7 Sellmeier index through the same Snell ray
+/// calculation, rather than moving three independent RGB copies.
+fn spectral_refraction(
+    x: f32,
+    y: f32,
+    normal: [f32; 3],
+    source: &LayerBuffer,
+    settings: Settings,
+    optics: OpticalCalibration,
+    spectral_bands: &[SpectralBand],
+) -> ([f32; 3], f32) {
+    let mut rgb_sum = [0.0_f32; 3];
+    let mut rgb_weight = [0.0_f32; 3];
+    let mut alpha_sum = 0.0_f32;
+    let mut alpha_weight = 0.0_f32;
+
+    for band in spectral_bands {
+        let offset = wavelength_refraction_offset(
+            normal,
+            settings.refraction,
+            settings.dispersion,
+            band.refractive_index,
+            optics,
+        );
+        let sample = displaced_sample(source, x, y, offset, settings);
+        let rgb = unpremultiplied_rgb(sample);
+        for channel in 0..3 {
+            rgb_sum[channel] += rgb[channel] * band.rgb_response[channel];
+            rgb_weight[channel] += band.rgb_response[channel];
+        }
+        alpha_sum += sample.alpha.clamp(0.0, 1.0) * band.luminance_response;
+        alpha_weight += band.luminance_response;
+    }
+
+    let rgb = [
+        rgb_sum[0] / rgb_weight[0].max(1.0e-8),
+        rgb_sum[1] / rgb_weight[1].max(1.0e-8),
+        rgb_sum[2] / rgb_weight[2].max(1.0e-8),
+    ];
+    (rgb, alpha_sum / alpha_weight.max(1.0e-8))
+}
+
+fn build_spectral_bands(settings: Settings, optics: OpticalCalibration) -> Vec<SpectralBand> {
+    if settings.dispersion.abs() <= 1.0e-6 {
+        return Vec::new();
+    }
+    let steps = effective_spectral_steps(settings, optics);
+    (0..steps)
+        .map(|step| {
+            // Stratified midpoint quadrature avoids endpoint bias, especially
+            // for the lowest allowed manual sample count.
+            let wavelength_nm = SPECTRUM_MIN_NM
+                + (SPECTRUM_MAX_NM - SPECTRUM_MIN_NM) * (step as f32 + 0.5) / steps as f32;
+            SpectralBand {
+                refractive_index: bk7_refractive_index(wavelength_nm),
+                rgb_response: spectral_response(wavelength_nm),
+                luminance_response: cie_xyz_1931(wavelength_nm)[1].max(0.0),
+            }
+        })
+        .collect()
+}
+
+fn effective_spectral_steps(settings: Settings, optics: OpticalCalibration) -> usize {
+    if !settings.auto_spectral_steps {
+        return settings.dispersion_steps.clamp(3, 32);
+    }
+    automatic_spectral_steps(
+        settings.refraction,
+        settings.dispersion,
+        settings.height_strength,
+        settings.normal_radius,
+        settings.downsample,
+        settings.sampling,
+        optics,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn automatic_spectral_steps(
+    refraction: f32,
+    dispersion: f32,
+    height_strength: f32,
+    normal_radius: f32,
+    downsample: [f32; 2],
+    sampling: Sampling,
+    optics: OpticalCalibration,
+) -> usize {
+    // A normalized height map can change by at most one across a central
+    // difference pair. Cap the estimate short of a grazing interface: beyond
+    // this point the Snell projection is already close to its asymptote.
+    let estimated_slope = (height_strength.abs() / (2.0 * normal_radius.max(0.25))).clamp(0.0, 8.0);
+    let normal = surface_normal([estimated_slope, 0.0]);
+    let blue = wavelength_refraction_offset(
+        normal,
+        refraction,
+        dispersion,
+        bk7_refractive_index(SPECTRUM_MIN_NM),
+        optics,
+    );
+    let red = wavelength_refraction_offset(
+        normal,
+        refraction,
+        dispersion,
+        bk7_refractive_index(SPECTRUM_MAX_NM),
+        optics,
+    );
+    let reference = reference_refraction_offset(normal, refraction, optics);
+    let render_scale = downsample[0].abs().max(downsample[1].abs()).max(1.0e-3);
+    let spectral_span = length2(sub2(blue, red)) * render_scale;
+    let displacement = length2(reference) * render_scale;
+    // Eight samples cover the broad CIE response at modest settings. Add
+    // samples for sub-pixel spectral travel, strong ray projection, steep
+    // interfaces, and nearest-neighbor quantization. This is intentionally a
+    // smooth estimate to avoid large performance jumps between adjacent UI
+    // values.
+    let sampling_cost = if sampling == Sampling::Nearest {
+        2.0
+    } else {
+        0.0
+    };
+    let estimate = 8.0
+        + spectral_span * 0.75
+        + displacement.sqrt() * 0.30
+        + estimated_slope.ln_1p() * 1.5
+        + sampling_cost;
+    (estimate.ceil() as usize).clamp(6, 32)
+}
+
+fn spectral_response(wavelength_nm: f32) -> [f32; 3] {
+    // Convert the analytic CIE 1931 2-degree observer fit to linear sRGB.
+    // Negative matrix lobes are out-of-gamut monochromatic colors, so clamp
+    // them before using the values as positive sensor-integration weights.
+    let xyz = cie_xyz_1931(wavelength_nm);
+    [
+        (3.240_6 * xyz[0] - 1.537_2 * xyz[1] - 0.498_6 * xyz[2]).max(0.0),
+        (-0.968_9 * xyz[0] + 1.875_8 * xyz[1] + 0.041_5 * xyz[2]).max(0.0),
+        (0.055_7 * xyz[0] - 0.204_0 * xyz[1] + 1.057_0 * xyz[2]).max(0.0),
+    ]
+}
+
+fn cie_xyz_1931(wavelength_nm: f32) -> [f32; 3] {
+    // Smooth analytic fit by Wyman, Sloan, and Shirley. Its asymmetric lobes
+    // reproduce the CIE color-matching curves far more closely than three
+    // hand-tuned RGB Gaussians while remaining practical in a pixel effect.
+    let x = 0.362 * cie_lobe(wavelength_nm, 442.0, 0.062_4, 0.037_4)
+        + 1.056 * cie_lobe(wavelength_nm, 599.8, 0.026_4, 0.032_3)
+        - 0.065 * cie_lobe(wavelength_nm, 501.1, 0.049_0, 0.038_2);
+    let y = 0.821 * cie_lobe(wavelength_nm, 568.8, 0.021_3, 0.024_7)
+        + 0.286 * cie_lobe(wavelength_nm, 530.9, 0.061_3, 0.032_2);
+    let z = 1.217 * cie_lobe(wavelength_nm, 437.0, 0.084_5, 0.027_8)
+        + 0.681 * cie_lobe(wavelength_nm, 459.0, 0.038_5, 0.072_5);
+    [x.max(0.0), y.max(0.0), z.max(0.0)]
+}
+
+fn cie_lobe(value: f32, center: f32, left_scale: f32, right_scale: f32) -> f32 {
+    let scale = if value < center {
+        left_scale
+    } else {
+        right_scale
+    };
+    let t = (value - center) * scale;
+    (-0.5 * t * t).exp()
+}
+
+fn bk7_refractive_index(wavelength_nm: f32) -> f32 {
+    // Schott N-BK7 Sellmeier coefficients; wavelength is in micrometers.
+    let wavelength_um = (wavelength_nm * 0.001).clamp(0.36, 2.4);
+    let lambda_squared = wavelength_um * wavelength_um;
+    let n_squared = 1.0
+        + 1.039_612 * lambda_squared / (lambda_squared - 0.006_000_699)
+        + 0.231_792_35 * lambda_squared / (lambda_squared - 0.020_017_914)
+        + 1.010_469_4 * lambda_squared / (lambda_squared - 103.560_65);
+    n_squared.max(1.0).sqrt()
+}
+
+fn surface_normal(slope: [f32; 2]) -> [f32; 3] {
+    let inverse_length = (slope[0].mul_add(slope[0], slope[1] * slope[1]) + 1.0)
+        .sqrt()
+        .recip();
+    [
+        finite_or(slope[0] * inverse_length, 0.0),
+        finite_or(slope[1] * inverse_length, 0.0),
+        finite_or(inverse_length, 1.0),
+    ]
+}
+
+fn refracted_ray(surface_normal: [f32; 3], refractive_index: f32) -> [f32; 3] {
+    // Incident camera ray (0, 0, -1), refracted from air into glass. This is
+    // the vector form of Snell's law with eta = n_air / n_glass.
+    let eta = 1.0 / refractive_index.max(1.000_001);
+    let cos_incident = surface_normal[2].clamp(0.0, 1.0);
+    let transmitted_cosine = (1.0 - eta * eta * (1.0 - cos_incident * cos_incident))
+        .max(0.0)
+        .sqrt();
+    let normal_scale = eta * cos_incident - transmitted_cosine;
+    [
+        normal_scale * surface_normal[0],
+        normal_scale * surface_normal[1],
+        -eta + normal_scale * surface_normal[2],
+    ]
+}
+
+fn refracted_screen_slope(surface_normal: [f32; 3], refractive_index: f32) -> [f32; 2] {
+    let ray = refracted_ray(surface_normal, refractive_index);
+    let depth = (-ray[2]).max(1.0e-6);
+    [
+        finite_or(ray[0] / depth, 0.0),
+        finite_or(ray[1] / depth, 0.0),
+    ]
+}
+
+fn reference_refraction_offset(
+    surface_normal: [f32; 3],
+    refraction: f32,
+    optics: OpticalCalibration,
+) -> [f32; 2] {
+    mul2(
+        refracted_screen_slope(surface_normal, optics.reference_index),
+        refraction * optics.projection_scale,
+    )
+}
+
+fn wavelength_refraction_offset(
+    surface_normal: [f32; 3],
+    refraction: f32,
+    dispersion: f32,
+    refractive_index: f32,
+    optics: OpticalCalibration,
+) -> [f32; 2] {
+    let reference_ray = refracted_screen_slope(surface_normal, optics.reference_index);
+    let wavelength_ray = refracted_screen_slope(surface_normal, refractive_index);
+    add2(
+        mul2(reference_ray, refraction * optics.projection_scale),
+        mul2(
+            sub2(wavelength_ray, reference_ray),
+            dispersion * optics.dispersion_scale,
+        ),
+    )
+}
+
+fn composite_refracted(
+    base: PixelF32,
+    refracted: PixelF32,
+    mix: f32,
+    preserve_alpha: bool,
+) -> PixelF32 {
+    let mix = finite_or(mix, 1.0).clamp(0.0, 1.0);
+    let base_alpha = finite_or(base.alpha, 0.0).clamp(0.0, 1.0);
+    let refracted_alpha = finite_or(refracted.alpha, 0.0).clamp(0.0, 1.0);
+    if preserve_alpha {
+        let base_rgb = unpremultiplied_rgb(base);
+        let refracted_rgb = unpremultiplied_rgb(refracted);
+        let rgb = [
+            lerp(base_rgb[0], refracted_rgb[0], mix),
+            lerp(base_rgb[1], refracted_rgb[1], mix),
+            lerp(base_rgb[2], refracted_rgb[2], mix),
+        ];
+        PixelF32 {
+            alpha: base_alpha,
+            red: rgb[0] * base_alpha,
+            green: rgb[1] * base_alpha,
+            blue: rgb[2] * base_alpha,
+        }
+    } else {
+        PixelF32 {
+            alpha: lerp(base_alpha, refracted_alpha, mix),
+            red: lerp(finite_or(base.red, 0.0), finite_or(refracted.red, 0.0), mix),
+            green: lerp(
+                finite_or(base.green, 0.0),
+                finite_or(refracted.green, 0.0),
+                mix,
+            ),
+            blue: lerp(
+                finite_or(base.blue, 0.0),
+                finite_or(refracted.blue, 0.0),
+                mix,
+            ),
+        }
+    }
+}
+
+fn displaced_sample(
+    source: &LayerBuffer,
+    x: f32,
+    y: f32,
+    offset: [f32; 2],
+    settings: Settings,
+) -> PixelF32 {
+    source.sample(
+        (x + offset[0]) * settings.downsample[0],
+        (y + offset[1]) * settings.downsample[1],
+        settings.sampling,
+        settings.edge,
+    )
+}
+
+fn channel_value(pixel: PixelF32, channel: MapChannel) -> f32 {
+    let rgb = unpremultiplied_rgb(pixel);
+    match channel {
+        MapChannel::Luma => 0.2126 * rgb[0] + 0.7152 * rgb[1] + 0.0722 * rgb[2],
+        MapChannel::Alpha => pixel.alpha,
+        MapChannel::Red => rgb[0],
+        MapChannel::Green => rgb[1],
+        MapChannel::Blue => rgb[2],
+    }
+}
+
+fn opaque_gray(value: f32) -> PixelF32 {
+    let value = finite_or(value, 0.0).clamp(0.0, 1.0);
+    PixelF32 {
+        alpha: 1.0,
+        red: value,
+        green: value,
+        blue: value,
+    }
+}
+
+fn sanitize_associated(pixel: PixelF32, clamp_rgb: bool) -> PixelF32 {
+    let mut pixel = sanitize_pixel(pixel, false);
+    if clamp_rgb {
+        pixel.red = pixel.red.clamp(0.0, pixel.alpha);
+        pixel.green = pixel.green.clamp(0.0, pixel.alpha);
+        pixel.blue = pixel.blue.clamp(0.0, pixel.alpha);
+    }
+    pixel
+}
+
+fn scaled_coordinate(
+    value: f32,
+    source_origin: f32,
+    source_length: usize,
+    target_origin: f32,
+    target_length: usize,
+) -> f32 {
+    if source_length <= 1 || target_length <= 1 {
+        target_origin
+    } else {
+        target_origin
+            + (value - source_origin) * (target_length - 1) as f32 / (source_length - 1) as f32
+    }
+}
+
+fn layer_buffer_origin(layer: &Layer, requested_rect: Option<ae::Rect>) -> [f32; 2] {
+    let native = layer.origin();
+    if native.h != 0 || native.v != 0 {
+        return [native.h as f32, native.v as f32];
+    }
+    if let Some(rect) = requested_rect
+        && rect.width() == layer.width() as i32
+        && rect.height() == layer.height() as i32
+    {
+        return [rect.left as f32, rect.top as f32];
+    }
+    [native.h as f32, native.v as f32]
+}
+
+fn point(params: &Parameters<Params>, id: Params) -> Result<[f32; 2], Error> {
+    let param = params.get(id)?;
+    let point = param.as_point()?;
+    Ok(match point.float_value() {
+        Ok(value) => [value.x as f32, value.y as f32],
+        Err(_) => {
+            let (x, y) = point.value();
+            [x, y]
+        }
+    })
+}
+
+fn point_to_full(point: [f32; 2], downsample: [f32; 2]) -> [f32; 2] {
+    [point[0] / downsample[0], point[1] / downsample[1]]
+}
+
+fn slider(params: &Parameters<Params>, id: Params, fallback: f32) -> f32 {
+    let Ok(param) = params.get(id) else {
+        return fallback;
+    };
+    let Ok(slider) = param.as_float_slider() else {
+        return fallback;
+    };
+    finite_or(slider.value() as f32, fallback)
+}
+
+fn integer_slider(params: &Parameters<Params>, id: Params, fallback: i32) -> i32 {
+    let Ok(param) = params.get(id) else {
+        return fallback;
+    };
+    let Ok(slider) = param.as_slider() else {
+        return fallback;
+    };
+    slider.value()
+}
+
+fn height_source(value: i32) -> HeightSource {
+    match value {
+        2 => HeightSource::CustomMap,
+        3 => HeightSource::InputLuma,
+        4 => HeightSource::InputAlpha,
+        _ => HeightSource::Procedural,
+    }
+}
+
+pub(crate) fn shape(value: i32) -> Shape {
+    match value {
+        2 => Shape::RoundedRectangle,
+        3 => Shape::Diamond,
+        4 => Shape::Ring,
+        5 => Shape::Facets,
+        6 => Shape::Shards,
+        7 => Shape::ImpactGlass,
+        _ => Shape::Sphere,
+    }
+}
+
+fn map_channel(value: i32) -> MapChannel {
+    match value {
+        2 => MapChannel::Alpha,
+        3 => MapChannel::Red,
+        4 => MapChannel::Green,
+        5 => MapChannel::Blue,
+        _ => MapChannel::Luma,
+    }
+}
+
+fn sampling(value: i32) -> Sampling {
+    if value == 1 {
+        Sampling::Nearest
+    } else {
+        Sampling::Bilinear
+    }
+}
+
+fn edge(value: i32) -> EdgeMode {
+    match value {
+        1 => EdgeMode::Transparent,
+        3 => EdgeMode::Tile,
+        4 => EdgeMode::Mirror,
+        _ => EdgeMode::Clamp,
+    }
+}
+
+fn sample_edge(edge: EdgeMode) -> SampleEdge {
+    match edge {
+        EdgeMode::Transparent => SampleEdge::Transparent,
+        EdgeMode::Clamp => SampleEdge::Clamp,
+        EdgeMode::Tile => SampleEdge::Tile,
+        EdgeMode::Mirror => SampleEdge::Mirror,
+    }
+}
+
+fn debug_view(value: i32) -> DebugView {
+    match value {
+        2 => DebugView::Height,
+        3 => DebugView::Normal,
+        4 => DebugView::Displacement,
+        5 => DebugView::FacetId,
+        _ => DebugView::Final,
+    }
+}
+
+fn is_f32(world: ae::aegp::WorldType) -> bool {
+    matches!(world, ae::aegp::WorldType::F32 | ae::aegp::WorldType::None)
+}
+
+fn lerp(a: f32, b: f32, t: f32) -> f32 {
+    a + (b - a) * t
+}
+
+fn add2(a: [f32; 2], b: [f32; 2]) -> [f32; 2] {
+    [a[0] + b[0], a[1] + b[1]]
+}
+
+fn sub2(a: [f32; 2], b: [f32; 2]) -> [f32; 2] {
+    [a[0] - b[0], a[1] - b[1]]
+}
+
+fn mul2(value: [f32; 2], scale: f32) -> [f32; 2] {
+    [value[0] * scale, value[1] * scale]
+}
+
+fn length2(value: [f32; 2]) -> f32 {
+    value[0].hypot(value[1])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scaled_coordinates_preserve_endpoints() {
+        assert_eq!(scaled_coordinate(-100.0, -100.0, 1920, 25.0, 960), 25.0);
+        assert!((scaled_coordinate(1819.0, -100.0, 1920, 25.0, 960) - 984.0).abs() < 1.0e-5);
+    }
+
+    #[test]
+    fn channel_value_unpremultiplies_rgb() {
+        let pixel = PixelF32 {
+            alpha: 0.5,
+            red: 0.4,
+            green: 0.2,
+            blue: 0.1,
+        };
+        assert!((channel_value(pixel, MapChannel::Red) - 0.8).abs() < 1.0e-6);
+        assert!((channel_value(pixel, MapChannel::Alpha) - 0.5).abs() < 1.0e-6);
+    }
+
+    #[test]
+    fn refraction_mix_interpolates_associated_color() {
+        let transparent = PixelF32 {
+            alpha: 0.0,
+            red: 0.0,
+            green: 0.0,
+            blue: 0.0,
+        };
+        let opaque_red = PixelF32 {
+            alpha: 1.0,
+            red: 1.0,
+            green: 0.0,
+            blue: 0.0,
+        };
+        let output = composite_refracted(transparent, opaque_red, 0.5, false);
+        assert!((output.alpha - 0.5).abs() < 1.0e-6);
+        assert!((output.red - 0.5).abs() < 1.0e-6);
+    }
+
+    #[test]
+    fn layer_buffer_samples_in_layer_coordinates() {
+        let buffer = LayerBuffer {
+            pixels: vec![PixelF32 {
+                alpha: 1.0,
+                red: 0.75,
+                green: 0.0,
+                blue: 0.0,
+            }],
+            width: 1,
+            height: 1,
+            origin: [-12.0, 7.0],
+        };
+        let pixel = buffer.sample(-12.0, 7.0, Sampling::Nearest, EdgeMode::Transparent);
+        assert_eq!(pixel.red, 0.75);
+    }
+
+    #[test]
+    fn sellmeier_matches_bk7_reference_indices() {
+        // Published Schott values at the F, d, and C Fraunhofer lines.
+        for (wavelength, expected) in [(486.13, 1.522_38), (587.56, 1.516_80), (656.27, 1.514_32)] {
+            assert!((bk7_refractive_index(wavelength) - expected).abs() < 5.0e-5);
+        }
+        assert!(bk7_refractive_index(380.0) > bk7_refractive_index(780.0));
+    }
+
+    #[test]
+    fn snell_ray_is_normalized_and_obeys_the_sine_law() {
+        let normal = surface_normal([1.0, 0.0]);
+        let index = bk7_refractive_index(REFERENCE_WAVELENGTH_NM);
+        let ray = refracted_ray(normal, index);
+        let ray_length = (ray[0].mul_add(ray[0], ray[1] * ray[1]) + ray[2] * ray[2]).sqrt();
+        assert!((ray_length - 1.0).abs() < 1.0e-5);
+
+        let sin_incident = (1.0 - normal[2] * normal[2]).sqrt();
+        let cos_transmitted = -(ray[0] * normal[0] + ray[1] * normal[1] + ray[2] * normal[2]);
+        let sin_transmitted = (1.0 - cos_transmitted * cos_transmitted).max(0.0).sqrt();
+        assert!((sin_transmitted - sin_incident / index).abs() < 1.0e-5);
+    }
+
+    #[test]
+    fn flat_interface_has_no_screen_displacement() {
+        let optics = OpticalCalibration::bk7();
+        let normal = surface_normal([0.0, 0.0]);
+        assert_eq!(
+            reference_refraction_offset(normal, 100.0, optics),
+            [0.0, 0.0]
+        );
+        assert_eq!(
+            wavelength_refraction_offset(normal, 100.0, 20.0, bk7_refractive_index(380.0), optics,),
+            [0.0, 0.0]
+        );
+    }
+
+    #[test]
+    fn refraction_control_is_calibrated_at_a_45_degree_slope() {
+        let optics = OpticalCalibration::bk7();
+        let offset = reference_refraction_offset(surface_normal([1.0, 0.0]), 40.0, optics);
+        assert!((length2(offset) - 40.0).abs() < 1.0e-4);
+    }
+
+    #[test]
+    fn snell_projection_tracks_height_gradient_direction() {
+        // central_difference returns the outward normal's XY terms. A height
+        // ramp rising toward +X therefore sends the camera ray toward +X
+        // inside the glass backing plane.
+        let optics = OpticalCalibration::bk7();
+        let offset = reference_refraction_offset(surface_normal([-1.0, 0.0]), 40.0, optics);
+        assert!(offset[0] > 0.0);
+        assert!(offset[1].abs() < 1.0e-6);
+    }
+
+    #[test]
+    fn sellmeier_dispersion_orders_blue_reference_and_red_rays() {
+        let optics = OpticalCalibration::bk7();
+        let normal = surface_normal([-1.0, 0.0]);
+        let blue =
+            wavelength_refraction_offset(normal, 40.0, 5.0, bk7_refractive_index(380.0), optics);
+        let reference = reference_refraction_offset(normal, 40.0, optics);
+        let red =
+            wavelength_refraction_offset(normal, 40.0, 5.0, bk7_refractive_index(780.0), optics);
+        assert!((blue[0] - reference[0] - 5.0).abs() < 1.0e-4);
+        assert!(blue[0] > reference[0] && reference[0] > red[0]);
+    }
+
+    #[test]
+    fn legacy_shape_popup_indices_remain_stable() {
+        assert_eq!(shape(5), Shape::Facets);
+        assert_eq!(shape(6), Shape::Shards);
+        assert_eq!(shape(7), Shape::ImpactGlass);
+    }
+
+    #[test]
+    fn spectral_responses_are_smooth_and_cover_every_channel() {
+        let violet = spectral_response(420.0);
+        let green = spectral_response(545.0);
+        let red = spectral_response(650.0);
+        assert!(violet[2] > violet[1] && violet[2] > violet[0]);
+        assert!(green[1] > green[0] && green[1] > green[2]);
+        assert!(red[0] > red[1] && red[0] > red[2]);
+        let mut integrated = [0.0_f32; 3];
+        for wavelength in (380..=780).step_by(5) {
+            let response = spectral_response(wavelength as f32);
+            assert!(
+                response
+                    .iter()
+                    .all(|weight| weight.is_finite() && *weight >= 0.0)
+            );
+            for channel in 0..3 {
+                integrated[channel] += response[channel];
+            }
+        }
+        assert!(integrated.iter().all(|weight| *weight > 1.0));
+        assert!(cie_xyz_1931(555.0)[1] > cie_xyz_1931(450.0)[1]);
+        assert!(cie_xyz_1931(555.0)[1] > cie_xyz_1931(650.0)[1]);
+    }
+
+    #[test]
+    fn automatic_steps_scale_with_optical_difficulty_and_stay_bounded() {
+        let optics = OpticalCalibration::bk7();
+        let easy =
+            automatic_spectral_steps(20.0, 1.0, 20.0, 4.0, [0.5, 0.5], Sampling::Bilinear, optics);
+        let hard = automatic_spectral_steps(
+            256.0,
+            64.0,
+            200.0,
+            0.25,
+            [1.0, 1.0],
+            Sampling::Nearest,
+            optics,
+        );
+        assert!((6..=32).contains(&easy));
+        assert!((6..=32).contains(&hard));
+        assert!(hard > easy);
+    }
+
+    #[test]
+    fn automatic_steps_respect_render_resolution() {
+        let optics = OpticalCalibration::bk7();
+        let full = automatic_spectral_steps(
+            100.0,
+            12.0,
+            80.0,
+            1.0,
+            [1.0, 1.0],
+            Sampling::Bilinear,
+            optics,
+        );
+        let quarter = automatic_spectral_steps(
+            100.0,
+            12.0,
+            80.0,
+            1.0,
+            [0.25, 0.25],
+            Sampling::Bilinear,
+            optics,
+        );
+        assert!(full >= quarter);
+    }
+}

--- a/plugins/glass-displace/src/render.rs
+++ b/plugins/glass-displace/src/render.rs
@@ -9,8 +9,8 @@ use utils::image::{
 };
 
 use crate::glass::{
-    DebugView, EdgeMode, HeightSample, HeightSource, MapChannel, ProceduralSettings, Sampling,
-    Shape, central_difference, facet_color, map_level, procedural_height,
+    DebugView, EdgeMode, HeightSample, HeightSource, MapChannel, PreparedProcedural,
+    ProceduralSettings, Sampling, Shape, central_difference, facet_color, map_level,
 };
 use crate::params::Params;
 
@@ -20,6 +20,11 @@ const SPECTRUM_MAX_NM: f32 = 780.0;
 // glass. BK7's refractive index is approximately 1.5168 at this wavelength.
 const REFERENCE_WAVELENGTH_NM: f32 = 587.56;
 const DISPERSION_REFERENCE_WAVELENGTH_NM: f32 = SPECTRUM_MIN_NM;
+
+#[cfg(test)]
+thread_local! {
+    static REFRACTED_SCREEN_SLOPE_CALLS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
 
 #[derive(Clone)]
 pub(crate) struct LayerBuffer {
@@ -210,51 +215,55 @@ pub(crate) fn render(
     let origin_y = output_origin[1];
     let out_world_type = out_layer.world_type();
     let custom_map = maps.custom.as_ref();
+    let prepared_procedural = (settings.height_source == HeightSource::Procedural)
+        .then(|| PreparedProcedural::new(settings.procedural));
     let context = HeightContext {
         source: &source,
         custom_map,
         settings,
+        prepared_procedural,
     };
-    let optics = OpticalCalibration::bk7();
-    let spectral_bands = build_spectral_bands(settings, optics);
+    let (optics, spectral_bands) = prepare_render_optics(settings);
 
     out_layer.iterate(0, height as i32, None, |x, y, mut destination| {
         let global_x = (x as f32 + origin_x) / settings.downsample[0];
         let global_y = (y as f32 + origin_y) / settings.downsample[1];
-        let height_sample = context.height_sample(global_x, global_y);
-        let slope = central_difference(
-            global_x,
-            global_y,
-            settings.normal_radius,
-            settings.height_strength,
-            |sample_x, sample_y| context.height_sample(sample_x, sample_y).value,
-        );
-        let normal = surface_normal(slope);
-        let base = context.source_sample(global_x, global_y);
         let output = match settings.debug {
-            DebugView::Final => refracted_pixel(
-                [global_x, global_y],
-                normal,
-                base,
-                &source,
-                settings,
-                optics,
-                &spectral_bands,
-            ),
-            DebugView::Height => opaque_gray(height_sample.value),
-            DebugView::Normal => PixelF32 {
-                alpha: 1.0,
-                red: normal[0] * 0.5 + 0.5,
-                green: normal[1] * 0.5 + 0.5,
-                blue: normal[2],
-            },
+            DebugView::Final => {
+                let normal = context.normal(global_x, global_y);
+                let base = context.source_sample(global_x, global_y);
+                refracted_pixel(
+                    [global_x, global_y],
+                    normal,
+                    base,
+                    &source,
+                    settings,
+                    optics.expect("final view prepares optics"),
+                    &spectral_bands,
+                )
+            }
+            DebugView::Height => opaque_gray(context.height_sample(global_x, global_y).value),
+            DebugView::Normal => {
+                let normal = context.normal(global_x, global_y);
+                PixelF32 {
+                    alpha: 1.0,
+                    red: normal[0] * 0.5 + 0.5,
+                    green: normal[1] * 0.5 + 0.5,
+                    blue: normal[2],
+                }
+            }
             DebugView::Displacement => {
-                let offset = reference_refraction_offset(normal, settings.refraction, optics);
+                let normal = context.normal(global_x, global_y);
+                let offset = reference_refraction_offset(
+                    normal,
+                    settings.refraction,
+                    optics.expect("displacement view prepares optics"),
+                );
                 let magnitude = length2(offset);
                 opaque_gray((magnitude / 128.0).clamp(0.0, 1.0))
             }
             DebugView::FacetId => {
-                let color = facet_color(height_sample.facet_id);
+                let color = facet_color(context.facet_id(global_x, global_y));
                 PixelF32 {
                     alpha: 1.0,
                     red: color[0],
@@ -280,6 +289,7 @@ struct HeightContext<'a> {
     source: &'a LayerBuffer,
     custom_map: Option<&'a LayerBuffer>,
     settings: Settings,
+    prepared_procedural: Option<PreparedProcedural>,
 }
 
 impl HeightContext<'_> {
@@ -295,7 +305,11 @@ impl HeightContext<'_> {
     fn height_sample(&self, x: f32, y: f32) -> HeightSample {
         let raw = match self.settings.height_source {
             HeightSource::Procedural => {
-                return procedural_height(x, y, self.settings.procedural);
+                return self
+                    .prepared_procedural
+                    .as_ref()
+                    .expect("procedural height source prepares its constants")
+                    .height(x, y);
             }
             HeightSource::CustomMap => self
                 .custom_map
@@ -335,6 +349,44 @@ impl HeightContext<'_> {
             facet_id: 0,
         }
     }
+
+    fn normal(&self, x: f32, y: f32) -> [f32; 3] {
+        let slope = central_difference(
+            x,
+            y,
+            self.settings.normal_radius,
+            self.settings.height_strength,
+            |sample_x, sample_y| self.height_sample(sample_x, sample_y).value,
+        );
+        surface_normal(slope)
+    }
+
+    fn facet_id(&self, x: f32, y: f32) -> u32 {
+        if self.settings.height_source != HeightSource::Procedural
+            || !matches!(
+                self.settings.procedural.shape,
+                Shape::Facets | Shape::Shards | Shape::ImpactGlass
+            )
+        {
+            return 0;
+        }
+        self.prepared_procedural
+            .as_ref()
+            .expect("procedural height source prepares its constants")
+            .height(x, y)
+            .facet_id
+    }
+}
+
+fn prepare_render_optics(settings: Settings) -> (Option<OpticalCalibration>, Vec<SpectralBand>) {
+    let needs_optics = matches!(settings.debug, DebugView::Final | DebugView::Displacement);
+    let optics = needs_optics.then(OpticalCalibration::bk7);
+    let spectral_bands = if settings.debug == DebugView::Final {
+        build_spectral_bands(settings, optics.expect("final view prepares optics"))
+    } else {
+        Vec::new()
+    };
+    (optics, spectral_bands)
 }
 
 fn refracted_pixel(
@@ -386,14 +438,17 @@ fn spectral_refraction(
     let mut rgb_weight = [0.0_f32; 3];
     let mut alpha_sum = 0.0_f32;
     let mut alpha_weight = 0.0_f32;
+    let reference_ray = refracted_screen_slope(normal, optics.reference_index);
+    let reference_offset = mul2(reference_ray, settings.refraction * optics.projection_scale);
 
     for band in spectral_bands {
-        let offset = wavelength_refraction_offset(
+        let offset = wavelength_refraction_offset_from_reference(
             normal,
-            settings.refraction,
             settings.dispersion,
             band.refractive_index,
             optics,
+            reference_ray,
+            reference_offset,
         );
         let sample = displaced_sample(source, x, y, offset, settings);
         let rgb = unpremultiplied_rgb(sample);
@@ -574,6 +629,8 @@ fn refracted_ray(surface_normal: [f32; 3], refractive_index: f32) -> [f32; 3] {
 }
 
 fn refracted_screen_slope(surface_normal: [f32; 3], refractive_index: f32) -> [f32; 2] {
+    #[cfg(test)]
+    REFRACTED_SCREEN_SLOPE_CALLS.with(|calls| calls.set(calls.get() + 1));
     let ray = refracted_ray(surface_normal, refractive_index);
     let depth = (-ray[2]).max(1.0e-6);
     [
@@ -601,9 +658,28 @@ fn wavelength_refraction_offset(
     optics: OpticalCalibration,
 ) -> [f32; 2] {
     let reference_ray = refracted_screen_slope(surface_normal, optics.reference_index);
+    let reference_offset = mul2(reference_ray, refraction * optics.projection_scale);
+    wavelength_refraction_offset_from_reference(
+        surface_normal,
+        dispersion,
+        refractive_index,
+        optics,
+        reference_ray,
+        reference_offset,
+    )
+}
+
+fn wavelength_refraction_offset_from_reference(
+    surface_normal: [f32; 3],
+    dispersion: f32,
+    refractive_index: f32,
+    optics: OpticalCalibration,
+    reference_ray: [f32; 2],
+    reference_offset: [f32; 2],
+) -> [f32; 2] {
     let wavelength_ray = refracted_screen_slope(surface_normal, refractive_index);
     add2(
-        mul2(reference_ray, refraction * optics.projection_scale),
+        reference_offset,
         mul2(
             sub2(wavelength_ray, reference_ray),
             dispersion * optics.dispersion_scale,
@@ -857,6 +933,185 @@ fn length2(value: [f32; 2]) -> f32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_settings(dispersion: f32) -> Settings {
+        Settings {
+            height_source: HeightSource::Procedural,
+            map_channel: MapChannel::Luma,
+            invert_map: false,
+            map_black: 0.0,
+            map_white: 1.0,
+            procedural: ProceduralSettings {
+                shape: Shape::Sphere,
+                center: [2.0, 2.0],
+                size: 8.0,
+                aspect: 1.0,
+                rotation: 0.0,
+                roundness: 0.5,
+                ring_width: 0.25,
+                facet_size: 4.0,
+                facet_amount: 1.0,
+                facet_jitter: 0.75,
+                crack_width: 1.0,
+                crack_depth: 0.9,
+                radial_cracks: 18,
+                crack_branching: 0.55,
+                crack_jitter: 0.45,
+                stress_rings: 6,
+                ring_jitter: 0.35,
+                impact_falloff: 0.2,
+                seed: 1,
+            },
+            height_strength: 100.0,
+            normal_radius: 1.0,
+            refraction: 7.25,
+            dispersion,
+            dispersion_steps: 8,
+            auto_spectral_steps: false,
+            sampling: Sampling::Bilinear,
+            edge: EdgeMode::Clamp,
+            mix: 1.0,
+            preserve_alpha: false,
+            debug: DebugView::Final,
+            clamp_32: false,
+            downsample: [1.0, 1.0],
+        }
+    }
+
+    fn test_source() -> LayerBuffer {
+        let mut pixels = Vec::new();
+        for y in 0..6 {
+            for x in 0..7 {
+                let alpha = 0.35 + (x + y) as f32 * 0.04;
+                pixels.push(PixelF32 {
+                    alpha,
+                    red: alpha * (x as f32 / 6.0),
+                    green: alpha * (y as f32 / 5.0),
+                    blue: alpha * ((x + y) as f32 / 11.0),
+                });
+            }
+        }
+        LayerBuffer {
+            pixels,
+            width: 7,
+            height: 6,
+            origin: [0.0, 0.0],
+        }
+    }
+
+    fn legacy_wavelength_refraction_offset(
+        surface_normal: [f32; 3],
+        refraction: f32,
+        dispersion: f32,
+        refractive_index: f32,
+        optics: OpticalCalibration,
+    ) -> [f32; 2] {
+        let reference_ray = refracted_screen_slope(surface_normal, optics.reference_index);
+        let wavelength_ray = refracted_screen_slope(surface_normal, refractive_index);
+        add2(
+            mul2(reference_ray, refraction * optics.projection_scale),
+            mul2(
+                sub2(wavelength_ray, reference_ray),
+                dispersion * optics.dispersion_scale,
+            ),
+        )
+    }
+
+    fn legacy_spectral_refraction(
+        x: f32,
+        y: f32,
+        normal: [f32; 3],
+        source: &LayerBuffer,
+        settings: Settings,
+        optics: OpticalCalibration,
+        spectral_bands: &[SpectralBand],
+    ) -> ([f32; 3], f32) {
+        let mut rgb_sum = [0.0_f32; 3];
+        let mut rgb_weight = [0.0_f32; 3];
+        let mut alpha_sum = 0.0_f32;
+        let mut alpha_weight = 0.0_f32;
+        for band in spectral_bands {
+            let offset = legacy_wavelength_refraction_offset(
+                normal,
+                settings.refraction,
+                settings.dispersion,
+                band.refractive_index,
+                optics,
+            );
+            let sample = displaced_sample(source, x, y, offset, settings);
+            let rgb = unpremultiplied_rgb(sample);
+            for channel in 0..3 {
+                rgb_sum[channel] += rgb[channel] * band.rgb_response[channel];
+                rgb_weight[channel] += band.rgb_response[channel];
+            }
+            alpha_sum += sample.alpha.clamp(0.0, 1.0) * band.luminance_response;
+            alpha_weight += band.luminance_response;
+        }
+        (
+            [
+                rgb_sum[0] / rgb_weight[0].max(1.0e-8),
+                rgb_sum[1] / rgb_weight[1].max(1.0e-8),
+                rgb_sum[2] / rgb_weight[2].max(1.0e-8),
+            ],
+            alpha_sum / alpha_weight.max(1.0e-8),
+        )
+    }
+
+    #[test]
+    fn shared_reference_ray_preserves_legacy_spectral_result_bitwise() {
+        let settings = test_settings(4.75);
+        let optics = OpticalCalibration::bk7();
+        let bands = build_spectral_bands(settings, optics);
+        let source = test_source();
+        for slope in [[-1.25, 0.4], [0.0, 0.0], [0.35, -2.0]] {
+            let normal = surface_normal(slope);
+            let expected =
+                legacy_spectral_refraction(3.125, 2.75, normal, &source, settings, optics, &bands);
+            let actual =
+                spectral_refraction(3.125, 2.75, normal, &source, settings, optics, &bands);
+            for channel in 0..3 {
+                assert_eq!(actual.0[channel].to_bits(), expected.0[channel].to_bits());
+            }
+            assert_eq!(actual.1.to_bits(), expected.1.to_bits());
+        }
+    }
+
+    #[test]
+    fn spectral_refraction_computes_reference_ray_once_per_pixel() {
+        let settings = test_settings(4.75);
+        let optics = OpticalCalibration::bk7();
+        let bands = build_spectral_bands(settings, optics);
+        let source = test_source();
+        let normal = surface_normal([-0.75, 0.25]);
+
+        REFRACTED_SCREEN_SLOPE_CALLS.with(|calls| calls.set(0));
+        let _ = spectral_refraction(3.0, 2.0, normal, &source, settings, optics, &bands);
+        REFRACTED_SCREEN_SLOPE_CALLS.with(|calls| assert_eq!(calls.get(), bands.len() + 1));
+
+        REFRACTED_SCREEN_SLOPE_CALLS.with(|calls| calls.set(0));
+        let _ = legacy_spectral_refraction(3.0, 2.0, normal, &source, settings, optics, &bands);
+        REFRACTED_SCREEN_SLOPE_CALLS.with(|calls| assert_eq!(calls.get(), bands.len() * 2));
+    }
+
+    #[test]
+    fn debug_views_only_prepare_optical_work_they_use() {
+        for (view, expects_optics, expected_bands, expected_ray_calls) in [
+            (DebugView::Final, true, 8, 2),
+            (DebugView::Height, false, 0, 0),
+            (DebugView::Normal, false, 0, 0),
+            (DebugView::Displacement, true, 0, 2),
+            (DebugView::FacetId, false, 0, 0),
+        ] {
+            let mut settings = test_settings(4.75);
+            settings.debug = view;
+            REFRACTED_SCREEN_SLOPE_CALLS.with(|calls| calls.set(0));
+            let (optics, bands) = prepare_render_optics(settings);
+            assert_eq!(optics.is_some(), expects_optics, "{view:?}");
+            assert_eq!(bands.len(), expected_bands, "{view:?}");
+            REFRACTED_SCREEN_SLOPE_CALLS
+                .with(|calls| assert_eq!(calls.get(), expected_ray_calls, "{view:?}"));
+        }
+    }
 
     #[test]
     fn scaled_coordinates_preserve_endpoints() {

--- a/plugins/image-encrypt-decrypt/Cargo.toml
+++ b/plugins/image-encrypt-decrypt/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "image_crypt"
+description = "Applies reversible image-domain permutations, ciphers, and resilient visual encoding."
+version = "0.2.0"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib"]
+
+[features]
+default = []
+catch-panics = []
+
+[dependencies]
+after-effects = { workspace = true }
+utils = { path = "../../crates/utils" }
+
+
+[dev-dependencies]
+pipl = { workspace = true }
+
+[build-dependencies]
+chrono.workspace = true
+pipl.workspace = true
+winres = "0.1.12"
+
+[lints]
+workspace = true

--- a/plugins/image-encrypt-decrypt/Justfile
+++ b/plugins/image-encrypt-decrypt/Justfile
@@ -1,0 +1,12 @@
+# Read package.name from Cargo.toml for build naming.
+CrateName := if os() == "windows" {
+    `$inPackage = $false; foreach ($line in Get-Content -Path Cargo.toml) { if ($line -match '^\s*\[package\]\s*$') { $inPackage = $true; continue }; if ($line -match '^\s*\[.+\]\s*$') { if ($inPackage) { break } }; if ($inPackage -and $line -match '^\s*name\s*=\s*"([^"]+)"') { $matches[1]; break } }`
+} else {
+    `awk -F'"' 'BEGIN{in_pkg=0} /^[[:space:]]*\[package\][[:space:]]*$/{in_pkg=1;next} /^[[:space:]]*\[/{if(in_pkg)exit} in_pkg && /^[[:space:]]*name[[:space:]]*=/ {print $2; exit}' Cargo.toml`
+}
+
+PluginName       := "AOD_ImageCrypt"
+BundleIdentifier := "com.aodaruma." + PluginName
+BinaryName       := snakecase(CrateName)
+
+import "../../AdobePlugin.just"

--- a/plugins/image-encrypt-decrypt/README.md
+++ b/plugins/image-encrypt-decrypt/README.md
@@ -1,0 +1,38 @@
+# image-crypt (AOD_ImageCrypt)
+
+Applies reversible image-domain permutations and channel transforms, plus a corruption-tolerant visual format.
+
+This After Effects effect provides deterministic visual encoding for motion-graphics and glitch workflows. It is not a cryptographic security product and must not be used to protect confidential information.
+
+## Algorithms
+
+- **Coordinate Shear** performs several keyed toroidal X/Y shears. Every pixel has a unique destination, and applying the inverse rounds restores the original coordinates.
+- **Block Permutation** applies the same invertible construction to a grid of complete square tiles. Pixels inside a tile are not changed; incomplete right and bottom edge tiles remain in place.
+- **Affine Channel Cipher** quantizes RGB or RGBA and applies a keyed affine permutation modulo the selected precision. Adjacent channels are coupled during each round, so a small channel change produces a visibly different encoded value.
+- **Combined Legacy** composes Coordinate Shear, Block Permutation, and Affine Channel Cipher. Its popup index and behavior remain unchanged for projects created with version 0.1.0.
+- **Linear Interleave** flattens the raster and applies keyed affine permutations whose multipliers are selected to be coprime with the exact pixel count. This scatters pixels across scanlines and remains reversible for arbitrary dimensions.
+- **Bit-Plane Cipher** XORs keyed masks into quantized channel bit planes and rotates those planes independently. Decode reverses the rotation and mask in reverse round order.
+- **Interleave + Bit-Plane** combines Linear Interleave with Bit-Plane Cipher.
+- **Resilient Replicas (Lossy)** samples a lower-resolution logical raster, stores several encrypted copies of every logical pixel, and scatters the copies with Linear Interleave. Decode decrypts all available copies and takes a per-channel median. Limited edited or damaged pixels can therefore be ignored when intact copies remain in the majority.
+
+## Matching Encode and Decode
+
+Set **Operation** to Encode for the first instance and Decode for the matching second instance. The algorithm, four key words, rounds, algorithm-specific controls, frame dimensions, and host bit depth must match.
+
+The exact reversible algorithms require an unchanged encoded buffer between the two instances: resizing, resampling, cropping, color conversion, lossy rendering, or pixel edits can prevent exact restoration. Channel algorithms quantize floating-point input by design. A 16-bpc integer AE world uses 15 cipher bits for Bit-Plane modes so every intermediate bit pattern remains representable; floating-point worlds can use all 16 selected bits.
+
+## Resilient Replicas
+
+**Recovery Redundancy** requests 1 to 15 spatial copies. Larger values tolerate more damaged copies but reduce the logical image resolution. **Recovery Interleave** controls how many keyed scattering passes separate replicas; zero keeps the replica slots in scan order.
+
+The encoded image has the same frame dimensions, so error correction cannot add capacity without discarding some spatial detail. Resilient Replicas makes that trade explicitly: it reconstructs a nearest-neighbor version of the lower-resolution logical raster rather than the exact full-resolution source. With an odd group of `n` intact-format replicas, median decoding tolerates up to `(n - 1) / 2` arbitrary corrupted copies for that logical pixel. It is intended for isolated pixel edits and local scratches, not geometry changes, cropping, or broad color processing.
+
+The parameter panel dynamically shows Block Size, precision/channel controls, and recovery controls only for algorithms that use them.
+
+## Name Compatibility
+
+The display name and installed binary were shortened from `AOD_ImageEncryptDecrypt` to `AOD_ImageCrypt`. The internal After Effects match name intentionally remains `ImageEncryptDecrypt`, so existing projects continue to resolve the effect. The old `AOD_ImageEncryptDecrypt.aex` must be removed when installing `AOD_ImageCrypt.aex`; loading both binaries would register the same internal effect twice.
+
+## Building the Plugin
+
+See the [main README](../../README.md) for instructions on how to build the plugin.

--- a/plugins/image-encrypt-decrypt/build.rs
+++ b/plugins/image-encrypt-decrypt/build.rs
@@ -1,0 +1,97 @@
+use chrono::Datelike;
+use pipl::*;
+
+const PF_PLUG_IN_VERSION: u16 = 13;
+const PF_PLUG_IN_SUBVERS: u16 = 28;
+
+#[cfg(target_os = "windows")]
+fn embed_binary_safe_pipl(pipl: &[u8]) {
+    // `pipl` 0.1.1 embeds arbitrary bytes as RC text on Windows. A raw file
+    // resource prevents rc.exe from changing bytes above 0x7f.
+    let out_dir = std::path::PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR is set"));
+    let pipl_path = out_dir.join("image_crypt.pipl");
+    std::fs::write(&pipl_path, pipl).expect("write binary PiPL resource");
+
+    let escaped_path = pipl_path.to_string_lossy().replace('\\', "\\\\");
+    let mut resource = winres::WindowsResource::new();
+    resource.append_rc_content(&format!("16000 PiPL DISCARDABLE \"{escaped_path}\""));
+    resource.compile().expect("compile binary PiPL resource");
+}
+
+#[rustfmt::skip]
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(does_dialog)");
+    println!("cargo::rustc-check-cfg=cfg(threaded_rendering)");
+
+    let current_year = chrono::Local::now().year();
+    println!("cargo:rustc-env=BUILD_YEAR={}", current_year);
+
+    let pkg_version = env!("CARGO_PKG_VERSION");
+    let version_parts: Vec<&str> = pkg_version.split('.').collect();
+    if version_parts.len() != 3 {
+        panic!("CARGO_PKG_VERSION must be in the format 'major.minor.patch'");
+    }
+    let major: u32 = version_parts[0].parse().expect("Invalid major version");
+    let minor: u32 = version_parts[1].parse().expect("Invalid minor version");
+    let patch: u32 = version_parts[2].parse().expect("Invalid patch version");
+
+    // Determine the stage based on building whether debug or release
+    /*
+    // pipl load error occured when stage = Stage::Release in pipl == v0.1.1, so temporarily fixed to Develop
+    let stage = if cfg!(debug_assertions) {
+        Stage::Develop
+    } else {
+        Stage::Release
+    };
+    */
+    let stage = Stage::Develop;
+
+    let properties = || vec![
+        Property::Kind(PIPLType::AEEffect),
+        Property::Name("AOD_ImageCrypt"),
+        Property::Category("Aodaruma"),
+
+        #[cfg(target_os = "windows")]
+        Property::CodeWin64X86("EffectMain"),
+        #[cfg(target_os = "macos")]
+        Property::CodeMacIntel64("EffectMain"),
+        #[cfg(target_os = "macos")]
+        Property::CodeMacARM64("EffectMain"),
+
+        Property::AE_PiPL_Version { major: 2, minor: 0 },
+        Property::AE_Effect_Spec_Version { major: PF_PLUG_IN_VERSION, minor: PF_PLUG_IN_SUBVERS },
+        Property::AE_Effect_Version {
+            version: major,
+            subversion: minor,
+            bugversion: patch,
+            stage,
+            build: 1,
+        },
+        Property::AE_Effect_Info_Flags(0),
+        Property::AE_Effect_Global_OutFlags(
+            // set up from https://docs.rs/pipl/latest/pipl/struct.OutFlags.html
+            OutFlags::DeepColorAware
+            | OutFlags::SendUpdateParamsUI
+            ,
+        ),
+        Property::AE_Effect_Global_OutFlags_2(
+            // set up from https://docs.rs/pipl/latest/pipl/struct.OutFlags2.html
+            OutFlags2::FloatColorAware
+            | OutFlags2::SupportsSmartRender
+            | OutFlags2::RevealsZeroAlpha
+            // | OutFlags2::SupportsGpuRenderF32
+            ,
+        ),
+        // Keep the original internal identity so existing AE projects reopen
+        // against the shorter display/binary name without a missing effect.
+        Property::AE_Effect_Match_Name("ImageEncryptDecrypt"),
+        Property::AE_Reserved_Info(8),
+        Property::AE_Effect_Support_URL("https://github.com/Aodaruma/aod-AE-plugin"),
+    ];
+
+    // Keep the pipl crate's environment variables, but replace its text RC
+    // resource with a byte-for-byte PiPL resource on Windows.
+    pipl::plugin_build(properties());
+    #[cfg(target_os = "windows")]
+    embed_binary_safe_pipl(&pipl::build_pipl(properties()).expect("build PiPL"));
+}

--- a/plugins/image-encrypt-decrypt/src/lib.rs
+++ b/plugins/image-encrypt-decrypt/src/lib.rs
@@ -1,0 +1,1826 @@
+#![allow(clippy::drop_non_drop, clippy::question_mark)]
+
+use after_effects as ae;
+use std::env;
+
+use ae::pf::*;
+use utils::image::{TRANSPARENT, finite_or, read_layer};
+
+const COORDINATE_SALT: u64 = 0x3f84_d5b5_b547_0917;
+const BLOCK_SALT: u64 = 0x9216_d5d9_8979_fb1b;
+const CHANNEL_SALT: u64 = 0xd1b5_4a32_d192_ed03;
+const LINEAR_SALT: u64 = 0x6a09_e667_f3bc_c909;
+const BIT_PLANE_SALT: u64 = 0xbb67_ae85_84ca_a73b;
+const RECOVERY_SALT: u64 = 0x3c6e_f372_fe94_f82b;
+const MAX_REDUNDANCY: usize = 15;
+const MAX_RECOVERY_SAMPLES: usize = MAX_REDUNDANCY * 2 + 2;
+
+#[derive(Eq, PartialEq, Hash, Clone, Copy, Debug)]
+enum Params {
+    Operation,
+    Algorithm,
+    KeyA,
+    KeyB,
+    KeyC,
+    KeyD,
+    Rounds,
+    BlockSize,
+    Precision,
+    Channels,
+    // Appended after the 0.1.0 layout to preserve all existing parameter IDs.
+    RecoveryRedundancy,
+    RecoveryInterleave,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Operation {
+    Encode,
+    Decode,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Algorithm {
+    Coordinate,
+    Blocks,
+    Channels,
+    Combined,
+    LinearInterleave,
+    BitPlane,
+    InterleaveBitPlane,
+    ResilientReplicas,
+}
+
+impl Algorithm {
+    fn uses_blocks(self) -> bool {
+        matches!(self, Self::Blocks | Self::Combined)
+    }
+
+    fn uses_affine_cipher(self) -> bool {
+        matches!(self, Self::Channels | Self::Combined)
+    }
+
+    fn uses_bit_plane_cipher(self) -> bool {
+        matches!(self, Self::BitPlane | Self::InterleaveBitPlane)
+    }
+
+    fn uses_quantization(self) -> bool {
+        self.uses_affine_cipher()
+            || self.uses_bit_plane_cipher()
+            || matches!(self, Self::ResilientReplicas)
+    }
+
+    fn uses_recovery(self) -> bool {
+        matches!(self, Self::ResilientReplicas)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Precision {
+    Auto,
+    Bpc8,
+    Bpc16,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Channels {
+    Rgb,
+    Rgba,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Settings {
+    operation: Operation,
+    algorithm: Algorithm,
+    key: u64,
+    rounds: usize,
+    block_size: usize,
+    precision: Precision,
+    channels: Channels,
+    recovery_redundancy: usize,
+    recovery_interleave: usize,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct ResilientLayout {
+    physical_len: usize,
+    logical_width: usize,
+    logical_height: usize,
+    logical_len: usize,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct RenderLayout {
+    input_rect: Option<ae::Rect>,
+    output_rect: Option<ae::Rect>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct BufferBounds {
+    origin_x: i64,
+    origin_y: i64,
+    width: usize,
+    height: usize,
+}
+
+impl BufferBounds {
+    const fn new(origin: (i64, i64), width: usize, height: usize) -> Self {
+        Self {
+            origin_x: origin.0,
+            origin_y: origin.1,
+            width,
+            height,
+        }
+    }
+
+    fn layer_coordinate(self, local_x: usize, local_y: usize) -> (i64, i64) {
+        (
+            self.origin_x + local_x as i64,
+            self.origin_y + local_y as i64,
+        )
+    }
+
+    fn local_coordinate(self, layer_x: i64, layer_y: i64) -> Option<(usize, usize)> {
+        let local_x = layer_x.checked_sub(self.origin_x)?;
+        let local_y = layer_y.checked_sub(self.origin_y)?;
+        if local_x < 0
+            || local_y < 0
+            || local_x >= self.width as i64
+            || local_y >= self.height as i64
+        {
+            return None;
+        }
+        Some((local_x as usize, local_y as usize))
+    }
+}
+
+#[derive(Default)]
+struct Plugin {
+    aegp_id: Option<ae::aegp::PluginId>,
+}
+
+ae::define_effect!(Plugin, (), Params);
+
+const PLUGIN_DESCRIPTION: &str =
+    "Applies reversible permutations and ciphers, plus a corruption-tolerant visual format.";
+
+impl AdobePluginGlobal for Plugin {
+    fn params_setup(
+        &self,
+        params: &mut ae::Parameters<Params>,
+        _in_data: InData,
+        _: OutData,
+    ) -> Result<(), Error> {
+        params.add(
+            Params::Operation,
+            "Operation",
+            PopupDef::setup(|d| {
+                d.set_options(&["Encode", "Decode"]);
+                d.set_default(1);
+            }),
+        )?;
+
+        params.add_with_flags(
+            Params::Algorithm,
+            "Algorithm",
+            PopupDef::setup(|d| {
+                d.set_options(&[
+                    "Coordinate Shear",
+                    "Block Permutation",
+                    "Affine Channel Cipher",
+                    "Combined Legacy",
+                    "Linear Interleave",
+                    "Bit-Plane Cipher",
+                    "Interleave + Bit-Plane",
+                    "Resilient Replicas (Lossy)",
+                ]);
+                d.set_default(1);
+            }),
+            ae::ParamFlag::SUPERVISE | ae::ParamFlag::CANNOT_TIME_VARY,
+            ae::ParamUIFlags::empty(),
+        )?;
+
+        for (id, name, default) in [
+            (Params::KeyA, "Key A", 0x1357),
+            (Params::KeyB, "Key B", 0x2468),
+            (Params::KeyC, "Key C", 0x9abc),
+            (Params::KeyD, "Key D", 0xdef0),
+        ] {
+            params.add(
+                id,
+                name,
+                SliderDef::setup(|d| {
+                    d.set_valid_min(0);
+                    d.set_valid_max(65_535);
+                    d.set_slider_min(0);
+                    d.set_slider_max(65_535);
+                    d.set_default(default);
+                }),
+            )?;
+        }
+
+        params.add(
+            Params::Rounds,
+            "Rounds",
+            SliderDef::setup(|d| {
+                d.set_valid_min(1);
+                d.set_valid_max(16);
+                d.set_slider_min(1);
+                d.set_slider_max(16);
+                d.set_default(5);
+            }),
+        )?;
+
+        params.add(
+            Params::BlockSize,
+            "Block Size (px)",
+            SliderDef::setup(|d| {
+                d.set_valid_min(2);
+                d.set_valid_max(512);
+                d.set_slider_min(2);
+                d.set_slider_max(128);
+                d.set_default(16);
+            }),
+        )?;
+
+        params.add(
+            Params::Precision,
+            "Cipher Precision",
+            PopupDef::setup(|d| {
+                d.set_options(&["Auto", "8 bpc", "16 bpc"]);
+                d.set_default(1);
+            }),
+        )?;
+
+        params.add(
+            Params::Channels,
+            "Channels",
+            PopupDef::setup(|d| {
+                d.set_options(&["RGB", "RGBA"]);
+                d.set_default(1);
+            }),
+        )?;
+
+        params.add(
+            Params::RecoveryRedundancy,
+            "Recovery Redundancy",
+            SliderDef::setup(|d| {
+                d.set_valid_min(1);
+                d.set_valid_max(MAX_REDUNDANCY as i32);
+                d.set_slider_min(1);
+                d.set_slider_max(MAX_REDUNDANCY as i32);
+                d.set_default(5);
+            }),
+        )?;
+
+        params.add(
+            Params::RecoveryInterleave,
+            "Recovery Interleave",
+            SliderDef::setup(|d| {
+                d.set_valid_min(0);
+                d.set_valid_max(16);
+                d.set_slider_min(0);
+                d.set_slider_max(16);
+                d.set_default(4);
+            }),
+        )?;
+
+        Ok(())
+    }
+
+    fn handle_command(
+        &mut self,
+        cmd: ae::Command,
+        in_data: InData,
+        mut out_data: OutData,
+        params: &mut ae::Parameters<Params>,
+    ) -> Result<(), ae::Error> {
+        match cmd {
+            ae::Command::About => {
+                out_data.set_return_msg(
+                    format!(
+                        "AOD_ImageCrypt - {version}\r\r{PLUGIN_DESCRIPTION}\rCopyright (c) 2026-{build_year} Aodaruma",
+                        version = env!("CARGO_PKG_VERSION"),
+                        build_year = env!("BUILD_YEAR")
+                    )
+                    .as_str(),
+                );
+            }
+            ae::Command::GlobalSetup => {
+                out_data.set_out_flag(OutFlags::DeepColorAware, true);
+                out_data.set_out_flag(OutFlags::SendUpdateParamsUi, true);
+                out_data.set_out_flag2(OutFlags2::FloatColorAware, true);
+                out_data.set_out_flag2(OutFlags2::SupportsSmartRender, true);
+                out_data.set_out_flag2(OutFlags2::RevealsZeroAlpha, true);
+                if let Ok(suite) = ae::aegp::suites::Utility::new()
+                    && let Ok(plugin_id) = suite.register_with_aegp("AOD_ImageCrypt")
+                {
+                    self.aegp_id = Some(plugin_id);
+                }
+            }
+            ae::Command::Render {
+                in_layer,
+                out_layer,
+            } => self.do_render(
+                in_data,
+                in_layer,
+                out_layer,
+                params,
+                RenderLayout::default(),
+            )?,
+            ae::Command::SmartPreRender { mut extra } => {
+                let mut request = extra.output_request();
+                request.preserve_rgb_of_zero_alpha = 1;
+                let callbacks = extra.callbacks();
+                let query = callbacks.checkout_layer(
+                    0,
+                    1000,
+                    &request,
+                    in_data.current_time(),
+                    in_data.time_step(),
+                    in_data.time_scale(),
+                )?;
+                let mut full_request = request;
+                full_request.rect = query.max_result_rect;
+                let input = callbacks.checkout_layer(
+                    0,
+                    0,
+                    &full_request,
+                    in_data.current_time(),
+                    in_data.time_step(),
+                    in_data.time_scale(),
+                )?;
+                let full_rect: ae::Rect = input.max_result_rect.into();
+                let _ = extra.union_result_rect(full_rect);
+                let _ = extra.union_max_result_rect(full_rect);
+                extra.set_returns_extra_pixels(true);
+                extra.set_pre_render_data(RenderLayout {
+                    input_rect: Some(full_rect),
+                    output_rect: Some(full_rect),
+                });
+            }
+            ae::Command::SmartRender { extra } => {
+                let cb = extra.callbacks();
+                let layout = extra
+                    .pre_render_data::<RenderLayout>()
+                    .copied()
+                    .unwrap_or_default();
+                let in_layer = cb.checkout_layer_pixels(0)?;
+                let render_result: Result<(), Error> = (|| {
+                    let out_layer = cb.checkout_output()?;
+                    if let (Some(in_layer), Some(out_layer)) = (in_layer, out_layer) {
+                        self.do_render(in_data, in_layer, out_layer, params, layout)?;
+                    }
+                    Ok(())
+                })();
+                let checkin_result = cb.checkin_layer_pixels(0);
+                render_result?;
+                checkin_result?;
+            }
+            ae::Command::UserChangedParam { param_index } => {
+                if params.type_at(param_index) == Params::Algorithm {
+                    out_data.set_out_flag(OutFlags::RefreshUi, true);
+                }
+            }
+            ae::Command::UpdateParamsUi => {
+                let mut params_copy = params.cloned();
+                self.update_params_ui(in_data, &mut params_copy)?;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+}
+
+impl Plugin {
+    fn update_params_ui(
+        &self,
+        in_data: InData,
+        params: &mut Parameters<Params>,
+    ) -> Result<(), Error> {
+        let algorithm = algorithm_from_popup(params.get(Params::Algorithm)?.as_popup()?.value());
+        self.set_param_visible(in_data, params, Params::BlockSize, algorithm.uses_blocks())?;
+        for id in [Params::Precision, Params::Channels] {
+            self.set_param_visible(in_data, params, id, algorithm.uses_quantization())?;
+        }
+        for id in [Params::RecoveryRedundancy, Params::RecoveryInterleave] {
+            self.set_param_visible(in_data, params, id, algorithm.uses_recovery())?;
+        }
+        Ok(())
+    }
+
+    fn set_param_visible(
+        &self,
+        in_data: InData,
+        params: &mut Parameters<Params>,
+        id: Params,
+        visible: bool,
+    ) -> Result<(), Error> {
+        if in_data.is_premiere() {
+            return Self::set_param_ui_flag(params, id, ParamUIFlags::INVISIBLE, !visible);
+        }
+        if let Some(plugin_id) = self.aegp_id {
+            let effect = in_data.effect();
+            if let Some(index) = params.index(id)
+                && let Ok(effect_ref) = effect.aegp_effect(plugin_id)
+                && let Ok(stream) = effect_ref.new_stream_by_index(plugin_id, index as i32)
+            {
+                return stream.set_dynamic_stream_flag(
+                    ae::aegp::DynamicStreamFlags::Hidden,
+                    false,
+                    !visible,
+                );
+            }
+        }
+        Self::set_param_ui_flag(params, id, ParamUIFlags::INVISIBLE, !visible)
+    }
+
+    fn set_param_ui_flag(
+        params: &mut Parameters<Params>,
+        id: Params,
+        flag: ParamUIFlags,
+        status: bool,
+    ) -> Result<(), Error> {
+        let current = (params.get(id)?.ui_flags().bits() & flag.bits()) != 0;
+        if current == status {
+            return Ok(());
+        }
+        let mut param = params.get_mut(id)?;
+        param.set_ui_flag(flag, status);
+        param.update_param_ui()?;
+        Ok(())
+    }
+
+    fn read_settings(params: &mut Parameters<Params>) -> Result<Settings, Error> {
+        let words = [
+            params.get(Params::KeyA)?.as_slider()?.value(),
+            params.get(Params::KeyB)?.as_slider()?.value(),
+            params.get(Params::KeyC)?.as_slider()?.value(),
+            params.get(Params::KeyD)?.as_slider()?.value(),
+        ];
+        Ok(Settings {
+            operation: operation_from_popup(params.get(Params::Operation)?.as_popup()?.value()),
+            algorithm: algorithm_from_popup(params.get(Params::Algorithm)?.as_popup()?.value()),
+            key: key_from_words(words),
+            rounds: params
+                .get(Params::Rounds)?
+                .as_slider()?
+                .value()
+                .clamp(1, 16) as usize,
+            block_size: params
+                .get(Params::BlockSize)?
+                .as_slider()?
+                .value()
+                .clamp(2, 512) as usize,
+            precision: precision_from_popup(params.get(Params::Precision)?.as_popup()?.value()),
+            channels: channels_from_popup(params.get(Params::Channels)?.as_popup()?.value()),
+            recovery_redundancy: params
+                .get(Params::RecoveryRedundancy)?
+                .as_slider()?
+                .value()
+                .clamp(1, MAX_REDUNDANCY as i32) as usize,
+            recovery_interleave: params
+                .get(Params::RecoveryInterleave)?
+                .as_slider()?
+                .value()
+                .clamp(0, 16) as usize,
+        })
+    }
+
+    fn do_render(
+        &self,
+        in_data: InData,
+        in_layer: Layer,
+        mut out_layer: Layer,
+        params: &mut Parameters<Params>,
+        layout: RenderLayout,
+    ) -> Result<(), Error> {
+        let source_width = in_layer.width();
+        let source_height = in_layer.height();
+        let output_width = out_layer.width();
+        let output_height = out_layer.height();
+        if source_width == 0 || source_height == 0 || output_width == 0 || output_height == 0 {
+            return Ok(());
+        }
+
+        let settings = Self::read_settings(params)?;
+        let source = read_layer(&in_layer);
+        let out_world_type = out_layer.world_type();
+        let modulus = cipher_modulus(settings.precision, out_world_type);
+        let bit_precision = bit_precision_bits(settings.precision, out_world_type);
+        let (source_bounds, output_bounds) =
+            render_buffer_bounds(in_data, &in_layer, &out_layer, layout);
+        let active_channels = if matches!(settings.channels, Channels::Rgba) {
+            4
+        } else {
+            3
+        };
+
+        out_layer.iterate(0, output_height as i32, None, |x, y, mut destination| {
+            let layer_coordinate = output_bounds.layer_coordinate(x as usize, y as usize);
+            let Some(output_coord) =
+                source_bounds.local_coordinate(layer_coordinate.0, layer_coordinate.1)
+            else {
+                write_pixel(&mut destination, out_world_type, TRANSPARENT);
+                return Ok(());
+            };
+
+            if settings.algorithm.uses_recovery() {
+                let pixel = match settings.operation {
+                    Operation::Encode => resilient_encode_pixel(
+                        &source,
+                        source_width,
+                        source_height,
+                        output_coord,
+                        settings,
+                        modulus,
+                        active_channels,
+                    ),
+                    Operation::Decode => resilient_decode_pixel(
+                        &source,
+                        source_width,
+                        source_height,
+                        output_coord,
+                        settings,
+                        modulus,
+                        active_channels,
+                    ),
+                };
+                write_pixel(&mut destination, out_world_type, pixel);
+                return Ok(());
+            }
+
+            let source_coord = match settings.operation {
+                Operation::Encode => map_inverse(
+                    output_coord,
+                    source_width,
+                    source_height,
+                    settings.algorithm,
+                    settings.block_size,
+                    settings.key,
+                    settings.rounds,
+                ),
+                Operation::Decode => map_forward(
+                    output_coord,
+                    source_width,
+                    source_height,
+                    settings.algorithm,
+                    settings.block_size,
+                    settings.key,
+                    settings.rounds,
+                ),
+            };
+            let mut pixel = source[source_coord.1 * source_width + source_coord.0];
+
+            if settings.algorithm.uses_affine_cipher() {
+                let cipher_coord = match settings.operation {
+                    Operation::Encode => output_coord,
+                    Operation::Decode => source_coord,
+                };
+                pixel = cipher_pixel(
+                    pixel,
+                    settings.operation,
+                    cipher_coord,
+                    settings.key,
+                    settings.rounds,
+                    modulus,
+                    active_channels,
+                );
+            } else if settings.algorithm.uses_bit_plane_cipher() {
+                let cipher_coord = match settings.operation {
+                    Operation::Encode => output_coord,
+                    Operation::Decode => source_coord,
+                };
+                pixel = bit_plane_cipher_pixel(
+                    pixel,
+                    settings.operation,
+                    cipher_coord,
+                    settings.key,
+                    settings.rounds,
+                    bit_precision,
+                    active_channels,
+                );
+            }
+
+            write_pixel(&mut destination, out_world_type, pixel);
+            Ok(())
+        })?;
+
+        Ok(())
+    }
+}
+
+fn render_buffer_bounds(
+    in_data: InData,
+    in_layer: &Layer,
+    out_layer: &Layer,
+    layout: RenderLayout,
+) -> (BufferBounds, BufferBounds) {
+    let pre_effect_origin = in_data.pre_effect_source_origin();
+    let source_fallback = (-(pre_effect_origin.h as i64), -(pre_effect_origin.v as i64));
+    let source_origin = layer_buffer_origin(in_layer, layout.input_rect, source_fallback);
+
+    // output_origin is the position of input buffer (0, 0) inside the output
+    // buffer. Therefore the output buffer's layer-space top-left is shifted in
+    // the opposite direction.
+    let output_shift = in_data.output_origin();
+    let output_fallback = (
+        source_origin.0 - output_shift.h as i64,
+        source_origin.1 - output_shift.v as i64,
+    );
+    let output_origin = layer_buffer_origin(out_layer, layout.output_rect, output_fallback);
+
+    (
+        BufferBounds::new(source_origin, in_layer.width(), in_layer.height()),
+        BufferBounds::new(output_origin, out_layer.width(), out_layer.height()),
+    )
+}
+
+fn layer_buffer_origin(
+    layer: &Layer,
+    requested_rect: Option<ae::Rect>,
+    fallback: (i64, i64),
+) -> (i64, i64) {
+    let native = layer.origin();
+    if native.h != 0 || native.v != 0 {
+        return (native.h as i64, native.v as i64);
+    }
+    if let Some(rect) = requested_rect
+        && rect.width() == layer.width() as i32
+        && rect.height() == layer.height() as i32
+    {
+        return (rect.left as i64, rect.top as i64);
+    }
+    fallback
+}
+
+fn operation_from_popup(value: i32) -> Operation {
+    if value == 2 {
+        Operation::Decode
+    } else {
+        Operation::Encode
+    }
+}
+
+fn algorithm_from_popup(value: i32) -> Algorithm {
+    match value {
+        2 => Algorithm::Blocks,
+        3 => Algorithm::Channels,
+        4 => Algorithm::Combined,
+        5 => Algorithm::LinearInterleave,
+        6 => Algorithm::BitPlane,
+        7 => Algorithm::InterleaveBitPlane,
+        8 => Algorithm::ResilientReplicas,
+        _ => Algorithm::Coordinate,
+    }
+}
+
+fn precision_from_popup(value: i32) -> Precision {
+    match value {
+        2 => Precision::Bpc8,
+        3 => Precision::Bpc16,
+        _ => Precision::Auto,
+    }
+}
+
+fn channels_from_popup(value: i32) -> Channels {
+    if value == 2 {
+        Channels::Rgba
+    } else {
+        Channels::Rgb
+    }
+}
+
+fn key_from_words(words: [i32; 4]) -> u64 {
+    words.into_iter().enumerate().fold(0_u64, |key, (i, word)| {
+        key | ((word.clamp(0, 65_535) as u64) << (i * 16))
+    })
+}
+
+fn map_forward(
+    coord: (usize, usize),
+    width: usize,
+    height: usize,
+    algorithm: Algorithm,
+    block_size: usize,
+    key: u64,
+    rounds: usize,
+) -> (usize, usize) {
+    match algorithm {
+        Algorithm::Coordinate => {
+            coordinate_forward(coord, width, height, key, rounds, COORDINATE_SALT)
+        }
+        Algorithm::Blocks => block_forward(coord, width, height, block_size, key, rounds),
+        Algorithm::Channels => coord,
+        Algorithm::Combined => {
+            let coord = coordinate_forward(coord, width, height, key, rounds, COORDINATE_SALT);
+            block_forward(coord, width, height, block_size, key, rounds)
+        }
+        Algorithm::LinearInterleave | Algorithm::InterleaveBitPlane => {
+            linear_coordinate_forward(coord, width, height, key, rounds)
+        }
+        Algorithm::BitPlane | Algorithm::ResilientReplicas => coord,
+    }
+}
+
+fn map_inverse(
+    coord: (usize, usize),
+    width: usize,
+    height: usize,
+    algorithm: Algorithm,
+    block_size: usize,
+    key: u64,
+    rounds: usize,
+) -> (usize, usize) {
+    match algorithm {
+        Algorithm::Coordinate => {
+            coordinate_inverse(coord, width, height, key, rounds, COORDINATE_SALT)
+        }
+        Algorithm::Blocks => block_inverse(coord, width, height, block_size, key, rounds),
+        Algorithm::Channels => coord,
+        Algorithm::Combined => {
+            let coord = block_inverse(coord, width, height, block_size, key, rounds);
+            coordinate_inverse(coord, width, height, key, rounds, COORDINATE_SALT)
+        }
+        Algorithm::LinearInterleave | Algorithm::InterleaveBitPlane => {
+            linear_coordinate_inverse(coord, width, height, key, rounds)
+        }
+        Algorithm::BitPlane | Algorithm::ResilientReplicas => coord,
+    }
+}
+
+/// Permutes the flattened raster with keyed affine maps. Unlike the 2-D
+/// coordinate shear this deliberately crosses scanline boundaries, producing a
+/// long-range interleave while remaining exactly invertible for every frame
+/// dimension (including prime-sized buffers).
+fn linear_coordinate_forward(
+    coord: (usize, usize),
+    width: usize,
+    height: usize,
+    key: u64,
+    rounds: usize,
+) -> (usize, usize) {
+    let len = width.saturating_mul(height);
+    if width == 0 || height == 0 || len == 0 {
+        return (0, 0);
+    }
+    let index = linear_index_forward(coord.1 * width + coord.0, len, key, rounds, LINEAR_SALT);
+    (index % width, index / width)
+}
+
+fn linear_coordinate_inverse(
+    coord: (usize, usize),
+    width: usize,
+    height: usize,
+    key: u64,
+    rounds: usize,
+) -> (usize, usize) {
+    let len = width.saturating_mul(height);
+    if width == 0 || height == 0 || len == 0 {
+        return (0, 0);
+    }
+    let index = linear_index_inverse(coord.1 * width + coord.0, len, key, rounds, LINEAR_SALT);
+    (index % width, index / width)
+}
+
+fn linear_index_forward(mut index: usize, len: usize, key: u64, rounds: usize, salt: u64) -> usize {
+    if len <= 1 {
+        return 0;
+    }
+    for round in 0..rounds {
+        let (multiplier, offset) = linear_permutation_parameters(len, key, round, salt);
+        index = ((index as u128 * multiplier as u128 + offset as u128) % len as u128) as usize;
+    }
+    index
+}
+
+fn linear_index_inverse(mut index: usize, len: usize, key: u64, rounds: usize, salt: u64) -> usize {
+    if len <= 1 {
+        return 0;
+    }
+    for round in (0..rounds).rev() {
+        let (multiplier, offset) = linear_permutation_parameters(len, key, round, salt);
+        let shifted = (index + len - offset) % len;
+        let inverse = modular_inverse_usize(multiplier, len);
+        index = ((shifted as u128 * inverse as u128) % len as u128) as usize;
+    }
+    index
+}
+
+fn linear_permutation_parameters(len: usize, key: u64, round: usize, salt: u64) -> (usize, usize) {
+    let hash = mix64(key ^ salt ^ (round as u64).wrapping_mul(0xd6e8_feb8_6659_fd93));
+    let mut multiplier = (hash as usize) % len;
+    if multiplier == 0 {
+        multiplier = 1;
+    }
+    while greatest_common_divisor_usize(multiplier, len) != 1 {
+        multiplier += 1;
+        if multiplier >= len {
+            multiplier = 1;
+        }
+    }
+    let offset = (mix64(hash ^ 0xa076_1d64_78bd_642f) as usize) % len;
+    (multiplier, offset)
+}
+
+fn modular_inverse_usize(value: usize, modulus: usize) -> usize {
+    let (mut old_r, mut r) = (value as i128, modulus as i128);
+    let (mut old_s, mut s) = (1_i128, 0_i128);
+    while r != 0 {
+        let quotient = old_r / r;
+        (old_r, r) = (r, old_r - quotient * r);
+        (old_s, s) = (s, old_s - quotient * s);
+    }
+    old_s.rem_euclid(modulus as i128) as usize
+}
+
+fn greatest_common_divisor_usize(mut a: usize, mut b: usize) -> usize {
+    while b != 0 {
+        (a, b) = (b, a % b);
+    }
+    a
+}
+
+fn coordinate_forward(
+    mut coord: (usize, usize),
+    width: usize,
+    height: usize,
+    key: u64,
+    rounds: usize,
+    salt: u64,
+) -> (usize, usize) {
+    if width == 0 || height == 0 {
+        return (0, 0);
+    }
+    for round in 0..rounds {
+        let (ax, ay, bx, by) = shear_parameters(width, height, key, round, salt);
+        coord.0 = modular_sum(coord.0, ax, coord.1, bx, width);
+        coord.1 = modular_sum(coord.1, ay, coord.0, by, height);
+    }
+    coord
+}
+
+fn coordinate_inverse(
+    mut coord: (usize, usize),
+    width: usize,
+    height: usize,
+    key: u64,
+    rounds: usize,
+    salt: u64,
+) -> (usize, usize) {
+    if width == 0 || height == 0 {
+        return (0, 0);
+    }
+    for round in (0..rounds).rev() {
+        let (ax, ay, bx, by) = shear_parameters(width, height, key, round, salt);
+        coord.1 = modular_difference(coord.1, ay, coord.0, by, height);
+        coord.0 = modular_difference(coord.0, ax, coord.1, bx, width);
+    }
+    coord
+}
+
+fn block_forward(
+    coord: (usize, usize),
+    width: usize,
+    height: usize,
+    block_size: usize,
+    key: u64,
+    rounds: usize,
+) -> (usize, usize) {
+    block_map(
+        coord,
+        width,
+        height,
+        block_size,
+        |tile, tiles_x, tiles_y| {
+            coordinate_forward(tile, tiles_x, tiles_y, key, rounds, BLOCK_SALT)
+        },
+    )
+}
+
+fn block_inverse(
+    coord: (usize, usize),
+    width: usize,
+    height: usize,
+    block_size: usize,
+    key: u64,
+    rounds: usize,
+) -> (usize, usize) {
+    block_map(
+        coord,
+        width,
+        height,
+        block_size,
+        |tile, tiles_x, tiles_y| {
+            coordinate_inverse(tile, tiles_x, tiles_y, key, rounds, BLOCK_SALT)
+        },
+    )
+}
+
+fn block_map(
+    coord: (usize, usize),
+    width: usize,
+    height: usize,
+    block_size: usize,
+    transform: impl FnOnce((usize, usize), usize, usize) -> (usize, usize),
+) -> (usize, usize) {
+    let block_size = block_size.max(1);
+    let tiles_x = width / block_size;
+    let tiles_y = height / block_size;
+    let covered_width = tiles_x * block_size;
+    let covered_height = tiles_y * block_size;
+    if tiles_x == 0 || tiles_y == 0 || coord.0 >= covered_width || coord.1 >= covered_height {
+        return coord;
+    }
+    let local = (coord.0 % block_size, coord.1 % block_size);
+    let tile = (coord.0 / block_size, coord.1 / block_size);
+    let mapped = transform(tile, tiles_x, tiles_y);
+    (
+        mapped.0 * block_size + local.0,
+        mapped.1 * block_size + local.1,
+    )
+}
+
+fn shear_parameters(
+    width: usize,
+    height: usize,
+    key: u64,
+    round: usize,
+    salt: u64,
+) -> (usize, usize, usize, usize) {
+    let first = mix64(key ^ salt ^ (round as u64).wrapping_mul(0x9e37_79b9_7f4a_7c15));
+    let second = mix64(first ^ 0xa076_1d64_78bd_642f);
+    (
+        (first as usize) % width.max(1),
+        ((first >> 32) as usize) % height.max(1),
+        (second as usize) % width.max(1),
+        ((second >> 32) as usize) % height.max(1),
+    )
+}
+
+fn modular_sum(value: usize, factor: usize, other: usize, shift: usize, modulus: usize) -> usize {
+    if modulus == 0 {
+        return 0;
+    }
+    ((value as u128 + factor as u128 * other as u128 + shift as u128) % modulus as u128) as usize
+}
+
+fn modular_difference(
+    value: usize,
+    factor: usize,
+    other: usize,
+    shift: usize,
+    modulus: usize,
+) -> usize {
+    if modulus == 0 {
+        return 0;
+    }
+    let modulus = modulus as i128;
+    (value as i128 - factor as i128 * other as i128 - shift as i128).rem_euclid(modulus) as usize
+}
+
+fn cipher_modulus(precision: Precision, world_type: ae::aegp::WorldType) -> u32 {
+    match world_type {
+        ae::aegp::WorldType::U8 => ae::MAX_CHANNEL8 + 1,
+        ae::aegp::WorldType::U15 => match precision {
+            Precision::Bpc8 => ae::MAX_CHANNEL8 + 1,
+            Precision::Auto | Precision::Bpc16 => ae::MAX_CHANNEL16 + 1,
+        },
+        ae::aegp::WorldType::F32 | ae::aegp::WorldType::None => match precision {
+            Precision::Bpc8 => ae::MAX_CHANNEL8 + 1,
+            Precision::Auto | Precision::Bpc16 => ae::MAX_CHANNEL16 + 1,
+        },
+    }
+}
+
+fn bit_precision_bits(precision: Precision, world_type: ae::aegp::WorldType) -> u32 {
+    match world_type {
+        ae::aegp::WorldType::U8 => 8,
+        // AE's integer 16-bpc world uses a 0..32768 range. A 15-bit cipher
+        // therefore quantizes to 0..32767 so every rotated bit pattern remains
+        // representable and the transform stays bijective through host storage.
+        ae::aegp::WorldType::U15 => match precision {
+            Precision::Bpc8 => 8,
+            Precision::Auto | Precision::Bpc16 => 15,
+        },
+        ae::aegp::WorldType::F32 | ae::aegp::WorldType::None => match precision {
+            Precision::Bpc8 => 8,
+            Precision::Auto | Precision::Bpc16 => 16,
+        },
+    }
+}
+
+/// Rotates and masks the selected integer bit planes with a keyed stream. This
+/// differs from the affine channel cipher: no arithmetic carries cross bit
+/// planes, which creates a sharper digital/bit-plane look while remaining
+/// exactly reversible at the selected quantization precision.
+fn bit_plane_cipher_pixel(
+    pixel: ae::PixelF32,
+    operation: Operation,
+    coord: (usize, usize),
+    key: u64,
+    rounds: usize,
+    bits: u32,
+    active_channels: usize,
+) -> ae::PixelF32 {
+    let bits = bits.clamp(1, 16);
+    let maximum = (1_u32 << bits) - 1;
+    let mut values = [
+        quantize(pixel.red, maximum),
+        quantize(pixel.green, maximum),
+        quantize(pixel.blue, maximum),
+        quantize(pixel.alpha, maximum),
+    ];
+    for round in match operation {
+        Operation::Encode => EitherRounds::Forward(0..rounds),
+        Operation::Decode => EitherRounds::Reverse((0..rounds).rev()),
+    } {
+        for (channel, value) in values.iter_mut().enumerate().take(active_channels) {
+            let hash = bit_plane_hash(key, coord, round, channel);
+            let mask = hash as u32 & maximum;
+            let rotation = ((hash >> 32) as u32 % bits).max(1) % bits;
+            *value = match operation {
+                Operation::Encode => rotate_left_width(*value ^ mask, rotation, bits),
+                Operation::Decode => rotate_right_width(*value, rotation, bits) ^ mask,
+            };
+        }
+    }
+    ae::PixelF32 {
+        red: dequantize(values[0], maximum),
+        green: dequantize(values[1], maximum),
+        blue: dequantize(values[2], maximum),
+        alpha: if active_channels == 4 {
+            dequantize(values[3], maximum)
+        } else {
+            pixel.alpha
+        },
+    }
+}
+
+enum EitherRounds {
+    Forward(std::ops::Range<usize>),
+    Reverse(std::iter::Rev<std::ops::Range<usize>>),
+}
+
+impl Iterator for EitherRounds {
+    type Item = usize;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Forward(iter) => iter.next(),
+            Self::Reverse(iter) => iter.next(),
+        }
+    }
+}
+
+fn bit_plane_hash(key: u64, coord: (usize, usize), round: usize, channel: usize) -> u64 {
+    let position =
+        (coord.0 as u64).wrapping_mul(0x9e37_79b1_85eb_ca87) ^ (coord.1 as u64).rotate_left(29);
+    mix64(
+        key ^ BIT_PLANE_SALT
+            ^ position
+            ^ (round as u64).wrapping_mul(0xa5a3_564e_27f8_8671)
+            ^ (channel as u64).wrapping_mul(0xd6e8_feb8_6659_fd93),
+    )
+}
+
+fn rotate_left_width(value: u32, rotation: u32, bits: u32) -> u32 {
+    let mask = (1_u32 << bits) - 1;
+    if rotation == 0 {
+        return value & mask;
+    }
+    ((value << rotation) | (value >> (bits - rotation))) & mask
+}
+
+fn rotate_right_width(value: u32, rotation: u32, bits: u32) -> u32 {
+    let mask = (1_u32 << bits) - 1;
+    if rotation == 0 {
+        return value & mask;
+    }
+    ((value >> rotation) | (value << (bits - rotation))) & mask
+}
+
+/// Builds a lower-resolution logical raster whose samples are repeated across
+/// the full encoded frame. Interleaving scatters each repetition so a localized
+/// scratch or a handful of edited pixels are unlikely to damage the same
+/// logical sample. This necessarily trades spatial resolution for redundancy;
+/// lossless same-size error correction is impossible without spare capacity.
+fn resilient_layout(width: usize, height: usize, redundancy: usize) -> ResilientLayout {
+    let physical_len = width.saturating_mul(height).max(1);
+    let redundancy = redundancy.clamp(1, MAX_REDUNDANCY).min(physical_len);
+    if redundancy == 1 {
+        return ResilientLayout {
+            physical_len,
+            logical_width: width.max(1),
+            logical_height: height.max(1),
+            logical_len: physical_len,
+        };
+    }
+
+    let capacity = (physical_len / redundancy).max(1);
+    let aspect = width.max(1) as f64 / height.max(1) as f64;
+    let logical_width =
+        ((capacity as f64 * aspect).sqrt().floor() as usize).clamp(1, width.max(1).min(capacity));
+    let logical_height = (capacity / logical_width).clamp(1, height.max(1));
+    let logical_len = logical_width * logical_height;
+    ResilientLayout {
+        physical_len,
+        logical_width,
+        logical_height,
+        logical_len,
+    }
+}
+
+fn logical_coordinate(index: usize, layout: ResilientLayout) -> (usize, usize) {
+    (index % layout.logical_width, index / layout.logical_width)
+}
+
+fn logical_source_coordinate(
+    index: usize,
+    layout: ResilientLayout,
+    width: usize,
+    height: usize,
+) -> (usize, usize) {
+    let (x, y) = logical_coordinate(index, layout);
+    (
+        ((2 * x + 1) * width / (2 * layout.logical_width)).min(width - 1),
+        ((2 * y + 1) * height / (2 * layout.logical_height)).min(height - 1),
+    )
+}
+
+fn output_logical_index(
+    coord: (usize, usize),
+    layout: ResilientLayout,
+    width: usize,
+    height: usize,
+) -> usize {
+    let x = (coord.0 * layout.logical_width / width).min(layout.logical_width - 1);
+    let y = (coord.1 * layout.logical_height / height).min(layout.logical_height - 1);
+    y * layout.logical_width + x
+}
+
+fn resilient_encode_pixel(
+    source: &[ae::PixelF32],
+    width: usize,
+    height: usize,
+    destination_coord: (usize, usize),
+    settings: Settings,
+    modulus: u32,
+    active_channels: usize,
+) -> ae::PixelF32 {
+    let layout = resilient_layout(width, height, settings.recovery_redundancy);
+    let destination_index = destination_coord.1 * width + destination_coord.0;
+    let slot = linear_index_inverse(
+        destination_index,
+        layout.physical_len,
+        settings.key,
+        settings.recovery_interleave,
+        RECOVERY_SALT,
+    );
+    let logical_index = slot % layout.logical_len;
+    let source_coord = logical_source_coordinate(logical_index, layout, width, height);
+    cipher_pixel(
+        source[source_coord.1 * width + source_coord.0],
+        Operation::Encode,
+        logical_coordinate(logical_index, layout),
+        settings.key,
+        settings.rounds,
+        modulus,
+        active_channels,
+    )
+}
+
+fn resilient_decode_pixel(
+    source: &[ae::PixelF32],
+    width: usize,
+    height: usize,
+    destination_coord: (usize, usize),
+    settings: Settings,
+    modulus: u32,
+    active_channels: usize,
+) -> ae::PixelF32 {
+    let layout = resilient_layout(width, height, settings.recovery_redundancy);
+    let logical_index = output_logical_index(destination_coord, layout, width, height);
+    let logical_coord = logical_coordinate(logical_index, layout);
+    let mut samples = [TRANSPARENT; MAX_RECOVERY_SAMPLES];
+    let mut count = 0;
+    let mut slot = logical_index;
+    while slot < layout.physical_len && count < samples.len() {
+        let physical_index = linear_index_forward(
+            slot,
+            layout.physical_len,
+            settings.key,
+            settings.recovery_interleave,
+            RECOVERY_SALT,
+        );
+        samples[count] = cipher_pixel(
+            source[physical_index],
+            Operation::Decode,
+            logical_coord,
+            settings.key,
+            settings.rounds,
+            modulus,
+            active_channels,
+        );
+        count += 1;
+        slot += layout.logical_len;
+    }
+    debug_assert!(count > 0);
+    median_pixel(&samples[..count])
+}
+
+fn median_pixel(samples: &[ae::PixelF32]) -> ae::PixelF32 {
+    ae::PixelF32 {
+        red: median_channel(samples, |pixel| pixel.red),
+        green: median_channel(samples, |pixel| pixel.green),
+        blue: median_channel(samples, |pixel| pixel.blue),
+        alpha: median_channel(samples, |pixel| pixel.alpha),
+    }
+}
+
+fn median_channel(samples: &[ae::PixelF32], channel: impl Fn(ae::PixelF32) -> f32) -> f32 {
+    let mut values = [0.0_f32; MAX_RECOVERY_SAMPLES];
+    for (destination, sample) in values.iter_mut().zip(samples) {
+        *destination = finite_or(channel(*sample), 0.0);
+    }
+    let values = &mut values[..samples.len()];
+    values.sort_unstable_by(f32::total_cmp);
+    let middle = values.len() / 2;
+    if values.len() % 2 == 0 {
+        (values[middle - 1] + values[middle]) * 0.5
+    } else {
+        values[middle]
+    }
+}
+
+fn cipher_pixel(
+    pixel: ae::PixelF32,
+    operation: Operation,
+    coord: (usize, usize),
+    key: u64,
+    rounds: usize,
+    modulus: u32,
+    active_channels: usize,
+) -> ae::PixelF32 {
+    let max_value = modulus - 1;
+    let mut values = [
+        quantize(pixel.red, max_value),
+        quantize(pixel.green, max_value),
+        quantize(pixel.blue, max_value),
+        quantize(pixel.alpha, max_value),
+    ];
+    match operation {
+        Operation::Encode => {
+            channel_encode(&mut values, active_channels, modulus, key, coord, rounds)
+        }
+        Operation::Decode => {
+            channel_decode(&mut values, active_channels, modulus, key, coord, rounds)
+        }
+    }
+    ae::PixelF32 {
+        red: dequantize(values[0], max_value),
+        green: dequantize(values[1], max_value),
+        blue: dequantize(values[2], max_value),
+        alpha: if active_channels == 4 {
+            dequantize(values[3], max_value)
+        } else {
+            pixel.alpha
+        },
+    }
+}
+
+fn channel_encode(
+    values: &mut [u32; 4],
+    active_channels: usize,
+    modulus: u32,
+    key: u64,
+    coord: (usize, usize),
+    rounds: usize,
+) {
+    for round in 0..rounds {
+        for channel in 0..active_channels {
+            let value = if channel == 0 {
+                values[channel]
+            } else {
+                (values[channel] + values[channel - 1]) % modulus
+            };
+            let (multiplier, offset) = affine_parameters(key, coord, round, channel, modulus);
+            values[channel] = affine_encode(value, multiplier, offset, modulus);
+        }
+    }
+}
+
+fn channel_decode(
+    values: &mut [u32; 4],
+    active_channels: usize,
+    modulus: u32,
+    key: u64,
+    coord: (usize, usize),
+    rounds: usize,
+) {
+    for round in (0..rounds).rev() {
+        for channel in (0..active_channels).rev() {
+            let (multiplier, offset) = affine_parameters(key, coord, round, channel, modulus);
+            let value = affine_decode(values[channel], multiplier, offset, modulus);
+            values[channel] = if channel == 0 {
+                value
+            } else {
+                (value + modulus - values[channel - 1]) % modulus
+            };
+        }
+    }
+}
+
+fn affine_parameters(
+    key: u64,
+    coord: (usize, usize),
+    round: usize,
+    channel: usize,
+    modulus: u32,
+) -> (u32, u32) {
+    let position =
+        (coord.0 as u64).wrapping_mul(0x9e37_79b1_85eb_ca87) ^ (coord.1 as u64).rotate_left(29);
+    let hash = mix64(
+        key ^ CHANNEL_SALT
+            ^ position
+            ^ (round as u64).wrapping_mul(0xd6e8_feb8_6659_fd93)
+            ^ (channel as u64).wrapping_mul(0xa5a3_564e_27f8_8671),
+    );
+    let mut multiplier = (hash as u32 % (modulus - 1)) + 1;
+    while greatest_common_divisor(multiplier, modulus) != 1 {
+        multiplier += 1;
+        if multiplier >= modulus {
+            multiplier = 1;
+        }
+    }
+    let offset = (mix64(hash ^ 0xe703_7ed1_a0b4_28db) % modulus as u64) as u32;
+    (multiplier, offset)
+}
+
+fn affine_encode(value: u32, multiplier: u32, offset: u32, modulus: u32) -> u32 {
+    ((value as u64 * multiplier as u64 + offset as u64) % modulus as u64) as u32
+}
+
+fn affine_decode(value: u32, multiplier: u32, offset: u32, modulus: u32) -> u32 {
+    let shifted = (value + modulus - offset) % modulus;
+    ((shifted as u64 * modular_inverse(multiplier, modulus) as u64) % modulus as u64) as u32
+}
+
+fn modular_inverse(value: u32, modulus: u32) -> u32 {
+    let (mut old_r, mut r) = (value as i64, modulus as i64);
+    let (mut old_s, mut s) = (1_i64, 0_i64);
+    while r != 0 {
+        let quotient = old_r / r;
+        (old_r, r) = (r, old_r - quotient * r);
+        (old_s, s) = (s, old_s - quotient * s);
+    }
+    old_s.rem_euclid(modulus as i64) as u32
+}
+
+fn greatest_common_divisor(mut a: u32, mut b: u32) -> u32 {
+    while b != 0 {
+        (a, b) = (b, a % b);
+    }
+    a
+}
+
+fn quantize(value: f32, max_value: u32) -> u32 {
+    (finite_or(value, 0.0).clamp(0.0, 1.0) * max_value as f32).round() as u32
+}
+
+fn dequantize(value: u32, max_value: u32) -> f32 {
+    value as f32 / max_value as f32
+}
+
+fn mix64(mut value: u64) -> u64 {
+    value = value.wrapping_add(0x9e37_79b9_7f4a_7c15);
+    value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    value ^ (value >> 31)
+}
+
+fn write_pixel(
+    destination: &mut ae::GenericPixelMut<'_>,
+    world_type: ae::aegp::WorldType,
+    pixel: ae::PixelF32,
+) {
+    match world_type {
+        ae::aegp::WorldType::U8 => destination.set_from_u8(ae::Pixel8 {
+            red: to_integer_channel(pixel.red, ae::MAX_CHANNEL8) as u8,
+            green: to_integer_channel(pixel.green, ae::MAX_CHANNEL8) as u8,
+            blue: to_integer_channel(pixel.blue, ae::MAX_CHANNEL8) as u8,
+            alpha: to_integer_channel(pixel.alpha, ae::MAX_CHANNEL8) as u8,
+        }),
+        ae::aegp::WorldType::U15 => destination.set_from_u16(ae::Pixel16 {
+            red: to_integer_channel(pixel.red, ae::MAX_CHANNEL16) as u16,
+            green: to_integer_channel(pixel.green, ae::MAX_CHANNEL16) as u16,
+            blue: to_integer_channel(pixel.blue, ae::MAX_CHANNEL16) as u16,
+            alpha: to_integer_channel(pixel.alpha, ae::MAX_CHANNEL16) as u16,
+        }),
+        ae::aegp::WorldType::F32 | ae::aegp::WorldType::None => destination.set_from_f32(pixel),
+    }
+}
+
+fn to_integer_channel(value: f32, maximum: u32) -> u32 {
+    (finite_or(value, 0.0).clamp(0.0, 1.0) * maximum as f32).round() as u32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn buffer_bounds_align_negative_and_nonzero_origins() {
+        let source = BufferBounds::new((-12, 7), 100, 80);
+        let output = BufferBounds::new((-20, 4), 120, 90);
+
+        let layer_coordinate = output.layer_coordinate(8, 3);
+        assert_eq!(layer_coordinate, (-12, 7));
+        assert_eq!(source.local_coordinate(-12, 7), Some((0, 0)));
+        assert_eq!(source.local_coordinate(87, 86), Some((99, 79)));
+        assert_eq!(source.local_coordinate(-13, 7), None);
+        assert_eq!(source.local_coordinate(88, 7), None);
+    }
+
+    fn store_in_world(pixel: ae::PixelF32, world_type: ae::aegp::WorldType) -> ae::PixelF32 {
+        let maximum = match world_type {
+            ae::aegp::WorldType::U8 => Some(ae::MAX_CHANNEL8),
+            ae::aegp::WorldType::U15 => Some(ae::MAX_CHANNEL16),
+            ae::aegp::WorldType::F32 | ae::aegp::WorldType::None => None,
+        };
+        let Some(maximum) = maximum else {
+            return pixel;
+        };
+        ae::PixelF32 {
+            red: dequantize(to_integer_channel(pixel.red, maximum), maximum),
+            green: dequantize(to_integer_channel(pixel.green, maximum), maximum),
+            blue: dequantize(to_integer_channel(pixel.blue, maximum), maximum),
+            alpha: dequantize(to_integer_channel(pixel.alpha, maximum), maximum),
+        }
+    }
+
+    fn cipher_quantized(pixel: ae::PixelF32, modulus: u32, active_channels: usize) -> ae::PixelF32 {
+        let maximum = modulus - 1;
+        ae::PixelF32 {
+            red: dequantize(quantize(pixel.red, maximum), maximum),
+            green: dequantize(quantize(pixel.green, maximum), maximum),
+            blue: dequantize(quantize(pixel.blue, maximum), maximum),
+            alpha: if active_channels == 4 {
+                dequantize(quantize(pixel.alpha, maximum), maximum)
+            } else {
+                pixel.alpha
+            },
+        }
+    }
+
+    fn bit_quantized(pixel: ae::PixelF32, bits: u32, active_channels: usize) -> ae::PixelF32 {
+        cipher_quantized(pixel, 1_u32 << bits, active_channels)
+    }
+
+    fn assert_pixel_near(actual: ae::PixelF32, expected: ae::PixelF32) {
+        for (actual, expected) in [
+            (actual.red, expected.red),
+            (actual.green, expected.green),
+            (actual.blue, expected.blue),
+            (actual.alpha, expected.alpha),
+        ] {
+            assert!(
+                (actual - expected).abs() <= 1.0e-6,
+                "{actual} != {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn coordinate_scramble_round_trips_arbitrary_dimensions() {
+        for (width, height) in [(1, 1), (2, 3), (17, 11), (64, 48)] {
+            for y in 0..height {
+                for x in 0..width {
+                    let encoded = coordinate_forward(
+                        (x, y),
+                        width,
+                        height,
+                        0x0123_4567_89ab_cdef,
+                        7,
+                        COORDINATE_SALT,
+                    );
+                    let decoded = coordinate_inverse(
+                        encoded,
+                        width,
+                        height,
+                        0x0123_4567_89ab_cdef,
+                        7,
+                        COORDINATE_SALT,
+                    );
+                    assert_eq!(decoded, (x, y));
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn block_scramble_round_trips_complete_and_remainder_regions() {
+        let (width, height, block_size) = (37, 29, 8);
+        for y in 0..height {
+            for x in 0..width {
+                let encoded =
+                    block_forward((x, y), width, height, block_size, 0xfedc_ba98_7654_3210, 5);
+                let decoded =
+                    block_inverse(encoded, width, height, block_size, 0xfedc_ba98_7654_3210, 5);
+                assert_eq!(decoded, (x, y));
+            }
+        }
+    }
+
+    #[test]
+    fn linear_interleave_round_trips_prime_and_composite_lengths() {
+        for (width, height) in [(1, 1), (17, 1), (13, 11), (64, 48)] {
+            for y in 0..height {
+                for x in 0..width {
+                    let encoded =
+                        linear_coordinate_forward((x, y), width, height, 0x0123_4567_89ab_cdef, 9);
+                    let decoded =
+                        linear_coordinate_inverse(encoded, width, height, 0x0123_4567_89ab_cdef, 9);
+                    assert_eq!(decoded, (x, y));
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn channel_cipher_round_trips_host_precisions() {
+        for modulus in [ae::MAX_CHANNEL8 + 1, ae::MAX_CHANNEL16 + 1] {
+            let maximum = modulus - 1;
+            for active_channels in [3, 4] {
+                for value in [0, 1, maximum / 3, maximum / 2, maximum - 1, maximum] {
+                    let mut channels = [value, maximum - value, value / 2, maximum];
+                    let original = channels;
+                    channel_encode(
+                        &mut channels,
+                        active_channels,
+                        modulus,
+                        0x0ddc_0ffe_e15e_beef,
+                        (123, 456),
+                        6,
+                    );
+                    channel_decode(
+                        &mut channels,
+                        active_channels,
+                        modulus,
+                        0x0ddc_0ffe_e15e_beef,
+                        (123, 456),
+                        6,
+                    );
+                    assert_eq!(channels, original);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn cipher_precision_never_exceeds_integer_output_capacity() {
+        assert_eq!(
+            cipher_modulus(Precision::Bpc16, ae::aegp::WorldType::U8),
+            ae::MAX_CHANNEL8 + 1
+        );
+        assert_eq!(
+            cipher_modulus(Precision::Bpc16, ae::aegp::WorldType::U15),
+            ae::MAX_CHANNEL16 + 1
+        );
+        assert_eq!(
+            cipher_modulus(Precision::Bpc8, ae::aegp::WorldType::F32),
+            ae::MAX_CHANNEL8 + 1
+        );
+    }
+
+    #[test]
+    fn channel_cipher_round_trips_through_host_storage() {
+        let base = ae::PixelF32 {
+            red: 0.145_098_05,
+            green: 0.623_529_43,
+            blue: 0.901_960_8,
+            alpha: 0.741_176_5,
+        };
+        for world_type in [
+            ae::aegp::WorldType::U8,
+            ae::aegp::WorldType::U15,
+            ae::aegp::WorldType::F32,
+        ] {
+            let original = store_in_world(base, world_type);
+            for precision in [Precision::Auto, Precision::Bpc8, Precision::Bpc16] {
+                let modulus = cipher_modulus(precision, world_type);
+                for active_channels in [3, 4] {
+                    let encoded = cipher_pixel(
+                        original,
+                        Operation::Encode,
+                        (37, 91),
+                        0x0ddc_0ffe_e15e_beef,
+                        6,
+                        modulus,
+                        active_channels,
+                    );
+                    let encoded = store_in_world(encoded, world_type);
+                    let decoded = cipher_pixel(
+                        encoded,
+                        Operation::Decode,
+                        (37, 91),
+                        0x0ddc_0ffe_e15e_beef,
+                        6,
+                        modulus,
+                        active_channels,
+                    );
+                    let decoded = store_in_world(decoded, world_type);
+                    let expected = store_in_world(
+                        cipher_quantized(original, modulus, active_channels),
+                        world_type,
+                    );
+                    assert_pixel_near(decoded, expected);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn bit_plane_cipher_round_trips_selected_precision() {
+        let base = ae::PixelF32 {
+            red: 0.145_098_05,
+            green: 0.623_529_43,
+            blue: 0.901_960_8,
+            alpha: 0.741_176_5,
+        };
+        for bits in [8, 15, 16] {
+            for active_channels in [3, 4] {
+                let encoded = bit_plane_cipher_pixel(
+                    base,
+                    Operation::Encode,
+                    (37, 91),
+                    0x0ddc_0ffe_e15e_beef,
+                    7,
+                    bits,
+                    active_channels,
+                );
+                let decoded = bit_plane_cipher_pixel(
+                    encoded,
+                    Operation::Decode,
+                    (37, 91),
+                    0x0ddc_0ffe_e15e_beef,
+                    7,
+                    bits,
+                    active_channels,
+                );
+                assert_pixel_near(decoded, bit_quantized(base, bits, active_channels));
+            }
+        }
+    }
+
+    #[test]
+    fn bit_plane_cipher_round_trips_through_host_storage() {
+        let base = ae::PixelF32 {
+            red: 0.145_098_05,
+            green: 0.623_529_43,
+            blue: 0.901_960_8,
+            alpha: 0.741_176_5,
+        };
+        for world_type in [
+            ae::aegp::WorldType::U8,
+            ae::aegp::WorldType::U15,
+            ae::aegp::WorldType::F32,
+        ] {
+            let original = store_in_world(base, world_type);
+            for precision in [Precision::Auto, Precision::Bpc8, Precision::Bpc16] {
+                let bits = bit_precision_bits(precision, world_type);
+                for active_channels in [3, 4] {
+                    let encoded = bit_plane_cipher_pixel(
+                        original,
+                        Operation::Encode,
+                        (37, 91),
+                        0x0ddc_0ffe_e15e_beef,
+                        7,
+                        bits,
+                        active_channels,
+                    );
+                    let encoded = store_in_world(encoded, world_type);
+                    let decoded = bit_plane_cipher_pixel(
+                        encoded,
+                        Operation::Decode,
+                        (37, 91),
+                        0x0ddc_0ffe_e15e_beef,
+                        7,
+                        bits,
+                        active_channels,
+                    );
+                    let decoded = store_in_world(decoded, world_type);
+                    let expected =
+                        store_in_world(bit_quantized(original, bits, active_channels), world_type);
+                    assert_pixel_near(decoded, expected);
+                }
+            }
+        }
+    }
+
+    fn recovery_settings() -> Settings {
+        Settings {
+            operation: Operation::Encode,
+            algorithm: Algorithm::ResilientReplicas,
+            key: 0x0123_4567_89ab_cdef,
+            rounds: 5,
+            block_size: 16,
+            precision: Precision::Bpc8,
+            channels: Channels::Rgba,
+            recovery_redundancy: 5,
+            recovery_interleave: 4,
+        }
+    }
+
+    #[test]
+    fn resilient_layout_never_exceeds_fixed_sample_storage() {
+        for width in 1..40 {
+            for height in 1..40 {
+                for redundancy in 1..=MAX_REDUNDANCY {
+                    let layout = resilient_layout(width, height, redundancy);
+                    let repetitions = layout.physical_len.div_ceil(layout.logical_len);
+                    assert!(repetitions <= MAX_RECOVERY_SAMPLES);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn resilient_replicas_recover_two_corrupted_copies() {
+        let (width, height) = (23, 17);
+        let settings = recovery_settings();
+        let modulus = ae::MAX_CHANNEL8 + 1;
+        let source: Vec<_> = (0..width * height)
+            .map(|index| {
+                let x = index % width;
+                let y = index / width;
+                ae::PixelF32 {
+                    red: ((x * 11 + y * 3) % 256) as f32 / 255.0,
+                    green: ((x * 5 + y * 17) % 256) as f32 / 255.0,
+                    blue: ((x * 19 + y * 7) % 256) as f32 / 255.0,
+                    alpha: ((x * 13 + y * 23) % 256) as f32 / 255.0,
+                }
+            })
+            .collect();
+        let mut encoded = vec![TRANSPARENT; width * height];
+        for y in 0..height {
+            for x in 0..width {
+                encoded[y * width + x] =
+                    resilient_encode_pixel(&source, width, height, (x, y), settings, modulus, 4);
+            }
+        }
+
+        // Damage two replicas belonging to the same logical sample. With the
+        // default five-or-more copies, median decoding still selects an intact
+        // value for every channel.
+        let layout = resilient_layout(width, height, settings.recovery_redundancy);
+        let damaged_logical_index = layout.logical_len / 2;
+        for repetition in 0..2 {
+            let slot = damaged_logical_index + repetition * layout.logical_len;
+            let physical_index = linear_index_forward(
+                slot,
+                layout.physical_len,
+                settings.key,
+                settings.recovery_interleave,
+                RECOVERY_SALT,
+            );
+            encoded[physical_index] = ae::PixelF32 {
+                red: 1.0,
+                green: 0.0,
+                blue: 1.0,
+                alpha: 0.0,
+            };
+        }
+
+        for y in 0..height {
+            for x in 0..width {
+                let decoded =
+                    resilient_decode_pixel(&encoded, width, height, (x, y), settings, modulus, 4);
+                let logical_index = output_logical_index((x, y), layout, width, height);
+                let source_coord = logical_source_coordinate(logical_index, layout, width, height);
+                let expected =
+                    cipher_quantized(source[source_coord.1 * width + source_coord.0], modulus, 4);
+                assert_pixel_near(decoded, expected);
+            }
+        }
+    }
+
+    #[test]
+    fn original_popup_values_remain_project_compatible() {
+        assert_eq!(algorithm_from_popup(1), Algorithm::Coordinate);
+        assert_eq!(algorithm_from_popup(2), Algorithm::Blocks);
+        assert_eq!(algorithm_from_popup(3), Algorithm::Channels);
+        assert_eq!(algorithm_from_popup(4), Algorithm::Combined);
+    }
+
+    #[test]
+    fn combined_coordinate_map_round_trips() {
+        let algorithm = Algorithm::Combined;
+        for y in 0..31 {
+            for x in 0..43 {
+                let encoded = map_forward((x, y), 43, 31, algorithm, 6, 0x55aa_1234_5678_cdef, 4);
+                let decoded = map_inverse(encoded, 43, 31, algorithm, 6, 0x55aa_1234_5678_cdef, 4);
+                assert_eq!(decoded, (x, y));
+            }
+        }
+    }
+}

--- a/plugins/image-relight/Cargo.toml
+++ b/plugins/image-relight/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "image_relight"
+description = "Relights images using color-region, channel-generated, or supplied normal maps."
+version = "0.5.0"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib"]
+
+[features]
+default = ["gpu_wgpu"]
+catch-panics = []
+gpu_wgpu = ["dep:wgpu", "dep:bytemuck", "dep:pollster", "dep:futures-intrusive"]
+
+[dependencies]
+after-effects = { workspace = true }
+utils = { path = "../../crates/utils" }
+
+wgpu = { workspace = true, optional = true }
+bytemuck = { workspace = true, optional = true }
+pollster = { workspace = true, optional = true }
+futures-intrusive = { workspace = true, optional = true }
+
+
+[dev-dependencies]
+pipl = { workspace = true }
+
+[build-dependencies]
+chrono.workspace = true
+pipl.workspace = true
+winres = "0.1.12"
+
+[lints]
+workspace = true

--- a/plugins/image-relight/Justfile
+++ b/plugins/image-relight/Justfile
@@ -1,0 +1,12 @@
+# Read package.name from Cargo.toml for build naming.
+CrateName := if os() == "windows" {
+    `$inPackage = $false; foreach ($line in Get-Content -Path Cargo.toml) { if ($line -match '^\s*\[package\]\s*$') { $inPackage = $true; continue }; if ($line -match '^\s*\[.+\]\s*$') { if ($inPackage) { break } }; if ($inPackage -and $line -match '^\s*name\s*=\s*"([^"]+)"') { $matches[1]; break } }`
+} else {
+    `awk -F'"' 'BEGIN{in_pkg=0} /^[[:space:]]*\[package\][[:space:]]*$/{in_pkg=1;next} /^[[:space:]]*\[/{if(in_pkg)exit} in_pkg && /^[[:space:]]*name[[:space:]]*=/ {print $2; exit}' Cargo.toml`
+}
+
+PluginName       := "AOD_ImageRelight"
+BundleIdentifier := "com.aodaruma." + PluginName
+BinaryName       := snakecase(CrateName)
+
+import "../../AdobePlugin.just"

--- a/plugins/image-relight/README.md
+++ b/plugins/image-relight/README.md
@@ -1,0 +1,71 @@
+# image-relight ( AOD_ImageRelight )
+
+Relights images using color-region, channel-generated, or supplied normal maps with configurable
+material and light controls.
+
+## Normal sources and outputs
+
+- **Generated / Color Regions** is the default. It separates a cel-painted image by its straight
+  (unpremultiplied) RGB colors, then builds an independent height surface inside each connected
+  color region. `Color Tolerance` controls RGB label quantization, `Alpha Threshold` excludes
+  transparent pixels, and `Edge Softness` feathers normals near region boundaries.
+  - **Distance Field (SDF)** preserves the original fast surface based on
+    an unsigned interior chamfer distance field (rather than a two-sided exact signed distance).
+    `Region Radius` sets the physical bevel/dome reach and `Height Shape` controls its falloff.
+  - **Poisson / Neumann (Smooth)** is the default solver. It solves a screened Poisson system
+    independently for every four-connected color region. `Boundary Condition` selects fixed-zero
+    height (Dirichlet) or zero-flux normal continuity (Neumann, the default for this solver).
+    `Iterations`, `Divergence / Curvature`, `Screened Damping`, and `Edge Feather` control
+    convergence and the smooth surface profile derived from the same region-boundary distance. The
+    shape is normalized per connected region, then its 0..1 relief is scaled by a bounded response
+    to Curvature and Damping. Consequently Curvature changes the actual relief magnitude, while
+    zero Curvature plus zero Damping produces a strictly flat surface.
+- **Generated / Height Channel** retains the original luminance, alpha, red, green, or blue height
+  source. It can blur the height before converting its gradient to a tangent-space normal.
+- Generated methods share `Normal Strength` and `Invert Height`. In Color Regions mode, inversion
+  turns raised region interiors into recessed surfaces while keeping every color boundary isolated.
+- **Normal Layer** decodes an independently selected RGB normal layer. Checked-out layer origins are
+  used to align it with the source in layer coordinates; areas outside the supplied map use a flat
+  normal. OpenGL (+Y) and DirectX (-Y) conventions are supported.
+- Output views include the final relight, normal map, height, diffuse, specular, and combined
+  lighting. Height output is available for generated normals; supplied normal maps have no unique
+  recoverable height, so that view uses neutral gray.
+
+The default **Principled (GGX)** surface uses the source image as its base color. `Base Tint`
+multiplies that color, while `Metallic`, `Roughness`, `IOR`, and `Specular IOR Level` follow the
+familiar Principled-material convention. The direct-light BRDF combines a GGX normal distribution,
+Smith masking-shadowing, Schlick Fresnel, and an energy-conserving Lambert diffuse lobe. IOR 1.5 and
+Specular IOR Level 0.5 produce the conventional 4% dielectric normal-incidence reflectance.
+`Environment Strength` supplies a simple base-color environment term because this effect has no
+environment-map input. **Legacy Blinn-Phong** remains selectable and retains the original
+Ambient/Diffuse/Specular/Shininess controls. Controls that do not apply to the selected source,
+surface, light, or output view are hidden dynamically.
+Generated-normal gradients, region distances, Poisson Laplacian weights, edge softness, height blur,
+and point-light distance/falloff are evaluated in full-resolution square-pixel coordinates,
+accounting for pixel aspect ratio and independent horizontal/vertical downsampling. For unscreened
+Neumann solves, the right-hand side is made mean-free and the otherwise-undetermined component mean
+is fixed during iteration, preventing drift while satisfying the Neumann compatibility condition.
+Color Region generation requests the full Smart Render source so region surfaces remain stable
+across tiled output requests. A thread-safe, single-entry transient cache reuses the generated
+height and normal maps between tiles with identical full-source content, bounds, and surface
+settings. The entry is replaced on any key change, so memory does not grow across frames or
+parameter edits. Point Position is localized against the checked-out source origin when preceding
+effects expand the bounds. Input and output support 8/16/32 bpc; color labels are derived after
+unpremultiplication and all rendered views retain the source alpha in premultiplied form.
+
+Large screened Poisson solves use a cached WGPU compute pipeline automatically. Small surfaces,
+pure unscreened Neumann systems, unavailable adapters, unsupported limits, and GPU execution errors
+fall back to the equivalent CPU solver. Set `AOD_IMAGE_RELIGHT_GPU=cpu` or `gpu` before launching
+After Effects to force either backend while testing.
+
+The v0.3 solver controls are appended after the v0.2 parameter sequence, and the v0.5 Principled
+material controls are appended after the complete v0.4 sequence, so all earlier parameter indices
+remain unchanged. Existing values for the original material controls are retained and can be used
+by selecting Legacy Blinn-Phong. The GPU backend and material update change no PiPL or sequence
+flags.
+
+This is the After Effects plugin **AOD_ImageRelight**, which provides the **AOD_ImageRelight.aex** plugin file for Adobe After Effects.
+
+## Building the Plugin
+
+See the [main README](../../README.md) for instructions on how to build the plugin.

--- a/plugins/image-relight/build.rs
+++ b/plugins/image-relight/build.rs
@@ -1,0 +1,94 @@
+use chrono::Datelike;
+use pipl::*;
+
+const PF_PLUG_IN_VERSION: u16 = 13;
+const PF_PLUG_IN_SUBVERS: u16 = 28;
+
+#[cfg(target_os = "windows")]
+fn embed_binary_safe_pipl(pipl: &[u8]) {
+    // `pipl` 0.1.1 embeds arbitrary bytes as RC text on Windows. A raw file
+    // resource prevents rc.exe from changing bytes above 0x7f.
+    let out_dir = std::path::PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR is set"));
+    let pipl_path = out_dir.join("image_relight.pipl");
+    std::fs::write(&pipl_path, pipl).expect("write binary PiPL resource");
+
+    let escaped_path = pipl_path.to_string_lossy().replace('\\', "\\\\");
+    let mut resource = winres::WindowsResource::new();
+    resource.append_rc_content(&format!("16000 PiPL DISCARDABLE \"{escaped_path}\""));
+    resource.compile().expect("compile binary PiPL resource");
+}
+
+#[rustfmt::skip]
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(does_dialog)");
+    println!("cargo::rustc-check-cfg=cfg(threaded_rendering)");
+
+    let current_year = chrono::Local::now().year();
+    println!("cargo:rustc-env=BUILD_YEAR={}", current_year);
+
+    let pkg_version = env!("CARGO_PKG_VERSION");
+    let version_parts: Vec<&str> = pkg_version.split('.').collect();
+    if version_parts.len() != 3 {
+        panic!("CARGO_PKG_VERSION must be in the format 'major.minor.patch'");
+    }
+    let major: u32 = version_parts[0].parse().expect("Invalid major version");
+    let minor: u32 = version_parts[1].parse().expect("Invalid minor version");
+    let patch: u32 = version_parts[2].parse().expect("Invalid patch version");
+
+    // Determine the stage based on building whether debug or release
+    /*
+    // pipl load error occured when stage = Stage::Release in pipl == v0.1.1, so temporarily fixed to Develop
+    let stage = if cfg!(debug_assertions) {
+        Stage::Develop
+    } else {
+        Stage::Release
+    };
+    */
+    let stage = Stage::Develop;
+
+    let properties = || vec![
+        Property::Kind(PIPLType::AEEffect),
+        Property::Name("AOD_ImageRelight"),
+        Property::Category("Aodaruma"),
+
+        #[cfg(target_os = "windows")]
+        Property::CodeWin64X86("EffectMain"),
+        #[cfg(target_os = "macos")]
+        Property::CodeMacIntel64("EffectMain"),
+        #[cfg(target_os = "macos")]
+        Property::CodeMacARM64("EffectMain"),
+
+        Property::AE_PiPL_Version { major: 2, minor: 0 },
+        Property::AE_Effect_Spec_Version { major: PF_PLUG_IN_VERSION, minor: PF_PLUG_IN_SUBVERS },
+        Property::AE_Effect_Version {
+            version: major,
+            subversion: minor,
+            bugversion: patch,
+            stage,
+            build: 1,
+        },
+        Property::AE_Effect_Info_Flags(0),
+        Property::AE_Effect_Global_OutFlags(
+            // set up from https://docs.rs/pipl/latest/pipl/struct.OutFlags.html
+            OutFlags::UseOutputExtent
+            | OutFlags::DeepColorAware
+            | OutFlags::SendUpdateParamsUI,
+        ),
+        Property::AE_Effect_Global_OutFlags_2(
+            // set up from https://docs.rs/pipl/latest/pipl/struct.OutFlags2.html
+            OutFlags2::FloatColorAware
+            | OutFlags2::SupportsSmartRender
+            | OutFlags2::ParamGroupStartCollapsedFlag,
+            // | OutFlags2::SupportsGpuRenderF32
+        ),
+        Property::AE_Effect_Match_Name("ImageRelight"),
+        Property::AE_Reserved_Info(8),
+        Property::AE_Effect_Support_URL("https://github.com/Aodaruma/aod-AE-plugin"),
+    ];
+
+    // Keep the pipl crate's environment variables, but replace its text RC
+    // resource with a byte-for-byte PiPL resource on Windows.
+    pipl::plugin_build(properties());
+    #[cfg(target_os = "windows")]
+    embed_binary_safe_pipl(&pipl::build_pipl(properties()).expect("build PiPL"));
+}

--- a/plugins/image-relight/src/gpu/mod.rs
+++ b/plugins/image-relight/src/gpu/mod.rs
@@ -1,0 +1,520 @@
+use bytemuck::{Pod, Zeroable};
+use futures_intrusive::channel::shared::oneshot_channel;
+use std::borrow::Cow;
+use std::sync::Mutex;
+use wgpu::*;
+
+const WORKGROUP_WIDTH: u32 = 16;
+const WORKGROUP_HEIGHT: u32 = 16;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum GpuBoundaryCondition {
+    Dirichlet,
+    Neumann,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct SolveParams {
+    pub width: usize,
+    pub height: usize,
+    pub condition: GpuBoundaryCondition,
+    pub iterations: usize,
+    pub lambda_squared: f32,
+    pub weight_x: f32,
+    pub weight_y: f32,
+    pub omega: f32,
+}
+
+pub(crate) struct WgpuContext {
+    device: Device,
+    queue: Queue,
+    limits: Limits,
+    red_pipeline: ComputePipeline,
+    black_pipeline: ComputePipeline,
+    layout: BindGroupLayout,
+    // One reusable allocation keeps repeated frame sizes cheap without retaining VRAM for every
+    // render thread or every size AE has requested in the past.
+    resources: Mutex<Option<WgpuResources>>,
+}
+
+impl WgpuContext {
+    pub(crate) fn new() -> Result<Self, String> {
+        let power_preference =
+            PowerPreference::from_env().unwrap_or(PowerPreference::HighPerformance);
+        let mut instance_desc = InstanceDescriptor::default();
+        if instance_desc.backends.contains(Backends::DX12)
+            && instance_desc.flags.contains(InstanceFlags::VALIDATION)
+        {
+            instance_desc
+                .flags
+                .remove(InstanceFlags::VALIDATION | InstanceFlags::GPU_BASED_VALIDATION);
+        }
+
+        let instance = Instance::new(&instance_desc);
+        let adapter = pollster::block_on(instance.request_adapter(&RequestAdapterOptions {
+            power_preference,
+            ..Default::default()
+        }))
+        .map_err(|error| format!("request_adapter failed: {error:?}"))?;
+        let required_limits = Limits::default()
+            .using_resolution(adapter.limits())
+            .using_alignment(adapter.limits());
+        validate_compute_limits(&required_limits)?;
+
+        let (device, queue) = pollster::block_on(adapter.request_device(&DeviceDescriptor {
+            label: Some("AOD_ImageRelight Poisson device"),
+            required_features: Features::empty(),
+            required_limits: required_limits.clone(),
+            experimental_features: ExperimentalFeatures::disabled(),
+            memory_hints: MemoryHints::Performance,
+            trace: Trace::Off,
+        }))
+        .map_err(|error| format!("request_device failed: {error:?}"))?;
+
+        let (layout, red_pipeline, black_pipeline) = create_pipelines(&device);
+        Ok(Self {
+            device,
+            queue,
+            limits: required_limits,
+            red_pipeline,
+            black_pipeline,
+            layout,
+            resources: Mutex::new(None),
+        })
+    }
+
+    pub(crate) fn solve(
+        &self,
+        labels: &[u32],
+        boundary: &[bool],
+        rhs: &[f32],
+        params: SolveParams,
+    ) -> Result<Vec<f32>, String> {
+        let pixel_count = params
+            .width
+            .checked_mul(params.height)
+            .ok_or_else(|| "image dimensions overflow".to_owned())?;
+        if labels.len() != pixel_count || boundary.len() != pixel_count || rhs.len() != pixel_count
+        {
+            return Err("Poisson input buffers do not match image dimensions".to_owned());
+        }
+        if pixel_count == 0 {
+            return Ok(Vec::new());
+        }
+        validate_solver_params(params, rhs)?;
+
+        let width = u32::try_from(params.width)
+            .map_err(|_| "image width exceeds the GPU u32 coordinate range".to_owned())?;
+        let height = u32::try_from(params.height)
+            .map_err(|_| "image height exceeds the GPU u32 coordinate range".to_owned())?;
+        let output_bytes = buffer_bytes::<f32>(pixel_count)?;
+        self.validate_resource_sizes(output_bytes, width, height)?;
+
+        // WGSL storage buffers have no portable bool element representation.
+        let boundary_words = boundary
+            .iter()
+            .map(|&value| u32::from(value))
+            .collect::<Vec<_>>();
+        let gpu_params = GpuParams {
+            image: [
+                width,
+                height,
+                match params.condition {
+                    GpuBoundaryCondition::Dirichlet => 0,
+                    GpuBoundaryCondition::Neumann => 1,
+                },
+                0,
+            ],
+            coefficients: [
+                params.lambda_squared,
+                params.weight_x,
+                params.weight_y,
+                params.omega,
+            ],
+        };
+
+        let mut resources = self
+            .resources
+            .lock()
+            .map_err(|_| "GPU Poisson resource lock was poisoned".to_owned())?;
+        let dimensions_changed = resources
+            .as_ref()
+            .is_none_or(|resource| resource.width != width || resource.height != height);
+        if dimensions_changed {
+            *resources = Some(WgpuResources::new(
+                &self.device,
+                &self.layout,
+                width,
+                height,
+                output_bytes,
+            ));
+        }
+        let resource = resources
+            .as_mut()
+            .ok_or_else(|| "GPU Poisson resources were not initialized".to_owned())?;
+
+        self.queue
+            .write_buffer(&resource.params, 0, bytemuck::bytes_of(&gpu_params));
+        self.queue
+            .write_buffer(&resource.labels, 0, bytemuck::cast_slice(labels));
+        self.queue.write_buffer(
+            &resource.boundary,
+            0,
+            bytemuck::cast_slice(boundary_words.as_slice()),
+        );
+        self.queue
+            .write_buffer(&resource.rhs, 0, bytemuck::cast_slice(rhs));
+
+        let dispatch_x = width.div_ceil(WORKGROUP_WIDTH);
+        let dispatch_y = height.div_ceil(WORKGROUP_HEIGHT);
+        let mut encoder = self
+            .device
+            .create_command_encoder(&CommandEncoderDescriptor {
+                label: Some("AOD_ImageRelight Poisson encoder"),
+            });
+        encoder.clear_buffer(&resource.heights, 0, Some(output_bytes));
+        {
+            let mut pass = encoder.begin_compute_pass(&ComputePassDescriptor {
+                label: Some("AOD_ImageRelight red-black SOR"),
+                timestamp_writes: None,
+            });
+            pass.set_bind_group(0, &resource.bind_group, &[]);
+            for _ in 0..params.iterations.max(1) {
+                pass.set_pipeline(&self.red_pipeline);
+                pass.dispatch_workgroups(dispatch_x, dispatch_y, 1);
+                pass.set_pipeline(&self.black_pipeline);
+                pass.dispatch_workgroups(dispatch_x, dispatch_y, 1);
+            }
+        }
+        encoder.copy_buffer_to_buffer(&resource.heights, 0, &resource.staging, 0, output_bytes);
+
+        let (sender, receiver) = oneshot_channel();
+        encoder.map_buffer_on_submit(
+            &resource.staging,
+            MapMode::Read,
+            ..output_bytes,
+            move |result| {
+                let _ = sender.send(result);
+            },
+        );
+        self.queue.submit(Some(encoder.finish()));
+        let _ = self.device.poll(PollType::wait_indefinitely());
+
+        let Some(Ok(())) = pollster::block_on(receiver.receive()) else {
+            return Err("GPU Poisson output readback failed".to_owned());
+        };
+        let mapped = resource.staging.slice(..output_bytes).get_mapped_range();
+        let mapped_heights: &[f32] = bytemuck::cast_slice(&mapped);
+        if mapped_heights.len() < pixel_count {
+            drop(mapped);
+            resource.staging.unmap();
+            return Err("GPU Poisson output was shorter than expected".to_owned());
+        }
+        let output = mapped_heights[..pixel_count].to_vec();
+        drop(mapped);
+        resource.staging.unmap();
+        Ok(output)
+    }
+
+    fn validate_resource_sizes(
+        &self,
+        buffer_size: u64,
+        width: u32,
+        height: u32,
+    ) -> Result<(), String> {
+        let storage_limit = self.limits.max_storage_buffer_binding_size as u64;
+        if buffer_size > storage_limit || buffer_size > self.limits.max_buffer_size {
+            return Err(format!(
+                "each Poisson image buffer requires {buffer_size} bytes, exceeding GPU limits"
+            ));
+        }
+
+        let dispatch_limit = self.limits.max_compute_workgroups_per_dimension;
+        if width.div_ceil(WORKGROUP_WIDTH) > dispatch_limit
+            || height.div_ceil(WORKGROUP_HEIGHT) > dispatch_limit
+        {
+            return Err("image dimensions exceed GPU dispatch limits".to_owned());
+        }
+        Ok(())
+    }
+}
+
+fn validate_compute_limits(limits: &Limits) -> Result<(), String> {
+    let invocations = WORKGROUP_WIDTH.saturating_mul(WORKGROUP_HEIGHT);
+    if WORKGROUP_WIDTH > limits.max_compute_workgroup_size_x
+        || WORKGROUP_HEIGHT > limits.max_compute_workgroup_size_y
+        || invocations > limits.max_compute_invocations_per_workgroup
+    {
+        return Err("GPU does not support the required 16x16 compute workgroup".to_owned());
+    }
+    if limits.max_storage_buffers_per_shader_stage < 4 {
+        return Err("GPU exposes fewer than four compute storage buffers".to_owned());
+    }
+    Ok(())
+}
+
+fn validate_solver_params(params: SolveParams, rhs: &[f32]) -> Result<(), String> {
+    if !params.lambda_squared.is_finite() || params.lambda_squared < 0.0 {
+        return Err("lambda_squared must be finite and non-negative".to_owned());
+    }
+    if !params.weight_x.is_finite() || params.weight_x <= 0.0 {
+        return Err("weight_x must be finite and positive".to_owned());
+    }
+    if !params.weight_y.is_finite() || params.weight_y <= 0.0 {
+        return Err("weight_y must be finite and positive".to_owned());
+    }
+    if !params.omega.is_finite() || !(0.0..=2.0).contains(&params.omega) || params.omega == 0.0 {
+        return Err("omega must be finite and in the interval (0, 2]".to_owned());
+    }
+    if rhs.iter().any(|value| !value.is_finite()) {
+        return Err("Poisson right-hand side contains a non-finite value".to_owned());
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(C)]
+struct GpuParams {
+    image: [u32; 4],
+    coefficients: [f32; 4],
+}
+
+struct WgpuResources {
+    width: u32,
+    height: u32,
+    params: Buffer,
+    labels: Buffer,
+    boundary: Buffer,
+    rhs: Buffer,
+    heights: Buffer,
+    staging: Buffer,
+    bind_group: BindGroup,
+}
+
+impl WgpuResources {
+    fn new(
+        device: &Device,
+        layout: &BindGroupLayout,
+        width: u32,
+        height: u32,
+        buffer_size: u64,
+    ) -> Self {
+        let params = create_buffer(
+            device,
+            "AOD_ImageRelight Poisson params",
+            std::mem::size_of::<GpuParams>() as u64,
+            BufferUsages::UNIFORM | BufferUsages::COPY_DST,
+        );
+        let labels = create_buffer(
+            device,
+            "AOD_ImageRelight Poisson labels",
+            buffer_size,
+            BufferUsages::STORAGE | BufferUsages::COPY_DST,
+        );
+        let boundary = create_buffer(
+            device,
+            "AOD_ImageRelight Poisson boundary",
+            buffer_size,
+            BufferUsages::STORAGE | BufferUsages::COPY_DST,
+        );
+        let rhs = create_buffer(
+            device,
+            "AOD_ImageRelight Poisson RHS",
+            buffer_size,
+            BufferUsages::STORAGE | BufferUsages::COPY_DST,
+        );
+        let heights = create_buffer(
+            device,
+            "AOD_ImageRelight Poisson heights",
+            buffer_size,
+            BufferUsages::STORAGE | BufferUsages::COPY_DST | BufferUsages::COPY_SRC,
+        );
+        let staging = create_buffer(
+            device,
+            "AOD_ImageRelight Poisson staging",
+            buffer_size,
+            BufferUsages::MAP_READ | BufferUsages::COPY_DST,
+        );
+        let bind_group = device.create_bind_group(&BindGroupDescriptor {
+            label: Some("AOD_ImageRelight Poisson bind group"),
+            layout,
+            entries: &[
+                bind_entry(0, &params),
+                bind_entry(1, &labels),
+                bind_entry(2, &boundary),
+                bind_entry(3, &rhs),
+                bind_entry(4, &heights),
+            ],
+        });
+        Self {
+            width,
+            height,
+            params,
+            labels,
+            boundary,
+            rhs,
+            heights,
+            staging,
+            bind_group,
+        }
+    }
+}
+
+fn create_pipelines(device: &Device) -> (BindGroupLayout, ComputePipeline, ComputePipeline) {
+    let shader = device.create_shader_module(ShaderModuleDescriptor {
+        label: Some("AOD_ImageRelight Poisson shader"),
+        source: ShaderSource::Wgsl(Cow::Borrowed(include_str!("poisson.wgsl"))),
+    });
+    let layout = device.create_bind_group_layout(&BindGroupLayoutDescriptor {
+        label: Some("AOD_ImageRelight Poisson bind group layout"),
+        entries: &[
+            buffer_layout_entry(
+                0,
+                BufferBindingType::Uniform,
+                std::mem::size_of::<GpuParams>(),
+            ),
+            buffer_layout_entry(1, BufferBindingType::Storage { read_only: true }, 0),
+            buffer_layout_entry(2, BufferBindingType::Storage { read_only: true }, 0),
+            buffer_layout_entry(3, BufferBindingType::Storage { read_only: true }, 0),
+            buffer_layout_entry(4, BufferBindingType::Storage { read_only: false }, 0),
+        ],
+    });
+    let pipeline_layout = device.create_pipeline_layout(&PipelineLayoutDescriptor {
+        label: Some("AOD_ImageRelight Poisson pipeline layout"),
+        bind_group_layouts: &[&layout],
+        immediate_size: 0,
+    });
+    let create = |label, entry_point| {
+        device.create_compute_pipeline(&ComputePipelineDescriptor {
+            label: Some(label),
+            layout: Some(&pipeline_layout),
+            module: &shader,
+            entry_point: Some(entry_point),
+            compilation_options: Default::default(),
+            cache: Default::default(),
+        })
+    };
+    let red = create("AOD_ImageRelight Poisson red pipeline", "red");
+    let black = create("AOD_ImageRelight Poisson black pipeline", "black");
+    (layout, red, black)
+}
+
+fn create_buffer(device: &Device, label: &'static str, size: u64, usage: BufferUsages) -> Buffer {
+    device.create_buffer(&BufferDescriptor {
+        label: Some(label),
+        size,
+        usage,
+        mapped_at_creation: false,
+    })
+}
+
+fn bind_entry(binding: u32, buffer: &Buffer) -> BindGroupEntry<'_> {
+    BindGroupEntry {
+        binding,
+        resource: buffer.as_entire_binding(),
+    }
+}
+
+fn buffer_layout_entry(
+    binding: u32,
+    ty: BufferBindingType,
+    minimum_size: usize,
+) -> BindGroupLayoutEntry {
+    BindGroupLayoutEntry {
+        binding,
+        visibility: ShaderStages::COMPUTE,
+        ty: BindingType::Buffer {
+            ty,
+            has_dynamic_offset: false,
+            min_binding_size: BufferSize::new(minimum_size as u64),
+        },
+        count: None,
+    }
+}
+
+fn buffer_bytes<T>(count: usize) -> Result<u64, String> {
+    let count = u64::try_from(count).map_err(|_| "buffer element count exceeds u64".to_owned())?;
+    count
+        .checked_mul(std::mem::size_of::<T>() as u64)
+        .ok_or_else(|| "GPU buffer byte count overflow".to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_params() -> SolveParams {
+        SolveParams {
+            width: 2,
+            height: 2,
+            condition: GpuBoundaryCondition::Neumann,
+            iterations: 20,
+            lambda_squared: 0.0,
+            weight_x: 1.0,
+            weight_y: 1.0,
+            omega: 1.5,
+        }
+    }
+
+    #[test]
+    fn rejects_non_finite_rhs_before_gpu_submission() {
+        assert!(validate_solver_params(valid_params(), &[f32::NAN]).is_err());
+    }
+
+    #[test]
+    fn rejects_unstable_relaxation_weight() {
+        let mut params = valid_params();
+        params.omega = 2.1;
+        assert!(validate_solver_params(params, &[0.0]).is_err());
+    }
+
+    #[test]
+    fn gpu_dirichlet_solve_keeps_the_boundary_fixed() {
+        let Ok(context) = WgpuContext::new() else {
+            eprintln!("Skipping ImageRelight GPU test because wgpu is unavailable");
+            return;
+        };
+        let labels = vec![7; 25];
+        let boundary = (0..25)
+            .map(|index| {
+                let x = index % 5;
+                let y = index / 5;
+                x == 0 || x == 4 || y == 0 || y == 4
+            })
+            .collect::<Vec<_>>();
+        let mut rhs = vec![0.0; 25];
+        rhs[12] = 1.0;
+        let output = context
+            .solve(
+                &labels,
+                &boundary,
+                &rhs,
+                SolveParams {
+                    width: 5,
+                    height: 5,
+                    condition: GpuBoundaryCondition::Dirichlet,
+                    iterations: 24,
+                    lambda_squared: 0.0,
+                    weight_x: 1.0,
+                    weight_y: 1.0,
+                    omega: 1.5,
+                },
+            )
+            .expect("GPU Poisson solve should succeed");
+        for (index, value) in output.iter().enumerate() {
+            if boundary[index] {
+                assert_eq!(*value, 0.0);
+            }
+        }
+        // The source is red parity. Positive black neighbors and red diagonals prove that
+        // dependent red/black dispatches are ordered within the single submitted command buffer.
+        let center = output[12];
+        assert!(center > 0.0);
+        for index in [7, 11, 13, 17] {
+            assert!(output[index] > 0.0 && output[index] < center);
+        }
+        for index in [6, 8, 16, 18] {
+            assert!(output[index] > 0.0 && output[index] < center);
+        }
+    }
+}

--- a/plugins/image-relight/src/gpu/mod.rs
+++ b/plugins/image-relight/src/gpu/mod.rs
@@ -469,6 +469,10 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(
+        target_os = "windows",
+        ignore = "requires an interactive Windows GPU driver; run explicitly with --ignored"
+    )]
     fn gpu_dirichlet_solve_keeps_the_boundary_fixed() {
         let Ok(context) = WgpuContext::new() else {
             eprintln!("Skipping ImageRelight GPU test because wgpu is unavailable");

--- a/plugins/image-relight/src/gpu/poisson.wgsl
+++ b/plugins/image-relight/src/gpu/poisson.wgsl
@@ -1,0 +1,109 @@
+const BACKGROUND_LABEL: u32 = 0xffffffffu;
+const DIRICHLET: u32 = 0u;
+
+struct Params {
+    image: vec4<u32>,
+    coefficients: vec4<f32>,
+}
+
+@group(0) @binding(0) var<uniform> params: Params;
+@group(0) @binding(1) var<storage, read> labels: array<u32>;
+@group(0) @binding(2) var<storage, read> boundary: array<u32>;
+@group(0) @binding(3) var<storage, read> rhs: array<f32>;
+@group(0) @binding(4) var<storage, read_write> heights: array<f32>;
+
+fn relax(coords: vec2<u32>, parity: u32) {
+    let width = params.image.x;
+    let height = params.image.y;
+    if coords.x >= width || coords.y >= height {
+        return;
+    }
+    if ((coords.x ^ coords.y) & 1u) != parity {
+        return;
+    }
+
+    let index = coords.y * width + coords.x;
+    let label = labels[index];
+    if label == BACKGROUND_LABEL {
+        return;
+    }
+    let dirichlet = params.image.z == DIRICHLET;
+    if dirichlet && boundary[index] != 0u {
+        return;
+    }
+
+    let lambda_squared = params.coefficients.x;
+    let weight_x = params.coefficients.y;
+    let weight_y = params.coefficients.z;
+    let omega = params.coefficients.w;
+    var sum = 0.0;
+    var diagonal = lambda_squared;
+
+    if coords.x > 0u {
+        let neighbor = index - 1u;
+        if labels[neighbor] == label {
+            sum += weight_x * heights[neighbor];
+            diagonal += weight_x;
+        } else if dirichlet {
+            diagonal += weight_x;
+        }
+    } else if dirichlet {
+        diagonal += weight_x;
+    }
+
+    if coords.x + 1u < width {
+        let neighbor = index + 1u;
+        if labels[neighbor] == label {
+            sum += weight_x * heights[neighbor];
+            diagonal += weight_x;
+        } else if dirichlet {
+            diagonal += weight_x;
+        }
+    } else if dirichlet {
+        diagonal += weight_x;
+    }
+
+    if coords.y > 0u {
+        let neighbor = index - width;
+        if labels[neighbor] == label {
+            sum += weight_y * heights[neighbor];
+            diagonal += weight_y;
+        } else if dirichlet {
+            diagonal += weight_y;
+        }
+    } else if dirichlet {
+        diagonal += weight_y;
+    }
+
+    if coords.y + 1u < height {
+        let neighbor = index + width;
+        if labels[neighbor] == label {
+            sum += weight_y * heights[neighbor];
+            diagonal += weight_y;
+        } else if dirichlet {
+            diagonal += weight_y;
+        }
+    } else if dirichlet {
+        diagonal += weight_y;
+    }
+
+    var candidate = 0.0;
+    if diagonal > 1.0e-12 {
+        candidate = (rhs[index] + sum) / diagonal;
+    }
+    let old = heights[index];
+    let updated = old + omega * (candidate - old);
+    if updated == updated && abs(updated) <= 3.4028234663852886e+38 {
+        heights[index] = updated;
+    }
+}
+
+@compute @workgroup_size(16, 16, 1)
+fn red(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    relax(global_id.xy, 0u);
+}
+
+@compute @workgroup_size(16, 16, 1)
+fn black(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    relax(global_id.xy, 1u);
+}

--- a/plugins/image-relight/src/lib.rs
+++ b/plugins/image-relight/src/lib.rs
@@ -2438,7 +2438,7 @@ fn normals_from_regions(
             let dy = (bottom - top) * 0.5 / step_y;
             normals[index] = normalize3([
                 -dx * strength * edge_weight,
-                -dy * strength * edge_weight,
+                dy * strength * edge_weight,
                 1.0,
             ]);
         }
@@ -2533,7 +2533,7 @@ fn normals_from_height(
             let dy_span = (bottom - top).max(1) as f32 * pixel_scale.1;
             let dx = (heights[y * width + right] - heights[y * width + left]) / dx_span;
             let dy = (heights[bottom * width + x] - heights[top * width + x]) / dy_span;
-            normals[y * width + x] = normalize3([-dx * strength, -dy * strength, 1.0]);
+            normals[y * width + x] = normalize3([-dx * strength, dy * strength, 1.0]);
         }
     }
     normals
@@ -2950,6 +2950,33 @@ mod tests {
             assert!((normal[1]).abs() < 1.0e-6);
             assert!((normal[2] - 1.0).abs() < 1.0e-6);
         }
+    }
+
+    #[test]
+    fn generated_normals_convert_image_y_to_tangent_y() {
+        let heights = vec![0.0, 0.0, 0.0, 0.5, 0.5, 0.5, 1.0, 1.0, 1.0];
+        let height_normal = normals_from_height(&heights, 3, 3, 1.0, (1.0, 1.0))[4];
+        assert!(height_normal[1] > 0.0);
+
+        let labels = vec![0; 9];
+        let distance = vec![2.0; 9];
+        let region_normal = normals_from_regions(
+            &heights,
+            &labels,
+            &distance,
+            3,
+            3,
+            1.0,
+            0.0,
+            false,
+            true,
+            (1.0, 1.0),
+        )[4];
+        assert!(region_normal[1] > 0.0);
+
+        let light_from_above = blinn_terms(height_normal, [0.0, 1.0, 1.0], 32.0).0;
+        let light_from_below = blinn_terms(height_normal, [0.0, -1.0, 1.0], 32.0).0;
+        assert!(light_from_above > light_from_below);
     }
 
     #[test]

--- a/plugins/image-relight/src/lib.rs
+++ b/plugins/image-relight/src/lib.rs
@@ -1,0 +1,3851 @@
+#![allow(clippy::drop_non_drop, clippy::question_mark)]
+
+#[cfg(feature = "gpu_wgpu")]
+mod gpu;
+
+use after_effects as ae;
+use std::collections::VecDeque;
+use std::env;
+#[cfg(feature = "gpu_wgpu")]
+use std::sync::OnceLock;
+use std::sync::{Arc, Mutex};
+
+use ae::pf::*;
+#[cfg(feature = "gpu_wgpu")]
+use gpu::{GpuBoundaryCondition, SolveParams, WgpuContext};
+use utils::ToPixel;
+use utils::image::{
+    SampleEdge, luma, read_layer, sample_bilinear, sanitize_pixel, unpremultiplied_rgb,
+};
+
+const PLUGIN_DESCRIPTION: &str = "Relights images using color-region, channel-generated, or supplied normal maps with configurable material and light controls.";
+const NORMAL_LAYER_CHECKOUT_ID: u32 = 1;
+
+#[derive(Eq, PartialEq, Hash, Clone, Copy, Debug)]
+enum Params {
+    NormalStart,
+    NormalSource,
+    GeneratedStart,
+    GenerationMethod,
+    ColorRegionsStart,
+    ColorTolerance,
+    AlphaThreshold,
+    RegionRadius,
+    RegionShape,
+    EdgeSoftness,
+    ColorRegionsEnd,
+    HeightChannelStart,
+    HeightChannel,
+    HeightBlur,
+    HeightChannelEnd,
+    NormalStrength,
+    InvertHeight,
+    GeneratedEnd,
+    ExternalStart,
+    NormalLayer,
+    NormalScale,
+    NormalY,
+    ExternalEnd,
+    NormalEnd,
+    LightStart,
+    LightType,
+    LightColor,
+    LightIntensity,
+    DirectionAzimuth,
+    DirectionElevation,
+    PointPosition,
+    PointHeight,
+    PointRadius,
+    LightEnd,
+    MaterialStart,
+    Ambient,
+    Diffuse,
+    Specular,
+    Shininess,
+    Exposure,
+    ClampOutput,
+    MaterialEnd,
+    OutputMode,
+    // Appended after the v0.2 parameter sequence to preserve existing project indices.
+    RegionSolverStart,
+    RegionSolver,
+    BoundaryCondition,
+    PoissonIterations,
+    PoissonCurvature,
+    ScreenedDamping,
+    EdgeFeather,
+    RegionSolverEnd,
+    // Appended after the v0.4 parameter sequence to preserve existing project indices.
+    PrincipledStart,
+    MaterialModel,
+    BaseTint,
+    Metallic,
+    Roughness,
+    Ior,
+    SpecularIorLevel,
+    EnvironmentStrength,
+    PrincipledEnd,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum NormalSource {
+    Generated,
+    Layer,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum GenerationMethod {
+    ColorRegions,
+    HeightChannel,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RegionSolver {
+    DistanceField,
+    Poisson,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum BoundaryCondition {
+    Dirichlet,
+    Neumann,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum HeightChannel {
+    Luminance,
+    Alpha,
+    Red,
+    Green,
+    Blue,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum NormalY {
+    OpenGl,
+    DirectX,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum LightType {
+    Directional,
+    Point,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum MaterialModel {
+    Principled,
+    LegacyBlinnPhong,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum OutputMode {
+    Relit,
+    Normal,
+    Height,
+    Diffuse,
+    Specular,
+    Lighting,
+}
+
+impl OutputMode {
+    fn uses_lighting(self) -> bool {
+        !matches!(self, Self::Normal | Self::Height)
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Settings {
+    normal_source: NormalSource,
+    generation_method: GenerationMethod,
+    color_tolerance: f32,
+    alpha_threshold: f32,
+    region_solver: RegionSolver,
+    region_radius: f32,
+    region_shape: f32,
+    boundary_condition: BoundaryCondition,
+    poisson_iterations: usize,
+    poisson_curvature: f32,
+    screened_damping: f32,
+    edge_feather: f32,
+    edge_softness: f32,
+    height_channel: HeightChannel,
+    height_blur: f32,
+    normal_strength: f32,
+    invert_height: bool,
+    normal_scale: f32,
+    normal_y: NormalY,
+    light_type: LightType,
+    light_color: [f32; 3],
+    light_intensity: f32,
+    direction_azimuth: f32,
+    direction_elevation: f32,
+    point_position: (f32, f32),
+    point_height: f32,
+    point_radius: f32,
+    ambient: f32,
+    diffuse: f32,
+    specular: f32,
+    shininess: f32,
+    material_model: MaterialModel,
+    base_tint: [f32; 3],
+    metallic: f32,
+    roughness: f32,
+    ior: f32,
+    specular_ior_level: f32,
+    environment_strength: f32,
+    exposure: f32,
+    clamp_output: bool,
+    output_mode: OutputMode,
+    pixel_scale: (f32, f32),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct SurfaceSettingsKey {
+    color_tolerance: u32,
+    alpha_threshold: u32,
+    region_solver: RegionSolver,
+    region_radius: u32,
+    region_shape: u32,
+    boundary_condition: BoundaryCondition,
+    poisson_iterations: usize,
+    poisson_curvature: u32,
+    screened_damping: u32,
+    edge_feather: u32,
+    edge_softness: u32,
+    normal_strength: u32,
+    invert_height: bool,
+    pixel_scale_x: u32,
+    pixel_scale_y: u32,
+}
+
+impl From<Settings> for SurfaceSettingsKey {
+    fn from(settings: Settings) -> Self {
+        Self {
+            color_tolerance: settings.color_tolerance.to_bits(),
+            alpha_threshold: settings.alpha_threshold.to_bits(),
+            region_solver: settings.region_solver,
+            region_radius: settings.region_radius.to_bits(),
+            region_shape: settings.region_shape.to_bits(),
+            boundary_condition: settings.boundary_condition,
+            poisson_iterations: settings.poisson_iterations,
+            poisson_curvature: settings.poisson_curvature.to_bits(),
+            screened_damping: settings.screened_damping.to_bits(),
+            edge_feather: settings.edge_feather.to_bits(),
+            edge_softness: settings.edge_softness.to_bits(),
+            normal_strength: settings.normal_strength.to_bits(),
+            invert_height: settings.invert_height,
+            pixel_scale_x: settings.pixel_scale.0.to_bits(),
+            pixel_scale_y: settings.pixel_scale.1.to_bits(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct SurfaceCacheKey {
+    source_hash: [u64; 4],
+    width: usize,
+    height: usize,
+    source_origin_h: i32,
+    source_origin_v: i32,
+    settings: SurfaceSettingsKey,
+}
+
+impl SurfaceCacheKey {
+    fn new(
+        source: &[PixelF32],
+        width: usize,
+        height: usize,
+        source_origin: ae::Point,
+        settings: Settings,
+    ) -> Self {
+        Self {
+            source_hash: source_content_hash(source),
+            width,
+            height,
+            source_origin_h: source_origin.h,
+            source_origin_v: source_origin.v,
+            settings: settings.into(),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct SurfaceMaps {
+    heights: Arc<[f32]>,
+    normals: Arc<[[f32; 3]]>,
+}
+
+impl SurfaceMaps {
+    fn new(heights: Vec<f32>, normals: Vec<[f32; 3]>) -> Self {
+        Self {
+            heights: heights.into(),
+            normals: normals.into(),
+        }
+    }
+}
+
+struct SurfaceCacheEntry {
+    key: SurfaceCacheKey,
+    maps: SurfaceMaps,
+}
+
+#[derive(Default)]
+struct SurfaceCache {
+    entry: Mutex<Option<SurfaceCacheEntry>>,
+}
+
+impl SurfaceCache {
+    fn get_or_build(
+        &self,
+        key: SurfaceCacheKey,
+        build: impl FnOnce() -> SurfaceMaps,
+    ) -> SurfaceMaps {
+        // The lock intentionally covers construction. It guarantees that competing Smart Render
+        // tiles for one frame execute the expensive full-frame solver exactly once.
+        let mut entry = self.entry.lock().unwrap_or_else(|error| error.into_inner());
+        if let Some(cached) = entry.as_ref()
+            && cached.key == key
+        {
+            return cached.maps.clone();
+        }
+        // Drop an unused previous frame before the new full-frame solve to avoid
+        // retaining two large surface maps at the peak of a cache miss.
+        *entry = None;
+        let maps = build();
+        *entry = Some(SurfaceCacheEntry {
+            key,
+            maps: maps.clone(),
+        });
+        maps
+    }
+
+    fn clear(&self) {
+        let mut entry = self.entry.lock().unwrap_or_else(|error| error.into_inner());
+        *entry = None;
+    }
+}
+
+fn source_content_hash(source: &[PixelF32]) -> [u64; 4] {
+    let mut state = [
+        0xA0D1_6A2B_9374_C5E8,
+        0x6C8E_9CF5_701A_42D3,
+        0xD1B5_4A32_D192_ED03,
+        0x94D0_49BB_1331_11EB,
+    ];
+    for (index, pixel) in source.iter().enumerate() {
+        let alpha_red = ((pixel.alpha.to_bits() as u64) << 32) | pixel.red.to_bits() as u64;
+        let green_blue = ((pixel.green.to_bits() as u64) << 32) | pixel.blue.to_bits() as u64;
+        let position = index as u64;
+        state[0] = mix_fingerprint_lane(state[0], alpha_red ^ position);
+        state[1] = mix_fingerprint_lane(
+            state[1],
+            green_blue ^ position.wrapping_mul(0x9E37_79B1_85EB_CA87),
+        );
+        state[2] =
+            mix_fingerprint_lane(state[2], alpha_red.rotate_left(23) ^ green_blue ^ !position);
+        state[3] = mix_fingerprint_lane(
+            state[3],
+            green_blue.rotate_right(17) ^ alpha_red ^ position.rotate_left(31),
+        );
+    }
+    let length = source.len() as u64;
+    for (lane, value) in state.iter_mut().enumerate() {
+        *value =
+            finalize_fingerprint(*value ^ length.wrapping_mul(0xD6E8_FEB8_6659_FD93 ^ lane as u64));
+    }
+    state
+}
+
+fn mix_fingerprint_lane(state: u64, value: u64) -> u64 {
+    state
+        .rotate_left(27)
+        .wrapping_add(finalize_fingerprint(value))
+        .wrapping_mul(0x9E37_79B1_85EB_CA87)
+}
+
+fn finalize_fingerprint(mut value: u64) -> u64 {
+    value ^= value >> 30;
+    value = value.wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    value ^= value >> 27;
+    value = value.wrapping_mul(0x94D0_49BB_1331_11EB);
+    value ^ (value >> 31)
+}
+
+#[derive(Default)]
+struct Plugin {
+    aegp_id: Option<ae::aegp::PluginId>,
+    surface_cache: SurfaceCache,
+}
+
+struct LayerCheckoutGuard<const N: usize> {
+    callbacks: SmartRenderCallbacks,
+    checkout_ids: [u32; N],
+    count: usize,
+}
+
+impl<const N: usize> LayerCheckoutGuard<N> {
+    fn new(callbacks: SmartRenderCallbacks) -> Self {
+        Self {
+            callbacks,
+            checkout_ids: [0; N],
+            count: 0,
+        }
+    }
+
+    fn checkout(&mut self, checkout_id: u32) -> Result<Option<Layer>, Error> {
+        assert!(self.count < N, "layer checkout guard capacity exceeded");
+        let layer = self.callbacks.checkout_layer_pixels(checkout_id)?;
+        self.checkout_ids[self.count] = checkout_id;
+        self.count += 1;
+        Ok(layer)
+    }
+
+    fn checkin_all(&mut self) -> Result<(), Error> {
+        let mut first_error = None;
+        while self.count > 0 {
+            self.count -= 1;
+            if let Err(error) = self
+                .callbacks
+                .checkin_layer_pixels(self.checkout_ids[self.count])
+                && first_error.is_none()
+            {
+                first_error = Some(error);
+            }
+        }
+        first_error.map_or(Ok(()), Err)
+    }
+}
+
+impl<const N: usize> Drop for LayerCheckoutGuard<N> {
+    fn drop(&mut self) {
+        let _ = self.checkin_all();
+    }
+}
+
+ae::define_effect!(Plugin, (), Params);
+
+impl AdobePluginGlobal for Plugin {
+    fn params_setup(
+        &self,
+        params: &mut ae::Parameters<Params>,
+        _in_data: InData,
+        _: OutData,
+    ) -> Result<(), Error> {
+        let supervise = || {
+            ae::ParamFlag::SUPERVISE
+                | ae::ParamFlag::CANNOT_TIME_VARY
+                | ae::ParamFlag::CANNOT_INTERP
+        };
+
+        params.add_group(
+            Params::NormalStart,
+            Params::NormalEnd,
+            "Normal Source",
+            false,
+            |params| {
+                params.add_with_flags(
+                    Params::NormalSource,
+                    "Source",
+                    PopupDef::setup(|d| {
+                        d.set_options(&["Generated", "Normal Layer"]);
+                        d.set_default(1);
+                    }),
+                    supervise(),
+                    ParamUIFlags::empty(),
+                )?;
+                params.add_group(
+                    Params::GeneratedStart,
+                    Params::GeneratedEnd,
+                    "Generated Normal",
+                    false,
+                    |params| {
+                        params.add_with_flags(
+                            Params::GenerationMethod,
+                            "Method",
+                            PopupDef::setup(|d| {
+                                d.set_options(&["Color Regions", "Height Channel"]);
+                                d.set_default(1);
+                            }),
+                            supervise(),
+                            ParamUIFlags::empty(),
+                        )?;
+                        params.add_group(
+                            Params::ColorRegionsStart,
+                            Params::ColorRegionsEnd,
+                            "Color Regions",
+                            false,
+                            |params| {
+                                add_float_slider(
+                                    params,
+                                    Params::ColorTolerance,
+                                    "Color Tolerance",
+                                    0.0,
+                                    1.0,
+                                    0.0,
+                                    0.2,
+                                    0.02,
+                                    3,
+                                )?;
+                                add_float_slider(
+                                    params,
+                                    Params::AlphaThreshold,
+                                    "Alpha Threshold",
+                                    0.0,
+                                    1.0,
+                                    0.0,
+                                    1.0,
+                                    0.01,
+                                    3,
+                                )?;
+                                add_float_slider(
+                                    params,
+                                    Params::RegionRadius,
+                                    "Region Radius (px)",
+                                    0.01,
+                                    4096.0,
+                                    1.0,
+                                    256.0,
+                                    32.0,
+                                    1,
+                                )?;
+                                add_float_slider(
+                                    params,
+                                    Params::RegionShape,
+                                    "Height Shape",
+                                    0.05,
+                                    16.0,
+                                    0.1,
+                                    8.0,
+                                    2.0,
+                                    2,
+                                )?;
+                                add_float_slider(
+                                    params,
+                                    Params::EdgeSoftness,
+                                    "Edge Softness (px)",
+                                    0.0,
+                                    1024.0,
+                                    0.0,
+                                    128.0,
+                                    1.0,
+                                    1,
+                                )?;
+                                Ok(())
+                            },
+                        )?;
+                        params.add_group(
+                            Params::HeightChannelStart,
+                            Params::HeightChannelEnd,
+                            "Height Channel",
+                            false,
+                            |params| {
+                                params.add(
+                                    Params::HeightChannel,
+                                    "Channel",
+                                    PopupDef::setup(|d| {
+                                        d.set_options(&[
+                                            "Luminance",
+                                            "Alpha",
+                                            "Red",
+                                            "Green",
+                                            "Blue",
+                                        ]);
+                                        d.set_default(1);
+                                    }),
+                                )?;
+                                params.add(
+                                    Params::HeightBlur,
+                                    "Height Blur (px)",
+                                    FloatSliderDef::setup(|d| {
+                                        d.set_valid_min(0.0);
+                                        d.set_valid_max(256.0);
+                                        d.set_slider_min(0.0);
+                                        d.set_slider_max(64.0);
+                                        d.set_default(1.0);
+                                        d.set_precision(1);
+                                    }),
+                                )?;
+                                Ok(())
+                            },
+                        )?;
+                        params.add(
+                            Params::NormalStrength,
+                            "Normal Strength",
+                            FloatSliderDef::setup(|d| {
+                                d.set_valid_min(0.0);
+                                d.set_valid_max(100.0);
+                                d.set_slider_min(0.0);
+                                d.set_slider_max(20.0);
+                                d.set_default(5.0);
+                                d.set_precision(2);
+                            }),
+                        )?;
+                        params.add(
+                            Params::InvertHeight,
+                            "Invert Height",
+                            CheckBoxDef::setup(|d| {
+                                d.set_default(false);
+                            }),
+                        )?;
+                        Ok(())
+                    },
+                )?;
+                params.add_group(
+                    Params::ExternalStart,
+                    Params::ExternalEnd,
+                    "Normal Layer",
+                    false,
+                    |params| {
+                        params.add(Params::NormalLayer, "Layer", LayerDef::new())?;
+                        params.add(
+                            Params::NormalScale,
+                            "XY Scale",
+                            FloatSliderDef::setup(|d| {
+                                d.set_valid_min(-20.0);
+                                d.set_valid_max(20.0);
+                                d.set_slider_min(-4.0);
+                                d.set_slider_max(4.0);
+                                d.set_default(1.0);
+                                d.set_precision(3);
+                            }),
+                        )?;
+                        params.add(
+                            Params::NormalY,
+                            "Y Convention",
+                            PopupDef::setup(|d| {
+                                d.set_options(&["OpenGL (+Y)", "DirectX (-Y)"]);
+                                d.set_default(1);
+                            }),
+                        )?;
+                        Ok(())
+                    },
+                )?;
+                Ok(())
+            },
+        )?;
+
+        params.add_group(
+            Params::LightStart,
+            Params::LightEnd,
+            "Light",
+            false,
+            |params| {
+                params.add_with_flags(
+                    Params::LightType,
+                    "Type",
+                    PopupDef::setup(|d| {
+                        d.set_options(&["Directional", "Point"]);
+                        d.set_default(1);
+                    }),
+                    supervise(),
+                    ParamUIFlags::empty(),
+                )?;
+                params.add(
+                    Params::LightColor,
+                    "Color",
+                    ColorDef::setup(|d| {
+                        d.set_default(Pixel8 {
+                            alpha: 255,
+                            red: 255,
+                            green: 255,
+                            blue: 255,
+                        });
+                    }),
+                )?;
+                add_float_slider(
+                    params,
+                    Params::LightIntensity,
+                    "Intensity",
+                    0.0,
+                    100.0,
+                    0.0,
+                    8.0,
+                    1.0,
+                    3,
+                )?;
+                params.add(
+                    Params::DirectionAzimuth,
+                    "Azimuth",
+                    AngleDef::setup(|d| {
+                        d.set_default(-45.0);
+                    }),
+                )?;
+                add_float_slider(
+                    params,
+                    Params::DirectionElevation,
+                    "Elevation",
+                    -89.9,
+                    89.9,
+                    -89.9,
+                    89.9,
+                    45.0,
+                    2,
+                )?;
+                params.add(
+                    Params::PointPosition,
+                    "Position",
+                    PointDef::setup(|d| {
+                        d.set_default((50.0, 50.0));
+                    }),
+                )?;
+                add_float_slider(
+                    params,
+                    Params::PointHeight,
+                    "Height (px)",
+                    0.01,
+                    100000.0,
+                    1.0,
+                    4000.0,
+                    500.0,
+                    2,
+                )?;
+                add_float_slider(
+                    params,
+                    Params::PointRadius,
+                    "Falloff Radius (px)",
+                    0.01,
+                    100000.0,
+                    1.0,
+                    4000.0,
+                    1000.0,
+                    2,
+                )?;
+                Ok(())
+            },
+        )?;
+
+        params.add_group(
+            Params::MaterialStart,
+            Params::MaterialEnd,
+            "Output / Legacy Material",
+            true,
+            |params| {
+                add_float_slider(
+                    params,
+                    Params::Ambient,
+                    "Ambient",
+                    0.0,
+                    10.0,
+                    0.0,
+                    2.0,
+                    0.1,
+                    3,
+                )?;
+                add_float_slider(
+                    params,
+                    Params::Diffuse,
+                    "Diffuse",
+                    0.0,
+                    10.0,
+                    0.0,
+                    2.0,
+                    1.0,
+                    3,
+                )?;
+                add_float_slider(
+                    params,
+                    Params::Specular,
+                    "Specular",
+                    0.0,
+                    10.0,
+                    0.0,
+                    2.0,
+                    0.3,
+                    3,
+                )?;
+                add_float_slider(
+                    params,
+                    Params::Shininess,
+                    "Shininess",
+                    1.0,
+                    2048.0,
+                    1.0,
+                    256.0,
+                    32.0,
+                    1,
+                )?;
+                add_float_slider(
+                    params,
+                    Params::Exposure,
+                    "Exposure (EV)",
+                    -20.0,
+                    20.0,
+                    -5.0,
+                    5.0,
+                    0.0,
+                    2,
+                )?;
+                params.add(
+                    Params::ClampOutput,
+                    "Clamp Output",
+                    CheckBoxDef::setup(|d| {
+                        d.set_default(true);
+                    }),
+                )?;
+                params.add_with_flags(
+                    Params::OutputMode,
+                    "Output",
+                    PopupDef::setup(|d| {
+                        d.set_options(&[
+                            "Relit Image",
+                            "Normal Map",
+                            "Height",
+                            "Diffuse",
+                            "Specular",
+                            "Lighting",
+                        ]);
+                        d.set_default(1);
+                    }),
+                    supervise(),
+                    ParamUIFlags::empty(),
+                )?;
+                Ok(())
+            },
+        )?;
+
+        // Keep this group appended so v0.2 project parameter indices remain stable.
+        params.add_group(
+            Params::RegionSolverStart,
+            Params::RegionSolverEnd,
+            "Color Region Solver",
+            false,
+            |params| {
+                params.add_with_flags(
+                    Params::RegionSolver,
+                    "Surface Solver",
+                    PopupDef::setup(|d| {
+                        d.set_options(&["Distance Field (SDF)", "Poisson / Neumann (Smooth)"]);
+                        d.set_default(2);
+                    }),
+                    supervise(),
+                    ParamUIFlags::empty(),
+                )?;
+                params.add(
+                    Params::BoundaryCondition,
+                    "Boundary Condition",
+                    PopupDef::setup(|d| {
+                        d.set_options(&["Fixed Height (Dirichlet)", "Normal Continuity (Neumann)"]);
+                        d.set_default(2);
+                    }),
+                )?;
+                params.add(
+                    Params::PoissonIterations,
+                    "Iterations",
+                    SliderDef::setup(|d| {
+                        d.set_valid_min(1);
+                        d.set_valid_max(2000);
+                        d.set_slider_min(1);
+                        d.set_slider_max(400);
+                        d.set_default(160);
+                    }),
+                )?;
+                add_float_slider(
+                    params,
+                    Params::PoissonCurvature,
+                    "Divergence / Curvature",
+                    0.0,
+                    50.0,
+                    0.0,
+                    10.0,
+                    1.5,
+                    3,
+                )?;
+                add_float_slider(
+                    params,
+                    Params::ScreenedDamping,
+                    "Screened Damping",
+                    0.0,
+                    4.0,
+                    0.0,
+                    2.0,
+                    0.02,
+                    3,
+                )?;
+                add_float_slider(
+                    params,
+                    Params::EdgeFeather,
+                    "Edge Feather (px)",
+                    0.0,
+                    1024.0,
+                    0.0,
+                    128.0,
+                    8.0,
+                    1,
+                )?;
+                Ok(())
+            },
+        )?;
+
+        // Keep Principled controls appended so all v0.4 and earlier indices remain stable.
+        params.add_group(
+            Params::PrincipledStart,
+            Params::PrincipledEnd,
+            "Material",
+            true,
+            |params| {
+                params.add_with_flags(
+                    Params::MaterialModel,
+                    "Surface",
+                    PopupDef::setup(|d| {
+                        d.set_options(&["Principled (GGX)", "Legacy Blinn-Phong"]);
+                        d.set_default(1);
+                    }),
+                    supervise(),
+                    ParamUIFlags::empty(),
+                )?;
+                params.add(
+                    Params::BaseTint,
+                    "Base Tint",
+                    ColorDef::setup(|d| {
+                        d.set_default(Pixel8 {
+                            alpha: 255,
+                            red: 255,
+                            green: 255,
+                            blue: 255,
+                        });
+                    }),
+                )?;
+                add_float_slider(
+                    params,
+                    Params::Metallic,
+                    "Metallic",
+                    0.0,
+                    1.0,
+                    0.0,
+                    1.0,
+                    0.0,
+                    3,
+                )?;
+                add_float_slider(
+                    params,
+                    Params::Roughness,
+                    "Roughness",
+                    0.0,
+                    1.0,
+                    0.0,
+                    1.0,
+                    0.5,
+                    3,
+                )?;
+                add_float_slider(params, Params::Ior, "IOR", 1.0, 4.0, 1.0, 3.0, 1.5, 3)?;
+                add_float_slider(
+                    params,
+                    Params::SpecularIorLevel,
+                    "Specular IOR Level",
+                    0.0,
+                    1.0,
+                    0.0,
+                    1.0,
+                    0.5,
+                    3,
+                )?;
+                add_float_slider(
+                    params,
+                    Params::EnvironmentStrength,
+                    "Environment Strength",
+                    0.0,
+                    10.0,
+                    0.0,
+                    2.0,
+                    0.1,
+                    3,
+                )?;
+                Ok(())
+            },
+        )?;
+        Ok(())
+    }
+
+    fn handle_command(
+        &mut self,
+        cmd: ae::Command,
+        in_data: InData,
+        mut out_data: OutData,
+        params: &mut ae::Parameters<Params>,
+    ) -> Result<(), ae::Error> {
+        match cmd {
+            ae::Command::About => out_data.set_return_msg(
+                format!(
+                    "AOD_ImageRelight - {version}\r\r{PLUGIN_DESCRIPTION}\rCopyright (c) 2026-{year} Aodaruma",
+                    version = env!("CARGO_PKG_VERSION"),
+                    year = env!("BUILD_YEAR")
+                )
+                .as_str(),
+            ),
+            ae::Command::GlobalSetup => {
+                out_data.set_out_flag(OutFlags::UseOutputExtent, true);
+                out_data.set_out_flag(OutFlags::DeepColorAware, true);
+                out_data.set_out_flag(OutFlags::SendUpdateParamsUi, true);
+                out_data.set_out_flag2(OutFlags2::FloatColorAware, true);
+                out_data.set_out_flag2(OutFlags2::SupportsSmartRender, true);
+                out_data.set_out_flag2(OutFlags2::ParamGroupStartCollapsedFlag, true);
+                if let Ok(suite) = ae::aegp::suites::Utility::new()
+                    && let Ok(plugin_id) = suite.register_with_aegp("AOD_ImageRelight")
+                {
+                    self.aegp_id = Some(plugin_id);
+                }
+            }
+            ae::Command::Render { in_layer, out_layer } => {
+                self.render_legacy(in_data, in_layer, out_layer, params)?;
+            }
+            ae::Command::SmartPreRender { mut extra } => {
+                let request = extra.output_request();
+                let callbacks = extra.callbacks();
+                let input_result = checkout_full_layer(callbacks, 0, 1000, 0, &request, in_data)?;
+                let full_rect: ae::Rect = input_result.max_result_rect.into();
+                let _ = extra.union_result_rect(full_rect);
+                let _ = extra.union_max_result_rect(full_rect);
+                extra.set_returns_extra_pixels(true);
+
+                if normal_source(params)? == NormalSource::Layer {
+                    let param_index = params.index(Params::NormalLayer).ok_or(Error::BadCallbackParameter)?;
+                    checkout_full_layer(
+                        callbacks,
+                        param_index as i32,
+                        1001,
+                        NORMAL_LAYER_CHECKOUT_ID,
+                        &request,
+                        in_data,
+                    )?;
+                }
+            }
+            ae::Command::SmartRender { extra } => {
+                let cb = extra.callbacks();
+                let settings = read_settings(params, in_data)?;
+                let mut checkouts = LayerCheckoutGuard::<2>::new(cb);
+                let render_result = (|| -> Result<(), Error> {
+                    let normal_layer = if settings.normal_source == NormalSource::Layer {
+                        checkouts.checkout(NORMAL_LAYER_CHECKOUT_ID)?
+                    } else {
+                        None
+                    };
+                    let input = checkouts.checkout(0)?;
+                    let output = cb.checkout_output()?;
+                    if let (Some(input), Some(output)) = (input, output) {
+                        self.do_render(input, output, normal_layer.as_ref(), settings)
+                    } else {
+                        Ok(())
+                    }
+                })();
+                let checkin_result = checkouts.checkin_all();
+                render_result?;
+                checkin_result?;
+            }
+            ae::Command::UserChangedParam { param_index } => {
+                if matches!(
+                    params.type_at(param_index),
+                    Params::NormalSource
+                        | Params::GenerationMethod
+                        | Params::RegionSolver
+                        | Params::LightType
+                        | Params::MaterialModel
+                        | Params::OutputMode
+                ) {
+                    out_data.set_out_flag(OutFlags::RefreshUi, true);
+                }
+            }
+            ae::Command::UpdateParamsUi => {
+                let mut cloned = params.cloned();
+                self.update_params_ui(in_data, &mut cloned)?;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+}
+
+impl Plugin {
+    fn render_legacy(
+        &self,
+        in_data: InData,
+        in_layer: Layer,
+        out_layer: Layer,
+        params: &mut Parameters<Params>,
+    ) -> Result<(), Error> {
+        let settings = read_settings(params, in_data)?;
+        if settings.normal_source == NormalSource::Layer {
+            let checkout = params.checkout_at(Params::NormalLayer, None, None, None)?;
+            let normal_layer = checkout.as_layer()?.value();
+            self.do_render(in_layer, out_layer, normal_layer.as_ref(), settings)
+        } else {
+            self.do_render(in_layer, out_layer, None, settings)
+        }
+    }
+
+    fn update_params_ui(
+        &self,
+        in_data: InData,
+        params: &mut Parameters<Params>,
+    ) -> Result<(), Error> {
+        let generated = normal_source(params)? == NormalSource::Generated;
+        for id in [
+            Params::GeneratedStart,
+            Params::GenerationMethod,
+            Params::NormalStrength,
+            Params::InvertHeight,
+            Params::GeneratedEnd,
+        ] {
+            self.set_param_visible(in_data, params, id, generated)?;
+        }
+        for id in [
+            Params::ExternalStart,
+            Params::NormalLayer,
+            Params::NormalScale,
+            Params::NormalY,
+            Params::ExternalEnd,
+        ] {
+            self.set_param_visible(in_data, params, id, !generated)?;
+        }
+
+        let color_regions =
+            generated && generation_method(params)? == GenerationMethod::ColorRegions;
+        for id in [
+            Params::ColorRegionsStart,
+            Params::ColorTolerance,
+            Params::AlphaThreshold,
+            Params::EdgeSoftness,
+            Params::ColorRegionsEnd,
+        ] {
+            self.set_param_visible(in_data, params, id, color_regions)?;
+        }
+        for id in [
+            Params::RegionSolverStart,
+            Params::RegionSolver,
+            Params::RegionSolverEnd,
+        ] {
+            self.set_param_visible(in_data, params, id, color_regions)?;
+        }
+        let sdf = color_regions && region_solver(params)? == RegionSolver::DistanceField;
+        for id in [Params::RegionRadius, Params::RegionShape] {
+            self.set_param_visible(in_data, params, id, sdf)?;
+        }
+        let poisson = color_regions && region_solver(params)? == RegionSolver::Poisson;
+        for id in [
+            Params::BoundaryCondition,
+            Params::PoissonIterations,
+            Params::PoissonCurvature,
+            Params::ScreenedDamping,
+            Params::EdgeFeather,
+        ] {
+            self.set_param_visible(in_data, params, id, poisson)?;
+        }
+        let height_channel =
+            generated && generation_method(params)? == GenerationMethod::HeightChannel;
+        for id in [
+            Params::HeightChannelStart,
+            Params::HeightChannel,
+            Params::HeightBlur,
+            Params::HeightChannelEnd,
+        ] {
+            self.set_param_visible(in_data, params, id, height_channel)?;
+        }
+
+        let light_type = light_type(params)?;
+        let output = output_mode(params)?;
+        let lighting = output.uses_lighting();
+        for id in [
+            Params::LightStart,
+            Params::LightType,
+            Params::LightColor,
+            Params::LightIntensity,
+            Params::LightEnd,
+        ] {
+            self.set_param_visible(in_data, params, id, lighting)?;
+        }
+        let directional = lighting && light_type == LightType::Directional;
+        self.set_param_visible(in_data, params, Params::DirectionAzimuth, directional)?;
+        self.set_param_visible(in_data, params, Params::DirectionElevation, directional)?;
+        let point = lighting && light_type == LightType::Point;
+        self.set_param_visible(in_data, params, Params::PointPosition, point)?;
+        self.set_param_visible(in_data, params, Params::PointHeight, point)?;
+        self.set_param_visible(in_data, params, Params::PointRadius, point)?;
+
+        let principled = lighting && material_model(params)? == MaterialModel::Principled;
+        let legacy = lighting && !principled;
+        self.set_param_visible(
+            in_data,
+            params,
+            Params::Ambient,
+            legacy && matches!(output, OutputMode::Relit | OutputMode::Lighting),
+        )?;
+        self.set_param_visible(
+            in_data,
+            params,
+            Params::Diffuse,
+            legacy
+                && matches!(
+                    output,
+                    OutputMode::Relit | OutputMode::Diffuse | OutputMode::Lighting
+                ),
+        )?;
+        let show_specular = matches!(
+            output,
+            OutputMode::Relit | OutputMode::Specular | OutputMode::Lighting
+        );
+        self.set_param_visible(in_data, params, Params::Specular, legacy && show_specular)?;
+        self.set_param_visible(in_data, params, Params::Shininess, legacy && show_specular)?;
+        for id in [
+            Params::PrincipledStart,
+            Params::MaterialModel,
+            Params::PrincipledEnd,
+        ] {
+            self.set_param_visible(in_data, params, id, lighting)?;
+        }
+        for id in [
+            Params::BaseTint,
+            Params::Metallic,
+            Params::Roughness,
+            Params::Ior,
+            Params::SpecularIorLevel,
+        ] {
+            self.set_param_visible(in_data, params, id, principled)?;
+        }
+        self.set_param_visible(
+            in_data,
+            params,
+            Params::EnvironmentStrength,
+            principled && matches!(output, OutputMode::Relit | OutputMode::Lighting),
+        )?;
+        self.set_param_visible(in_data, params, Params::Exposure, lighting)?;
+        self.set_param_visible(in_data, params, Params::ClampOutput, lighting)?;
+        Ok(())
+    }
+
+    fn set_param_visible(
+        &self,
+        in_data: InData,
+        params: &mut Parameters<Params>,
+        id: Params,
+        visible: bool,
+    ) -> Result<(), Error> {
+        if in_data.is_premiere() {
+            return Self::set_param_ui_flag(params, id, ParamUIFlags::INVISIBLE, !visible);
+        }
+        if let Some(plugin_id) = self.aegp_id {
+            let effect = in_data.effect();
+            if let Some(index) = params.index(id)
+                && let Ok(effect_ref) = effect.aegp_effect(plugin_id)
+                && let Ok(stream) = effect_ref.new_stream_by_index(plugin_id, index as i32)
+            {
+                return stream.set_dynamic_stream_flag(
+                    ae::aegp::DynamicStreamFlags::Hidden,
+                    false,
+                    !visible,
+                );
+            }
+        }
+        Self::set_param_ui_flag(params, id, ParamUIFlags::INVISIBLE, !visible)
+    }
+
+    fn set_param_ui_flag(
+        params: &mut Parameters<Params>,
+        id: Params,
+        flag: ParamUIFlags,
+        status: bool,
+    ) -> Result<(), Error> {
+        let current = (params.get(id)?.ui_flags().bits() & flag.bits()) != 0;
+        if current == status {
+            return Ok(());
+        }
+        let mut param = params.get_mut(id)?;
+        param.set_ui_flag(flag, status);
+        param.update_param_ui()?;
+        Ok(())
+    }
+
+    fn do_render(
+        &self,
+        in_layer: Layer,
+        mut out_layer: Layer,
+        normal_layer: Option<&Layer>,
+        mut settings: Settings,
+    ) -> Result<(), Error> {
+        let src_width = in_layer.width();
+        let src_height = in_layer.height();
+        let out_width = out_layer.width();
+        let out_height = out_layer.height();
+        if src_width == 0 || src_height == 0 || out_width == 0 || out_height == 0 {
+            return Ok(());
+        }
+        settings.point_position =
+            point_in_checkout_world(settings.point_position, in_layer.origin());
+        let source = read_layer(&in_layer);
+        let source_origin = in_layer.origin();
+        let output_origin = out_layer.origin();
+        let surface_maps = if settings.normal_source == NormalSource::Generated
+            && settings.generation_method == GenerationMethod::ColorRegions
+        {
+            let key = SurfaceCacheKey::new(&source, src_width, src_height, source_origin, settings);
+            self.surface_cache.get_or_build(key, || {
+                let (heights, normals) = build_surface_maps(
+                    &source,
+                    src_width,
+                    src_height,
+                    source_origin,
+                    None,
+                    settings,
+                );
+                SurfaceMaps::new(heights, normals)
+            })
+        } else {
+            self.surface_cache.clear();
+            let (heights, normals) = build_surface_maps(
+                &source,
+                src_width,
+                src_height,
+                source_origin,
+                normal_layer,
+                settings,
+            );
+            SurfaceMaps::new(heights, normals)
+        };
+        let shading = PreparedShading::new(settings);
+        let origin_delta_x = output_origin.h - source_origin.h;
+        let origin_delta_y = output_origin.v - source_origin.v;
+        let out_world_type = out_layer.world_type();
+        out_layer.iterate(0, out_height as i32, None, |x, y, mut dst| {
+            let source_x = x + origin_delta_x;
+            let source_y = y + origin_delta_y;
+            let (albedo, height, normal) = if source_x >= 0
+                && source_y >= 0
+                && (source_x as usize) < src_width
+                && (source_y as usize) < src_height
+            {
+                let index = source_y as usize * src_width + source_x as usize;
+                (
+                    source[index],
+                    surface_maps.heights[index],
+                    normalize3(surface_maps.normals[index]),
+                )
+            } else {
+                let sx = source_x as f32;
+                let sy = source_y as f32;
+                (
+                    sample_bilinear(
+                        &source,
+                        src_width,
+                        src_height,
+                        sx,
+                        sy,
+                        SampleEdge::Transparent,
+                    ),
+                    sample_scalar_bilinear(
+                        surface_maps.heights.as_ref(),
+                        src_width,
+                        src_height,
+                        sx,
+                        sy,
+                    ),
+                    sample_normal_bilinear(
+                        surface_maps.normals.as_ref(),
+                        src_width,
+                        src_height,
+                        sx,
+                        sy,
+                    ),
+                )
+            };
+            let pixel = shade_pixel(
+                albedo,
+                height,
+                normal,
+                source_x as f32,
+                source_y as f32,
+                shading,
+            );
+            match out_world_type {
+                ae::aegp::WorldType::U8 => dst.set_from_u8(pixel.to_pixel8()),
+                ae::aegp::WorldType::U15 => dst.set_from_u16(pixel.to_pixel16()),
+                ae::aegp::WorldType::F32 | ae::aegp::WorldType::None => dst.set_from_f32(pixel),
+            }
+            Ok(())
+        })?;
+        Ok(())
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn add_float_slider(
+    params: &mut Parameters<Params>,
+    id: Params,
+    name: &str,
+    valid_min: f32,
+    valid_max: f32,
+    slider_min: f32,
+    slider_max: f32,
+    default: f64,
+    precision: i16,
+) -> Result<(), Error> {
+    params.add(
+        id,
+        name,
+        FloatSliderDef::setup(|d| {
+            d.set_valid_min(valid_min);
+            d.set_valid_max(valid_max);
+            d.set_slider_min(slider_min);
+            d.set_slider_max(slider_max);
+            d.set_default(default);
+            d.set_precision(precision);
+        }),
+    )?;
+    Ok(())
+}
+
+fn normal_source(params: &Parameters<Params>) -> Result<NormalSource, Error> {
+    Ok(
+        if params.get(Params::NormalSource)?.as_popup()?.value() == 2 {
+            NormalSource::Layer
+        } else {
+            NormalSource::Generated
+        },
+    )
+}
+
+fn generation_method(params: &Parameters<Params>) -> Result<GenerationMethod, Error> {
+    Ok(
+        if params.get(Params::GenerationMethod)?.as_popup()?.value() == 2 {
+            GenerationMethod::HeightChannel
+        } else {
+            GenerationMethod::ColorRegions
+        },
+    )
+}
+
+fn region_solver(params: &Parameters<Params>) -> Result<RegionSolver, Error> {
+    Ok(
+        if params.get(Params::RegionSolver)?.as_popup()?.value() == 2 {
+            RegionSolver::Poisson
+        } else {
+            RegionSolver::DistanceField
+        },
+    )
+}
+
+fn light_type(params: &Parameters<Params>) -> Result<LightType, Error> {
+    Ok(if params.get(Params::LightType)?.as_popup()?.value() == 2 {
+        LightType::Point
+    } else {
+        LightType::Directional
+    })
+}
+
+fn material_model(params: &Parameters<Params>) -> Result<MaterialModel, Error> {
+    Ok(
+        if params.get(Params::MaterialModel)?.as_popup()?.value() == 2 {
+            MaterialModel::LegacyBlinnPhong
+        } else {
+            MaterialModel::Principled
+        },
+    )
+}
+
+fn output_mode(params: &Parameters<Params>) -> Result<OutputMode, Error> {
+    Ok(match params.get(Params::OutputMode)?.as_popup()?.value() {
+        2 => OutputMode::Normal,
+        3 => OutputMode::Height,
+        4 => OutputMode::Diffuse,
+        5 => OutputMode::Specular,
+        6 => OutputMode::Lighting,
+        _ => OutputMode::Relit,
+    })
+}
+
+fn read_settings(params: &Parameters<Params>, in_data: InData) -> Result<Settings, Error> {
+    let popup = |id| params.get(id)?.as_popup().map(|p| p.value());
+    let slider = |id| params.get(id)?.as_float_slider().map(|p| p.value() as f32);
+    let light_color = params.get(Params::LightColor)?.as_color()?.float_value()?;
+    let base_tint = params.get(Params::BaseTint)?.as_color()?.float_value()?;
+    Ok(Settings {
+        normal_source: normal_source(params)?,
+        generation_method: generation_method(params)?,
+        color_tolerance: slider(Params::ColorTolerance)?.clamp(0.0, 1.0),
+        alpha_threshold: slider(Params::AlphaThreshold)?.clamp(0.0, 1.0),
+        region_solver: region_solver(params)?,
+        region_radius: slider(Params::RegionRadius)?.max(0.01),
+        region_shape: slider(Params::RegionShape)?.max(0.05),
+        boundary_condition: if popup(Params::BoundaryCondition)? == 2 {
+            BoundaryCondition::Neumann
+        } else {
+            BoundaryCondition::Dirichlet
+        },
+        poisson_iterations: params
+            .get(Params::PoissonIterations)?
+            .as_slider()?
+            .value()
+            .clamp(1, 2000) as usize,
+        poisson_curvature: slider(Params::PoissonCurvature)?.clamp(0.0, 50.0),
+        screened_damping: slider(Params::ScreenedDamping)?.clamp(0.0, 4.0),
+        edge_feather: slider(Params::EdgeFeather)?.clamp(0.0, 1024.0),
+        edge_softness: slider(Params::EdgeSoftness)?.max(0.0),
+        height_channel: match popup(Params::HeightChannel)? {
+            2 => HeightChannel::Alpha,
+            3 => HeightChannel::Red,
+            4 => HeightChannel::Green,
+            5 => HeightChannel::Blue,
+            _ => HeightChannel::Luminance,
+        },
+        height_blur: slider(Params::HeightBlur)?.round().clamp(0.0, 256.0),
+        normal_strength: slider(Params::NormalStrength)?.max(0.0),
+        invert_height: params.get(Params::InvertHeight)?.as_checkbox()?.value(),
+        normal_scale: slider(Params::NormalScale)?,
+        normal_y: if popup(Params::NormalY)? == 2 {
+            NormalY::DirectX
+        } else {
+            NormalY::OpenGl
+        },
+        light_type: light_type(params)?,
+        light_color: [light_color.red, light_color.green, light_color.blue],
+        light_intensity: slider(Params::LightIntensity)?.max(0.0),
+        direction_azimuth: (params
+            .get(Params::DirectionAzimuth)?
+            .as_angle()?
+            .float_value()? as f32)
+            .to_radians(),
+        direction_elevation: slider(Params::DirectionElevation)?.to_radians(),
+        point_position: params.get(Params::PointPosition)?.as_point()?.value(),
+        point_height: slider(Params::PointHeight)?.max(0.01),
+        point_radius: slider(Params::PointRadius)?.max(0.01),
+        ambient: slider(Params::Ambient)?.max(0.0),
+        diffuse: slider(Params::Diffuse)?.max(0.0),
+        specular: slider(Params::Specular)?.max(0.0),
+        shininess: slider(Params::Shininess)?.max(1.0),
+        material_model: material_model(params)?,
+        base_tint: [base_tint.red, base_tint.green, base_tint.blue],
+        metallic: slider(Params::Metallic)?.clamp(0.0, 1.0),
+        roughness: slider(Params::Roughness)?.clamp(0.0, 1.0),
+        ior: slider(Params::Ior)?.clamp(1.0, 4.0),
+        specular_ior_level: slider(Params::SpecularIorLevel)?.clamp(0.0, 1.0),
+        environment_strength: slider(Params::EnvironmentStrength)?.max(0.0),
+        exposure: slider(Params::Exposure)?,
+        clamp_output: params.get(Params::ClampOutput)?.as_checkbox()?.value(),
+        output_mode: output_mode(params)?,
+        pixel_scale: render_pixel_scale(in_data),
+    })
+}
+
+fn render_pixel_scale(in_data: InData) -> (f32, f32) {
+    square_pixel_scale(
+        rational_or_one(in_data.pixel_aspect_ratio()),
+        rational_or_one(in_data.downsample_x()),
+        rational_or_one(in_data.downsample_y()),
+    )
+}
+
+fn rational_or_one(value: RationalScale) -> f32 {
+    if value.num > 0 && value.den > 0 {
+        let ratio = value.num as f32 / value.den as f32;
+        if ratio.is_finite() && ratio > 0.0 {
+            return ratio;
+        }
+    }
+    1.0
+}
+
+fn square_pixel_scale(pixel_aspect: f32, downsample_x: f32, downsample_y: f32) -> (f32, f32) {
+    (
+        pixel_aspect.max(1.0e-6) / downsample_x.max(1.0e-6),
+        1.0 / downsample_y.max(1.0e-6),
+    )
+}
+
+fn point_in_checkout_world(point: (f32, f32), origin: ae::Point) -> (f32, f32) {
+    local_point_in_target(point, ae::Point { h: 0, v: 0 }, origin)
+}
+
+#[cfg(test)]
+fn source_local_from_output_local(
+    x: f32,
+    y: f32,
+    output_origin: ae::Point,
+    source_origin: ae::Point,
+) -> (f32, f32) {
+    local_point_in_target((x, y), output_origin, source_origin)
+}
+
+fn local_point_in_target(
+    point: (f32, f32),
+    point_origin: ae::Point,
+    target_origin: ae::Point,
+) -> (f32, f32) {
+    (
+        point.0 + (point_origin.h - target_origin.h) as f32,
+        point.1 + (point_origin.v - target_origin.v) as f32,
+    )
+}
+
+fn checkout_full_layer(
+    callbacks: PreRenderCallbacks,
+    param_index: i32,
+    query_id: i32,
+    checkout_id: u32,
+    request: &ae::sys::PF_RenderRequest,
+    in_data: InData,
+) -> Result<ae::sys::PF_CheckoutResult, Error> {
+    let query = callbacks.checkout_layer(
+        param_index,
+        query_id,
+        request,
+        in_data.current_time(),
+        in_data.time_step(),
+        in_data.time_scale(),
+    )?;
+    let mut full_request = *request;
+    full_request.rect = query.max_result_rect;
+    callbacks.checkout_layer(
+        param_index,
+        checkout_id as i32,
+        &full_request,
+        in_data.current_time(),
+        in_data.time_step(),
+        in_data.time_scale(),
+    )
+}
+
+fn build_surface_maps(
+    source: &[PixelF32],
+    width: usize,
+    height: usize,
+    source_origin: ae::Point,
+    normal_layer: Option<&Layer>,
+    settings: Settings,
+) -> (Vec<f32>, Vec<[f32; 3]>) {
+    match settings.normal_source {
+        NormalSource::Generated => match settings.generation_method {
+            GenerationMethod::ColorRegions => {
+                color_region_surface_maps(source, width, height, settings)
+            }
+            GenerationMethod::HeightChannel => {
+                let mut heights: Vec<f32> = source
+                    .iter()
+                    .copied()
+                    .map(|pixel| {
+                        height_value(pixel, settings.height_channel, settings.invert_height)
+                    })
+                    .collect();
+                let blur_x = buffer_radius(settings.height_blur, settings.pixel_scale.0, width);
+                let blur_y = buffer_radius(settings.height_blur, settings.pixel_scale.1, height);
+                if blur_x > 0 || blur_y > 0 {
+                    heights = box_blur(&heights, width, height, blur_x, blur_y);
+                }
+                let normals = normals_from_height(
+                    &heights,
+                    width,
+                    height,
+                    settings.normal_strength,
+                    settings.pixel_scale,
+                );
+                (heights, normals)
+            }
+        },
+        NormalSource::Layer => {
+            let heights = vec![0.5; width * height];
+            let mut normals = vec![[0.0, 0.0, 1.0]; width * height];
+            if let Some(layer) = normal_layer {
+                let layer_width = layer.width();
+                let layer_height = layer.height();
+                if layer_width > 0 && layer_height > 0 {
+                    let normal_origin = layer.origin();
+                    let pixels = read_layer(layer);
+                    for y in 0..height {
+                        for x in 0..width {
+                            let (sx, sy) =
+                                aligned_layer_coordinate(x, y, source_origin, normal_origin);
+                            let pixel = sample_bilinear(
+                                &pixels,
+                                layer_width,
+                                layer_height,
+                                sx,
+                                sy,
+                                SampleEdge::Transparent,
+                            );
+                            normals[y * width + x] =
+                                decode_normal(pixel, settings.normal_scale, settings.normal_y);
+                        }
+                    }
+                }
+            }
+            (heights, normals)
+        }
+    }
+}
+
+const BACKGROUND_LABEL: u32 = u32::MAX;
+
+fn color_region_surface_maps(
+    source: &[PixelF32],
+    width: usize,
+    height: usize,
+    settings: Settings,
+) -> (Vec<f32>, Vec<[f32; 3]>) {
+    let labels: Vec<u32> = source
+        .iter()
+        .copied()
+        .map(|pixel| pack_region_label(pixel, settings.alpha_threshold, settings.color_tolerance))
+        .collect();
+    let boundary = region_boundary_mask(&labels, width, height);
+    let distance =
+        region_boundary_distance(&labels, &boundary, width, height, settings.pixel_scale);
+    let (heights, neumann_boundary) = match settings.region_solver {
+        RegionSolver::DistanceField => {
+            let radius = settings.region_radius.max(1.0e-6);
+            let shape = settings.region_shape.max(0.05);
+            let mut heights = vec![0.0; width * height];
+            for (index, value) in heights.iter_mut().enumerate() {
+                if labels[index] == BACKGROUND_LABEL {
+                    continue;
+                }
+                let shaped = (distance[index] / radius).clamp(0.0, 1.0).powf(shape);
+                *value = if settings.invert_height {
+                    1.0 - shaped
+                } else {
+                    shaped
+                };
+            }
+            (heights, false)
+        }
+        RegionSolver::Poisson => (
+            poisson_region_heights(
+                &labels,
+                &boundary,
+                &distance,
+                width,
+                height,
+                settings.boundary_condition,
+                settings.poisson_iterations,
+                settings.poisson_curvature,
+                settings.screened_damping,
+                settings.edge_feather,
+                settings.invert_height,
+                settings.pixel_scale,
+            ),
+            settings.boundary_condition == BoundaryCondition::Neumann,
+        ),
+    };
+    let normals = normals_from_regions(
+        &heights,
+        &labels,
+        &distance,
+        width,
+        height,
+        settings.normal_strength,
+        settings.edge_softness,
+        settings.invert_height,
+        neumann_boundary,
+        settings.pixel_scale,
+    );
+    (heights, normals)
+}
+
+fn pack_region_label(pixel: PixelF32, alpha_threshold: f32, tolerance: f32) -> u32 {
+    if !pixel.alpha.is_finite()
+        || pixel.alpha <= 0.0
+        || pixel.alpha < alpha_threshold.clamp(0.0, 1.0)
+    {
+        return BACKGROUND_LABEL;
+    }
+    let rgb = unpremultiplied_rgb(pixel);
+    let scale = ae::MAX_CHANNEL8 as f32;
+    let step = (tolerance.clamp(0.0, 1.0) * scale).round().max(1.0) as i32;
+    let quantize = |value: f32| -> u32 {
+        let raw = (value.clamp(0.0, 1.0) * scale + 0.5) as i32;
+        if step <= 1 {
+            raw as u32
+        } else {
+            (((raw + step / 2) / step) * step).clamp(0, ae::MAX_CHANNEL8 as i32) as u32
+        }
+    };
+    (quantize(rgb[0]) << 16) | (quantize(rgb[1]) << 8) | quantize(rgb[2])
+}
+
+fn region_boundary_mask(labels: &[u32], width: usize, height: usize) -> Vec<bool> {
+    let mut boundary = vec![false; width * height];
+    for y in 0..height {
+        for x in 0..width {
+            let index = y * width + x;
+            let label = labels[index];
+            if label == BACKGROUND_LABEL {
+                continue;
+            }
+            boundary[index] = x == 0
+                || y == 0
+                || x + 1 == width
+                || y + 1 == height
+                || labels[index - 1] != label
+                || labels[index + 1] != label
+                || labels[index - width] != label
+                || labels[index + width] != label;
+        }
+    }
+    boundary
+}
+
+fn region_boundary_distance(
+    labels: &[u32],
+    boundary: &[bool],
+    width: usize,
+    height: usize,
+    pixel_scale: (f32, f32),
+) -> Vec<f32> {
+    let mut distance = vec![f32::INFINITY; width * height];
+    for (index, is_boundary) in boundary.iter().copied().enumerate() {
+        if is_boundary {
+            distance[index] = 0.0;
+        }
+    }
+    let step_x = pixel_scale.0.max(1.0e-6);
+    let step_y = pixel_scale.1.max(1.0e-6);
+    let step_diagonal = step_x.hypot(step_y);
+
+    for y in 0..height {
+        for x in 0..width {
+            let index = y * width + x;
+            let label = labels[index];
+            if label == BACKGROUND_LABEL || distance[index] == 0.0 {
+                continue;
+            }
+            let mut best = distance[index];
+            if x > 0 && labels[index - 1] == label {
+                best = best.min(distance[index - 1] + step_x);
+            }
+            if y > 0 {
+                if labels[index - width] == label {
+                    best = best.min(distance[index - width] + step_y);
+                }
+                if x > 0 && labels[index - width - 1] == label {
+                    best = best.min(distance[index - width - 1] + step_diagonal);
+                }
+                if x + 1 < width && labels[index - width + 1] == label {
+                    best = best.min(distance[index - width + 1] + step_diagonal);
+                }
+            }
+            distance[index] = best;
+        }
+    }
+
+    for y in (0..height).rev() {
+        for x in (0..width).rev() {
+            let index = y * width + x;
+            let label = labels[index];
+            if label == BACKGROUND_LABEL || distance[index] == 0.0 {
+                continue;
+            }
+            let mut best = distance[index];
+            if x + 1 < width && labels[index + 1] == label {
+                best = best.min(distance[index + 1] + step_x);
+            }
+            if y + 1 < height {
+                if labels[index + width] == label {
+                    best = best.min(distance[index + width] + step_y);
+                }
+                if x + 1 < width && labels[index + width + 1] == label {
+                    best = best.min(distance[index + width + 1] + step_diagonal);
+                }
+                if x > 0 && labels[index + width - 1] == label {
+                    best = best.min(distance[index + width - 1] + step_diagonal);
+                }
+            }
+            distance[index] = best;
+        }
+    }
+    distance
+}
+
+fn region_components(labels: &[u32], width: usize, height: usize) -> Vec<Vec<usize>> {
+    let mut components = Vec::new();
+    let mut visited = vec![false; labels.len()];
+    let mut queue = VecDeque::new();
+    for seed in 0..labels.len() {
+        if visited[seed] || labels[seed] == BACKGROUND_LABEL {
+            continue;
+        }
+        let label = labels[seed];
+        let mut component = Vec::new();
+        visited[seed] = true;
+        queue.push_back(seed);
+        while let Some(index) = queue.pop_front() {
+            component.push(index);
+            let x = index % width;
+            let y = index / width;
+            let neighbors = [
+                (x > 0).then_some(index.saturating_sub(1)),
+                (x + 1 < width).then_some(index + 1),
+                (y > 0).then_some(index.saturating_sub(width)),
+                (y + 1 < height).then_some(index + width),
+            ];
+            for neighbor in neighbors.into_iter().flatten() {
+                if !visited[neighbor] && labels[neighbor] == label {
+                    visited[neighbor] = true;
+                    queue.push_back(neighbor);
+                }
+            }
+        }
+        components.push(component);
+    }
+    components
+}
+
+fn poisson_profiles(distance: &[f32], components: &[Vec<usize>], edge_feather: f32) -> Vec<f32> {
+    let mut profile = vec![0.0; distance.len()];
+    for component in components {
+        let max_distance = component
+            .iter()
+            .map(|&index| distance[index])
+            .filter(|value| value.is_finite())
+            .fold(0.0_f32, f32::max);
+        if max_distance <= 1.0e-8 {
+            continue;
+        }
+        for &index in component {
+            let base = (distance[index] / max_distance).clamp(0.0, 1.0);
+            let feather = if edge_feather > 0.0 {
+                smoothstep(0.0, edge_feather, distance[index])
+            } else {
+                1.0
+            };
+            profile[index] = base * feather;
+        }
+    }
+    profile
+}
+
+fn poisson_rhs(
+    profile: &[f32],
+    boundary: &[bool],
+    components: &[Vec<usize>],
+    condition: BoundaryCondition,
+    curvature: f32,
+    lambda_squared: f32,
+) -> Vec<f32> {
+    let mut rhs = vec![0.0; profile.len()];
+    for component in components {
+        let mean = if condition == BoundaryCondition::Neumann && !component.is_empty() {
+            component.iter().map(|&index| profile[index]).sum::<f32>() / component.len() as f32
+        } else {
+            0.0
+        };
+        for &index in component {
+            if condition == BoundaryCondition::Dirichlet && boundary[index] {
+                continue;
+            }
+            let forcing = if condition == BoundaryCondition::Neumann {
+                // Removing the component mean makes the unscreened Neumann system compatible.
+                curvature * (profile[index] - mean)
+            } else {
+                curvature * profile[index]
+            };
+            rhs[index] = forcing + lambda_squared * profile[index];
+        }
+    }
+    rhs
+}
+
+fn poisson_sor_omega(width: usize, height: usize) -> f32 {
+    let extent = width.max(height);
+    if extent <= 2 {
+        return 1.0;
+    }
+    let rho = (std::f32::consts::PI / extent as f32).cos();
+    (2.0 / (1.0 + (1.0 - rho * rho).max(0.0).sqrt())).clamp(1.0, 1.8)
+}
+
+#[cfg(test)]
+#[allow(clippy::too_many_arguments)]
+fn poisson_candidate(
+    index: usize,
+    heights: &[f32],
+    labels: &[u32],
+    rhs: &[f32],
+    width: usize,
+    height: usize,
+    condition: BoundaryCondition,
+    lambda_squared: f32,
+    weight_x: f32,
+    weight_y: f32,
+) -> f32 {
+    let x = index % width;
+    let y = index / width;
+    let label = labels[index];
+    let mut sum = 0.0;
+    let mut diagonal = lambda_squared;
+    let mut add_neighbor = |neighbor: Option<usize>, weight: f32| {
+        if let Some(neighbor) = neighbor
+            && labels[neighbor] == label
+        {
+            sum += weight * heights[neighbor];
+            diagonal += weight;
+        } else if condition == BoundaryCondition::Dirichlet {
+            // A missing or differently labelled neighbor has fixed zero height.
+            diagonal += weight;
+        }
+    };
+    add_neighbor((x > 0).then_some(index.saturating_sub(1)), weight_x);
+    add_neighbor((x + 1 < width).then_some(index + 1), weight_x);
+    add_neighbor((y > 0).then_some(index.saturating_sub(width)), weight_y);
+    add_neighbor((y + 1 < height).then_some(index + width), weight_y);
+    if diagonal <= 1.0e-12 {
+        0.0
+    } else {
+        (rhs[index] + sum) / diagonal
+    }
+}
+
+const POISSON_LEFT: u8 = 1 << 0;
+const POISSON_RIGHT: u8 = 1 << 1;
+const POISSON_TOP: u8 = 1 << 2;
+const POISSON_BOTTOM: u8 = 1 << 3;
+
+#[derive(Clone, Copy, Debug)]
+struct PoissonStencil {
+    index: u32,
+    neighbor_mask: u8,
+    diagonal: f32,
+}
+
+#[allow(clippy::too_many_arguments)]
+fn prepare_poisson_stencil(
+    index: usize,
+    labels: &[u32],
+    width: usize,
+    height: usize,
+    condition: BoundaryCondition,
+    lambda_squared: f32,
+    weight_x: f32,
+    weight_y: f32,
+) -> PoissonStencil {
+    let x = index % width;
+    let y = index / width;
+    let label = labels[index];
+    let mut neighbor_mask = 0;
+    let mut diagonal = lambda_squared;
+    let mut add_neighbor = |neighbor: Option<usize>, bit: u8, weight: f32| {
+        if let Some(neighbor) = neighbor
+            && labels[neighbor] == label
+        {
+            neighbor_mask |= bit;
+            diagonal += weight;
+        } else if condition == BoundaryCondition::Dirichlet {
+            diagonal += weight;
+        }
+    };
+    add_neighbor(
+        (x > 0).then_some(index.saturating_sub(1)),
+        POISSON_LEFT,
+        weight_x,
+    );
+    add_neighbor(
+        (x + 1 < width).then_some(index + 1),
+        POISSON_RIGHT,
+        weight_x,
+    );
+    add_neighbor(
+        (y > 0).then_some(index.saturating_sub(width)),
+        POISSON_TOP,
+        weight_y,
+    );
+    add_neighbor(
+        (y + 1 < height).then_some(index + width),
+        POISSON_BOTTOM,
+        weight_y,
+    );
+    PoissonStencil {
+        index: index as u32,
+        neighbor_mask,
+        diagonal,
+    }
+}
+
+fn poisson_candidate_from_stencil(
+    stencil: PoissonStencil,
+    heights: &[f32],
+    rhs: &[f32],
+    width: usize,
+    weight_x: f32,
+    weight_y: f32,
+) -> f32 {
+    if stencil.diagonal <= 1.0e-12 {
+        return 0.0;
+    }
+    let index = stencil.index as usize;
+    let mut sum = 0.0;
+    if stencil.neighbor_mask & POISSON_LEFT != 0 {
+        sum += weight_x * heights[index - 1];
+    }
+    if stencil.neighbor_mask & POISSON_RIGHT != 0 {
+        sum += weight_x * heights[index + 1];
+    }
+    if stencil.neighbor_mask & POISSON_TOP != 0 {
+        sum += weight_y * heights[index - width];
+    }
+    if stencil.neighbor_mask & POISSON_BOTTOM != 0 {
+        sum += weight_y * heights[index + width];
+    }
+    (rhs[index] + sum) / stencil.diagonal
+}
+
+fn remove_component_means(values: &mut [f32], components: &[Vec<usize>]) {
+    for component in components {
+        if component.is_empty() {
+            continue;
+        }
+        let mean =
+            component.iter().map(|&index| values[index]).sum::<f32>() / component.len() as f32;
+        for &index in component {
+            values[index] -= mean;
+        }
+    }
+}
+
+fn normalize_component_heights(
+    heights: &mut [f32],
+    components: &[Vec<usize>],
+    condition: BoundaryCondition,
+    relief_scale: f32,
+    invert: bool,
+) {
+    let relief_scale = relief_scale.clamp(0.0, 1.0);
+    for component in components {
+        let mut minimum = f32::INFINITY;
+        let mut maximum = f32::NEG_INFINITY;
+        for &index in component {
+            let value = heights[index];
+            if value.is_finite() {
+                minimum = minimum.min(value);
+                maximum = maximum.max(value);
+            }
+        }
+        if condition == BoundaryCondition::Dirichlet {
+            minimum = 0.0;
+        }
+        let range = maximum - minimum;
+        for &index in component {
+            let mut value = if range.is_finite() && range > 1.0e-8 {
+                ((heights[index] - minimum) / range).clamp(0.0, 1.0)
+            } else {
+                0.0
+            };
+            value *= relief_scale;
+            if invert {
+                value = 1.0 - value;
+            }
+            heights[index] = value;
+        }
+    }
+}
+
+fn poisson_relief_scale(curvature: f32, screened_damping: f32) -> f32 {
+    let total_drive = curvature.max(0.0) + screened_damping.max(0.0);
+    if !total_drive.is_finite() || total_drive <= 0.0 {
+        0.0
+    } else {
+        1.0 - (-total_drive).exp()
+    }
+}
+
+#[cfg(feature = "gpu_wgpu")]
+static POISSON_GPU: OnceLock<Result<Arc<WgpuContext>, String>> = OnceLock::new();
+
+#[cfg(feature = "gpu_wgpu")]
+#[allow(clippy::too_many_arguments)]
+fn try_poisson_gpu(
+    labels: &[u32],
+    boundary: &[bool],
+    rhs: &[f32],
+    width: usize,
+    height: usize,
+    condition: BoundaryCondition,
+    iterations: usize,
+    lambda_squared: f32,
+    weight_x: f32,
+    weight_y: f32,
+    omega: f32,
+) -> Option<Vec<f32>> {
+    // Pure Neumann systems need a per-component mean projection after every iteration. Keep that
+    // uncommon configuration on the CPU until the projection also lives on the GPU.
+    if condition == BoundaryCondition::Neumann && lambda_squared <= 1.0e-12 {
+        return None;
+    }
+
+    let updates = labels.len().saturating_mul(iterations.max(1));
+    let preference = env::var("AOD_IMAGE_RELIGHT_GPU")
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    let enabled = match preference.as_str() {
+        "0" | "off" | "false" | "cpu" => false,
+        "1" | "on" | "true" | "gpu" => true,
+        _ => updates >= 8 * 1024 * 1024,
+    };
+    if !enabled {
+        return None;
+    }
+
+    let context = POISSON_GPU
+        .get_or_init(|| WgpuContext::new().map(Arc::new))
+        .as_ref()
+        .ok()?;
+    let heights = context
+        .solve(
+            labels,
+            boundary,
+            rhs,
+            SolveParams {
+                width,
+                height,
+                condition: match condition {
+                    BoundaryCondition::Dirichlet => GpuBoundaryCondition::Dirichlet,
+                    BoundaryCondition::Neumann => GpuBoundaryCondition::Neumann,
+                },
+                iterations,
+                lambda_squared,
+                weight_x,
+                weight_y,
+                omega,
+            },
+        )
+        .ok()?;
+    heights
+        .iter()
+        .all(|value| value.is_finite())
+        .then_some(heights)
+}
+
+#[cfg(not(feature = "gpu_wgpu"))]
+#[allow(clippy::too_many_arguments)]
+fn try_poisson_gpu(
+    _labels: &[u32],
+    _boundary: &[bool],
+    _rhs: &[f32],
+    _width: usize,
+    _height: usize,
+    _condition: BoundaryCondition,
+    _iterations: usize,
+    _lambda_squared: f32,
+    _weight_x: f32,
+    _weight_y: f32,
+    _omega: f32,
+) -> Option<Vec<f32>> {
+    None
+}
+
+#[allow(clippy::too_many_arguments)]
+fn solve_poisson_cpu(
+    labels: &[u32],
+    boundary: &[bool],
+    rhs: &[f32],
+    components: &[Vec<usize>],
+    width: usize,
+    height: usize,
+    condition: BoundaryCondition,
+    iterations: usize,
+    lambda_squared: f32,
+    weight_x: f32,
+    weight_y: f32,
+    omega: f32,
+) -> Vec<f32> {
+    // A zero initialization avoids turning a finite-iteration seed residue into false relief.
+    let mut heights = vec![0.0; labels.len()];
+    let mut red = Vec::new();
+    let mut black = Vec::new();
+    for component in components {
+        for &index in component {
+            if condition == BoundaryCondition::Dirichlet && boundary[index] {
+                continue;
+            }
+            let x = index % width;
+            let y = index / width;
+            let stencil = prepare_poisson_stencil(
+                index,
+                labels,
+                width,
+                height,
+                condition,
+                lambda_squared,
+                weight_x,
+                weight_y,
+            );
+            if ((x ^ y) & 1) == 0 {
+                red.push(stencil);
+            } else {
+                black.push(stencil);
+            }
+        }
+    }
+
+    for _ in 0..iterations.max(1) {
+        let mut max_delta = 0.0_f32;
+        for indices in [&red, &black] {
+            for &stencil in indices {
+                let index = stencil.index as usize;
+                let candidate = poisson_candidate_from_stencil(
+                    stencil, &heights, rhs, width, weight_x, weight_y,
+                );
+                let old = heights[index];
+                let updated = old + omega * (candidate - old);
+                heights[index] = if updated.is_finite() { updated } else { old };
+                max_delta = max_delta.max((heights[index] - old).abs());
+            }
+        }
+        if condition == BoundaryCondition::Neumann && lambda_squared <= 1.0e-12 {
+            // Pure Neumann solutions are defined up to a constant; pin each component mean.
+            remove_component_means(&mut heights, components);
+        }
+        if max_delta <= 1.0e-5 {
+            break;
+        }
+    }
+    heights
+}
+
+#[allow(clippy::too_many_arguments)]
+fn poisson_region_heights(
+    labels: &[u32],
+    boundary: &[bool],
+    distance: &[f32],
+    width: usize,
+    height: usize,
+    condition: BoundaryCondition,
+    iterations: usize,
+    curvature: f32,
+    screened_damping: f32,
+    edge_feather: f32,
+    invert: bool,
+    pixel_scale: (f32, f32),
+) -> Vec<f32> {
+    let relief_scale = poisson_relief_scale(curvature, screened_damping);
+    if relief_scale <= 0.0 {
+        return labels
+            .iter()
+            .map(|&label| {
+                if invert && label != BACKGROUND_LABEL {
+                    1.0
+                } else {
+                    0.0
+                }
+            })
+            .collect();
+    }
+    let components = region_components(labels, width, height);
+    let profile = poisson_profiles(distance, &components, edge_feather.max(0.0));
+    let lambda_squared = screened_damping.max(0.0).powi(2);
+    let rhs = poisson_rhs(
+        &profile,
+        boundary,
+        &components,
+        condition,
+        curvature,
+        lambda_squared,
+    );
+    let weight_x = 1.0 / pixel_scale.0.max(1.0e-6).powi(2);
+    let weight_y = 1.0 / pixel_scale.1.max(1.0e-6).powi(2);
+    let omega = poisson_sor_omega(width, height);
+    let mut heights = try_poisson_gpu(
+        labels,
+        boundary,
+        &rhs,
+        width,
+        height,
+        condition,
+        iterations.max(1),
+        lambda_squared,
+        weight_x,
+        weight_y,
+        omega,
+    )
+    .unwrap_or_else(|| {
+        solve_poisson_cpu(
+            labels,
+            boundary,
+            &rhs,
+            &components,
+            width,
+            height,
+            condition,
+            iterations,
+            lambda_squared,
+            weight_x,
+            weight_y,
+            omega,
+        )
+    });
+
+    normalize_component_heights(&mut heights, &components, condition, relief_scale, invert);
+    heights
+}
+
+#[allow(clippy::too_many_arguments)]
+fn normals_from_regions(
+    heights: &[f32],
+    labels: &[u32],
+    distance: &[f32],
+    width: usize,
+    height: usize,
+    strength: f32,
+    edge_softness: f32,
+    inverted: bool,
+    neumann_boundary: bool,
+    pixel_scale: (f32, f32),
+) -> Vec<[f32; 3]> {
+    let mut normals = vec![[0.0, 0.0, 1.0]; width * height];
+    let boundary_height = if inverted { 1.0 } else { 0.0 };
+    let step_x = pixel_scale.0.max(1.0e-6);
+    let step_y = pixel_scale.1.max(1.0e-6);
+    for y in 0..height {
+        for x in 0..width {
+            let index = y * width + x;
+            let label = labels[index];
+            if label == BACKGROUND_LABEL {
+                continue;
+            }
+            let boundary_height = if neumann_boundary {
+                heights[index]
+            } else {
+                boundary_height
+            };
+            let sample = |sample_x: usize, sample_y: usize| {
+                let sample_index = sample_y * width + sample_x;
+                if labels[sample_index] == label {
+                    heights[sample_index]
+                } else {
+                    boundary_height
+                }
+            };
+            let left = if x > 0 {
+                sample(x - 1, y)
+            } else {
+                boundary_height
+            };
+            let right = if x + 1 < width {
+                sample(x + 1, y)
+            } else {
+                boundary_height
+            };
+            let top = if y > 0 {
+                sample(x, y - 1)
+            } else {
+                boundary_height
+            };
+            let bottom = if y + 1 < height {
+                sample(x, y + 1)
+            } else {
+                boundary_height
+            };
+            let edge_weight = if edge_softness > 0.0 {
+                smoothstep(0.0, edge_softness, distance[index])
+            } else {
+                1.0
+            };
+            let dx = (right - left) * 0.5 / step_x;
+            let dy = (bottom - top) * 0.5 / step_y;
+            normals[index] = normalize3([
+                -dx * strength * edge_weight,
+                -dy * strength * edge_weight,
+                1.0,
+            ]);
+        }
+    }
+    normals
+}
+
+fn buffer_radius(distance: f32, square_per_pixel: f32, extent: usize) -> usize {
+    ((distance.max(0.0) / square_per_pixel.max(1.0e-6)).round() as usize)
+        .min(extent.saturating_sub(1))
+}
+
+fn aligned_layer_coordinate(
+    x: usize,
+    y: usize,
+    source_origin: ae::Point,
+    target_origin: ae::Point,
+) -> (f32, f32) {
+    (
+        x as f32 + (source_origin.h - target_origin.h) as f32,
+        y as f32 + (source_origin.v - target_origin.v) as f32,
+    )
+}
+
+fn height_value(pixel: PixelF32, channel: HeightChannel, invert: bool) -> f32 {
+    let rgb = unpremultiplied_rgb(pixel);
+    let value = match channel {
+        HeightChannel::Luminance => luma(pixel),
+        HeightChannel::Alpha => pixel.alpha,
+        HeightChannel::Red => rgb[0],
+        HeightChannel::Green => rgb[1],
+        HeightChannel::Blue => rgb[2],
+    }
+    .clamp(0.0, 1.0);
+    if invert { 1.0 - value } else { value }
+}
+
+fn box_blur(
+    source: &[f32],
+    width: usize,
+    height: usize,
+    radius_x: usize,
+    radius_y: usize,
+) -> Vec<f32> {
+    if (radius_x == 0 && radius_y == 0) || width == 0 || height == 0 {
+        return source.to_vec();
+    }
+    let mut horizontal = vec![0.0; source.len()];
+    let mut prefix = vec![0.0; width + 1];
+    for y in 0..height {
+        prefix[0] = 0.0;
+        for x in 0..width {
+            prefix[x + 1] = prefix[x] + source[y * width + x];
+        }
+        for x in 0..width {
+            let left = x.saturating_sub(radius_x);
+            let right = (x + radius_x + 1).min(width);
+            horizontal[y * width + x] = (prefix[right] - prefix[left]) / (right - left) as f32;
+        }
+    }
+    let mut output = vec![0.0; source.len()];
+    prefix.resize(height + 1, 0.0);
+    for x in 0..width {
+        prefix[0] = 0.0;
+        for y in 0..height {
+            prefix[y + 1] = prefix[y] + horizontal[y * width + x];
+        }
+        for y in 0..height {
+            let top = y.saturating_sub(radius_y);
+            let bottom = (y + radius_y + 1).min(height);
+            output[y * width + x] = (prefix[bottom] - prefix[top]) / (bottom - top) as f32;
+        }
+    }
+    output
+}
+
+fn normals_from_height(
+    heights: &[f32],
+    width: usize,
+    height: usize,
+    strength: f32,
+    pixel_scale: (f32, f32),
+) -> Vec<[f32; 3]> {
+    let mut normals = vec![[0.0, 0.0, 1.0]; width * height];
+    for y in 0..height {
+        let top = y.saturating_sub(1);
+        let bottom = (y + 1).min(height - 1);
+        for x in 0..width {
+            let left = x.saturating_sub(1);
+            let right = (x + 1).min(width - 1);
+            let dx_span = (right - left).max(1) as f32 * pixel_scale.0;
+            let dy_span = (bottom - top).max(1) as f32 * pixel_scale.1;
+            let dx = (heights[y * width + right] - heights[y * width + left]) / dx_span;
+            let dy = (heights[bottom * width + x] - heights[top * width + x]) / dy_span;
+            normals[y * width + x] = normalize3([-dx * strength, -dy * strength, 1.0]);
+        }
+    }
+    normals
+}
+
+fn decode_normal(pixel: PixelF32, scale: f32, convention: NormalY) -> [f32; 3] {
+    if pixel.alpha <= 1.0e-6 {
+        return [0.0, 0.0, 1.0];
+    }
+    let rgb = unpremultiplied_rgb(pixel);
+    let mut y = rgb[1] * 2.0 - 1.0;
+    if convention == NormalY::DirectX {
+        y = -y;
+    }
+    normalize3([(rgb[0] * 2.0 - 1.0) * scale, y * scale, rgb[2] * 2.0 - 1.0])
+}
+
+#[derive(Clone, Copy)]
+struct PreparedShading {
+    settings: Settings,
+    exposure: f32,
+    dielectric_f0: f32,
+    roughness_alpha_squared: f32,
+    directional: Option<([f32; 3], [f32; 3])>,
+}
+
+impl PreparedShading {
+    fn new(settings: Settings) -> Self {
+        let directional = if settings.light_type == LightType::Directional {
+            let (light, _) = light_vector(0.0, 0.0, settings);
+            let light = normalize3(light);
+            let halfway = normalize3([light[0], light[1], light[2] + 1.0]);
+            Some((light, halfway))
+        } else {
+            None
+        };
+        Self {
+            settings,
+            exposure: 2.0_f32.powf(settings.exposure),
+            dielectric_f0: dielectric_f0(settings.ior, settings.specular_ior_level),
+            roughness_alpha_squared: settings.roughness.max(0.045).powi(4),
+            directional,
+        }
+    }
+}
+
+fn shade_pixel(
+    albedo: PixelF32,
+    height: f32,
+    normal: [f32; 3],
+    x: f32,
+    y: f32,
+    shading: PreparedShading,
+) -> PixelF32 {
+    let settings = shading.settings;
+    let alpha = albedo.alpha.clamp(0.0, 1.0);
+    if settings.output_mode == OutputMode::Normal {
+        return PixelF32 {
+            alpha,
+            red: (normal[0] * 0.5 + 0.5) * alpha,
+            green: (normal[1] * 0.5 + 0.5) * alpha,
+            blue: (normal[2] * 0.5 + 0.5) * alpha,
+        };
+    }
+    if settings.output_mode == OutputMode::Height {
+        return gray_with_alpha(height, alpha);
+    }
+
+    let (light, halfway, attenuation) = if let Some((light, halfway)) = shading.directional {
+        (light, halfway, 1.0)
+    } else {
+        let (light, attenuation) = light_vector(x, y, settings);
+        let light = normalize3(light);
+        let halfway = normalize3([light[0], light[1], light[2] + 1.0]);
+        (light, halfway, attenuation)
+    };
+    let rgb = unpremultiplied_rgb(albedo);
+    let mut output_rgb = match settings.material_model {
+        MaterialModel::Principled => {
+            shade_principled(rgb, normal, light, halfway, attenuation, shading)
+        }
+        MaterialModel::LegacyBlinnPhong => {
+            shade_legacy(rgb, normal, light, halfway, attenuation, settings)
+        }
+    };
+    for channel in &mut output_rgb {
+        *channel *= shading.exposure;
+    }
+    sanitize_pixel(
+        PixelF32 {
+            alpha,
+            red: output_rgb[0] * alpha,
+            green: output_rgb[1] * alpha,
+            blue: output_rgb[2] * alpha,
+        },
+        settings.clamp_output,
+    )
+}
+
+fn shade_legacy(
+    albedo: [f32; 3],
+    normal: [f32; 3],
+    light: [f32; 3],
+    halfway: [f32; 3],
+    attenuation: f32,
+    settings: Settings,
+) -> [f32; 3] {
+    let terms = blinn_terms_prepared(normal, light, halfway, settings.shininess);
+    let diffuse = terms.0 * settings.diffuse * settings.light_intensity * attenuation;
+    let specular = terms.1 * settings.specular * settings.light_intensity * attenuation;
+    match settings.output_mode {
+        OutputMode::Diffuse => [diffuse; 3],
+        OutputMode::Specular => [specular; 3],
+        OutputMode::Lighting => [
+            settings.ambient + settings.light_color[0] * (diffuse + specular),
+            settings.ambient + settings.light_color[1] * (diffuse + specular),
+            settings.ambient + settings.light_color[2] * (diffuse + specular),
+        ],
+        OutputMode::Relit => [
+            albedo[0] * (settings.ambient + settings.light_color[0] * diffuse)
+                + settings.light_color[0] * specular,
+            albedo[1] * (settings.ambient + settings.light_color[1] * diffuse)
+                + settings.light_color[1] * specular,
+            albedo[2] * (settings.ambient + settings.light_color[2] * diffuse)
+                + settings.light_color[2] * specular,
+        ],
+        _ => [0.0; 3],
+    }
+}
+
+fn shade_principled(
+    source_color: [f32; 3],
+    normal: [f32; 3],
+    light: [f32; 3],
+    halfway: [f32; 3],
+    attenuation: f32,
+    shading: PreparedShading,
+) -> [f32; 3] {
+    let settings = shading.settings;
+    let base_color = [
+        source_color[0] * settings.base_tint[0],
+        source_color[1] * settings.base_tint[1],
+        source_color[2] * settings.base_tint[2],
+    ];
+    let (diffuse, specular) = principled_terms_prepared(
+        normal,
+        light,
+        halfway,
+        base_color,
+        settings.metallic,
+        shading.dielectric_f0,
+        shading.roughness_alpha_squared,
+    );
+    let direct_scale = settings.light_intensity * attenuation;
+    let direct_diffuse = multiply_light(diffuse, settings.light_color, direct_scale);
+    let direct_specular = multiply_light(specular, settings.light_color, direct_scale);
+    let environment = [
+        base_color[0] * settings.environment_strength,
+        base_color[1] * settings.environment_strength,
+        base_color[2] * settings.environment_strength,
+    ];
+    match settings.output_mode {
+        OutputMode::Diffuse => direct_diffuse,
+        OutputMode::Specular => direct_specular,
+        OutputMode::Lighting | OutputMode::Relit => [
+            environment[0] + direct_diffuse[0] + direct_specular[0],
+            environment[1] + direct_diffuse[1] + direct_specular[1],
+            environment[2] + direct_diffuse[2] + direct_specular[2],
+        ],
+        _ => [0.0; 3],
+    }
+}
+
+fn multiply_light(value: [f32; 3], light_color: [f32; 3], scale: f32) -> [f32; 3] {
+    [
+        value[0] * light_color[0] * scale,
+        value[1] * light_color[1] * scale,
+        value[2] * light_color[2] * scale,
+    ]
+}
+
+fn dielectric_f0(ior: f32, specular_ior_level: f32) -> f32 {
+    let ratio = (ior.clamp(1.0, 4.0) - 1.0) / (ior.clamp(1.0, 4.0) + 1.0);
+    (ratio * ratio * specular_ior_level.clamp(0.0, 1.0) * 2.0).clamp(0.0, 1.0)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn principled_terms_prepared(
+    normal: [f32; 3],
+    light: [f32; 3],
+    halfway: [f32; 3],
+    base_color: [f32; 3],
+    metallic: f32,
+    dielectric_f0: f32,
+    alpha_squared: f32,
+) -> ([f32; 3], [f32; 3]) {
+    let normal = normalize3(normal);
+    let no_l = dot3(normal, light).max(0.0);
+    let no_v = normal[2].max(0.0);
+    if no_l <= 0.0 || no_v <= 0.0 {
+        return ([0.0; 3], [0.0; 3]);
+    }
+    let no_h = dot3(normal, halfway).max(0.0);
+    let vo_h = halfway[2].max(0.0);
+    let alpha_squared = alpha_squared.max(1.0e-8);
+    let denominator = no_h * no_h * (alpha_squared - 1.0) + 1.0;
+    let distribution =
+        alpha_squared / (std::f32::consts::PI * denominator * denominator).max(1.0e-8);
+    let geometry = smith_ggx_g1(no_l, alpha_squared) * smith_ggx_g1(no_v, alpha_squared);
+    let metallic = metallic.clamp(0.0, 1.0);
+    let one_minus_cosine_fifth = (1.0 - vo_h).clamp(0.0, 1.0).powi(5);
+    let mut diffuse = [0.0; 3];
+    let mut specular = [0.0; 3];
+    for channel in 0..3 {
+        let conductor_f0 = base_color[channel].clamp(0.0, 1.0);
+        let f0 = dielectric_f0 * (1.0 - metallic) + conductor_f0 * metallic;
+        let fresnel = f0 + (1.0 - f0) * one_minus_cosine_fifth;
+        let diffuse_brdf =
+            (1.0 - fresnel) * (1.0 - metallic) * base_color[channel] / std::f32::consts::PI;
+        let specular_brdf = distribution * geometry * fresnel / (4.0 * no_v * no_l).max(1.0e-8);
+        diffuse[channel] = diffuse_brdf * no_l;
+        specular[channel] = specular_brdf * no_l;
+    }
+    (diffuse, specular)
+}
+
+fn smith_ggx_g1(no_x: f32, alpha_squared: f32) -> f32 {
+    let no_x = no_x.clamp(0.0, 1.0);
+    if no_x <= 0.0 {
+        return 0.0;
+    }
+    2.0 * no_x / (no_x + (alpha_squared + (1.0 - alpha_squared) * no_x * no_x).sqrt())
+}
+
+fn light_vector(x: f32, y: f32, settings: Settings) -> ([f32; 3], f32) {
+    match settings.light_type {
+        LightType::Directional => {
+            let planar = settings.direction_elevation.cos();
+            (
+                normalize3([
+                    planar * settings.direction_azimuth.cos(),
+                    planar * settings.direction_azimuth.sin(),
+                    settings.direction_elevation.sin(),
+                ]),
+                1.0,
+            )
+        }
+        LightType::Point => {
+            let vector = [
+                (settings.point_position.0 - x) * settings.pixel_scale.0,
+                (y - settings.point_position.1) * settings.pixel_scale.1,
+                settings.point_height,
+            ];
+            let distance = length3(vector);
+            let ratio = distance / settings.point_radius;
+            (normalize3(vector), 1.0 / (1.0 + ratio * ratio))
+        }
+    }
+}
+
+#[cfg(test)]
+fn blinn_terms(normal: [f32; 3], light: [f32; 3], shininess: f32) -> (f32, f32) {
+    let normal = normalize3(normal);
+    let light = normalize3(light);
+    let halfway = normalize3([light[0], light[1], light[2] + 1.0]);
+    blinn_terms_prepared(normal, light, halfway, shininess)
+}
+
+fn blinn_terms_prepared(
+    normal: [f32; 3],
+    light: [f32; 3],
+    halfway: [f32; 3],
+    shininess: f32,
+) -> (f32, f32) {
+    let normal = normalize3(normal);
+    let diffuse = dot3(normal, light).max(0.0);
+    if diffuse <= 0.0 {
+        return (0.0, 0.0);
+    }
+    let specular = dot3(normal, halfway).max(0.0).powf(shininess.max(1.0));
+    (diffuse, specular)
+}
+
+fn sample_normal_bilinear(
+    values: &[[f32; 3]],
+    width: usize,
+    height: usize,
+    x: f32,
+    y: f32,
+) -> [f32; 3] {
+    let x = x.clamp(0.0, width.saturating_sub(1) as f32);
+    let y = y.clamp(0.0, height.saturating_sub(1) as f32);
+    let x0 = x.floor() as usize;
+    let y0 = y.floor() as usize;
+    let x1 = (x0 + 1).min(width - 1);
+    let y1 = (y0 + 1).min(height - 1);
+    let tx = x - x0 as f32;
+    let ty = y - y0 as f32;
+    let mut value = [0.0; 3];
+    for channel in 0..3 {
+        let top =
+            values[y0 * width + x0][channel] * (1.0 - tx) + values[y0 * width + x1][channel] * tx;
+        let bottom =
+            values[y1 * width + x0][channel] * (1.0 - tx) + values[y1 * width + x1][channel] * tx;
+        value[channel] = top * (1.0 - ty) + bottom * ty;
+    }
+    normalize3(value)
+}
+
+fn sample_scalar_bilinear(values: &[f32], width: usize, height: usize, x: f32, y: f32) -> f32 {
+    let x = x.clamp(0.0, width.saturating_sub(1) as f32);
+    let y = y.clamp(0.0, height.saturating_sub(1) as f32);
+    let x0 = x.floor() as usize;
+    let y0 = y.floor() as usize;
+    let x1 = (x0 + 1).min(width - 1);
+    let y1 = (y0 + 1).min(height - 1);
+    let tx = x - x0 as f32;
+    let ty = y - y0 as f32;
+    let top = values[y0 * width + x0] * (1.0 - tx) + values[y0 * width + x1] * tx;
+    let bottom = values[y1 * width + x0] * (1.0 - tx) + values[y1 * width + x1] * tx;
+    top * (1.0 - ty) + bottom * ty
+}
+
+fn smoothstep(edge0: f32, edge1: f32, value: f32) -> f32 {
+    if edge1 <= edge0 {
+        return if value >= edge1 { 1.0 } else { 0.0 };
+    }
+    let t = ((value - edge0) / (edge1 - edge0)).clamp(0.0, 1.0);
+    t * t * (3.0 - 2.0 * t)
+}
+
+fn normalize3(vector: [f32; 3]) -> [f32; 3] {
+    let length = length3(vector);
+    if !length.is_finite() || length <= 1.0e-8 {
+        [0.0, 0.0, 1.0]
+    } else {
+        [vector[0] / length, vector[1] / length, vector[2] / length]
+    }
+}
+
+fn length3(vector: [f32; 3]) -> f32 {
+    dot3(vector, vector).sqrt()
+}
+
+fn dot3(a: [f32; 3], b: [f32; 3]) -> f32 {
+    a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+}
+
+fn gray_with_alpha(value: f32, alpha: f32) -> PixelF32 {
+    PixelF32 {
+        alpha,
+        red: value * alpha,
+        green: value * alpha,
+        blue: value * alpha,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_settings() -> Settings {
+        Settings {
+            normal_source: NormalSource::Generated,
+            generation_method: GenerationMethod::ColorRegions,
+            color_tolerance: 0.02,
+            alpha_threshold: 0.01,
+            region_solver: RegionSolver::DistanceField,
+            region_radius: 32.0,
+            region_shape: 2.0,
+            boundary_condition: BoundaryCondition::Neumann,
+            poisson_iterations: 160,
+            poisson_curvature: 1.5,
+            screened_damping: 0.02,
+            edge_feather: 8.0,
+            edge_softness: 1.0,
+            height_channel: HeightChannel::Luminance,
+            height_blur: 0.0,
+            normal_strength: 1.0,
+            invert_height: false,
+            normal_scale: 1.0,
+            normal_y: NormalY::OpenGl,
+            light_type: LightType::Point,
+            light_color: [1.0; 3],
+            light_intensity: 1.0,
+            direction_azimuth: 0.0,
+            direction_elevation: 0.0,
+            point_position: (10.0, 10.0),
+            point_height: 10.0,
+            point_radius: 20.0,
+            ambient: 0.0,
+            diffuse: 1.0,
+            specular: 0.0,
+            shininess: 32.0,
+            material_model: MaterialModel::LegacyBlinnPhong,
+            base_tint: [1.0; 3],
+            metallic: 0.0,
+            roughness: 0.5,
+            ior: 1.5,
+            specular_ior_level: 0.5,
+            environment_strength: 0.1,
+            exposure: 0.0,
+            clamp_output: false,
+            output_mode: OutputMode::Relit,
+            pixel_scale: (1.0, 1.0),
+        }
+    }
+
+    #[test]
+    fn flat_height_produces_flat_normals() {
+        let normals = normals_from_height(&[0.5; 25], 5, 5, 10.0, (1.0, 1.0));
+        for normal in normals {
+            assert!((normal[0]).abs() < 1.0e-6);
+            assert!((normal[1]).abs() < 1.0e-6);
+            assert!((normal[2] - 1.0).abs() < 1.0e-6);
+        }
+    }
+
+    #[test]
+    fn neutral_normal_map_decodes_to_surface_normal() {
+        let pixel = PixelF32 {
+            alpha: 1.0,
+            red: 0.5,
+            green: 0.5,
+            blue: 1.0,
+        };
+        let normal = decode_normal(pixel, 1.0, NormalY::OpenGl);
+        assert!(normal[0].abs() < 1.0e-6);
+        assert!(normal[1].abs() < 1.0e-6);
+        assert!((normal[2] - 1.0).abs() < 1.0e-6);
+    }
+
+    #[test]
+    fn front_light_is_brighter_than_back_light() {
+        let front = blinn_terms([0.0, 0.0, 1.0], [0.0, 0.0, 1.0], 32.0);
+        let back = blinn_terms([0.0, 0.0, 1.0], [0.0, 0.0, -1.0], 32.0);
+        assert!(front.0 > back.0);
+        assert!(front.1 > back.1);
+    }
+
+    #[test]
+    fn principled_default_ior_has_four_percent_reflectance() {
+        assert!((dielectric_f0(1.5, 0.5) - 0.04).abs() < 1.0e-6);
+    }
+
+    #[test]
+    fn smoother_ggx_has_a_stronger_normal_incidence_highlight() {
+        let evaluate = |roughness: f32| {
+            principled_terms_prepared(
+                [0.0, 0.0, 1.0],
+                [0.0, 0.0, 1.0],
+                [0.0, 0.0, 1.0],
+                [0.5; 3],
+                0.0,
+                0.04,
+                roughness.max(0.045).powi(4),
+            )
+        };
+        let smooth = evaluate(0.2);
+        let rough = evaluate(0.8);
+        assert!(smooth.1[0] > rough.1[0]);
+        assert!(smooth.0[0].is_finite() && smooth.1[0].is_finite());
+    }
+
+    #[test]
+    fn metallic_surface_has_no_diffuse_lobe_and_tints_specular() {
+        let (diffuse, specular) = principled_terms_prepared(
+            [0.0, 0.0, 1.0],
+            [0.0, 0.0, 1.0],
+            [0.0, 0.0, 1.0],
+            [0.8, 0.2, 0.05],
+            1.0,
+            0.04,
+            0.5_f32.powi(4),
+        );
+        assert_eq!(diffuse, [0.0; 3]);
+        assert!(specular[0] > specular[1]);
+        assert!(specular[1] > specular[2]);
+    }
+
+    #[test]
+    fn ggx_terms_stay_finite_at_grazing_angles() {
+        let (diffuse, specular) = principled_terms_prepared(
+            normalize3([1.0, 0.0, 1.0e-4]),
+            normalize3([1.0, 0.0, 1.0e-4]),
+            normalize3([1.0, 0.0, 1.0001]),
+            [1.0; 3],
+            0.35,
+            0.04,
+            0.3_f32.powi(4),
+        );
+        assert!(diffuse.into_iter().chain(specular).all(f32::is_finite));
+    }
+
+    #[test]
+    fn box_blur_preserves_constant_height() {
+        let blurred = box_blur(&[0.25; 35], 7, 5, 3, 1);
+        assert!(blurred.iter().all(|value| (*value - 0.25).abs() < 1.0e-6));
+    }
+
+    #[test]
+    fn pixel_geometry_accounts_for_par_and_downsample() {
+        assert_eq!(square_pixel_scale(2.0, 0.5, 0.25), (4.0, 4.0));
+        assert_eq!(buffer_radius(20.0, 2.0, 100), 10);
+    }
+
+    #[test]
+    fn extended_bounds_origin_localizes_point_light() {
+        let local = point_in_checkout_world((50.0, 25.0), ae::Point { h: -20, v: 10 });
+        assert_eq!(local, (70.0, 15.0));
+        let local_positive = point_in_checkout_world((50.0, 25.0), ae::Point { h: 12, v: 8 });
+        assert_eq!(local_positive, (38.0, 17.0));
+    }
+
+    #[test]
+    fn legacy_full_frame_with_matching_origins_keeps_identity_coordinates() {
+        let origin = ae::Point { h: 17, v: -9 };
+        assert_eq!(
+            source_local_from_output_local(3.0, 4.0, origin, origin),
+            (3.0, 4.0)
+        );
+    }
+
+    #[test]
+    fn smart_render_tile_origin_translates_without_resizing() {
+        let source_origin = ae::Point { h: -40, v: 25 };
+        let tile_origin = ae::Point { h: 120, v: 80 };
+        let first = source_local_from_output_local(3.0, 4.0, tile_origin, source_origin);
+        let adjacent = source_local_from_output_local(4.0, 4.0, tile_origin, source_origin);
+        assert_eq!(first, (163.0, 59.0));
+        assert_eq!(adjacent, (164.0, 59.0));
+    }
+
+    #[test]
+    fn point_light_and_tile_pixel_share_source_local_coordinates() {
+        let source_origin = ae::Point { h: -20, v: 10 };
+        let tile_origin = ae::Point { h: 30, v: 12 };
+        let sampled = source_local_from_output_local(20.0, 3.0, tile_origin, source_origin);
+        let point_light = point_in_checkout_world((50.0, 15.0), source_origin);
+        assert_eq!(sampled, (70.0, 5.0));
+        assert_eq!(sampled, point_light);
+    }
+
+    #[test]
+    fn generated_normal_gradient_is_resolution_invariant() {
+        let width = 7;
+        let height = 3;
+        let full_resolution: Vec<f32> = (0..width * height)
+            .map(|index| (index % width) as f32 * 0.1)
+            .collect();
+        let half_resolution: Vec<f32> = (0..width * height)
+            .map(|index| (index % width) as f32 * 0.2)
+            .collect();
+        let full = normals_from_height(&full_resolution, width, height, 1.0, (1.0, 1.0));
+        let half = normals_from_height(&half_resolution, width, height, 1.0, (2.0, 2.0));
+        for channel in 0..3 {
+            assert!((full[width + 3][channel] - half[width + 3][channel]).abs() < 1.0e-6);
+        }
+    }
+
+    #[test]
+    fn point_falloff_is_resolution_invariant() {
+        let full_settings = test_settings();
+        let mut half_settings = full_settings;
+        half_settings.point_position = (5.0, 5.0);
+        half_settings.pixel_scale = (2.0, 2.0);
+        let full = light_vector(20.0, 10.0, full_settings);
+        let half = light_vector(10.0, 5.0, half_settings);
+        for channel in 0..3 {
+            assert!((full.0[channel] - half.0[channel]).abs() < 1.0e-6);
+        }
+        assert!((full.1 - half.1).abs() < 1.0e-6);
+    }
+
+    #[test]
+    fn checked_out_normal_layer_origins_are_aligned() {
+        let source_origin = ae::Point { h: 120, v: 80 };
+        let normal_origin = ae::Point { h: 100, v: 60 };
+        assert_eq!(
+            aligned_layer_coordinate(3, 4, source_origin, normal_origin),
+            (23.0, 24.0)
+        );
+    }
+
+    #[test]
+    fn region_labels_use_straight_color_and_keep_opaque_black() {
+        let half_alpha = PixelF32 {
+            alpha: 0.5,
+            red: 0.1,
+            green: 0.2,
+            blue: 0.3,
+        };
+        let opaque = PixelF32 {
+            alpha: 1.0,
+            red: 0.2,
+            green: 0.4,
+            blue: 0.6,
+        };
+        assert_eq!(
+            pack_region_label(half_alpha, 0.01, 0.0),
+            pack_region_label(opaque, 0.01, 0.0)
+        );
+        assert_ne!(
+            pack_region_label(
+                PixelF32 {
+                    alpha: 1.0,
+                    red: 0.0,
+                    green: 0.0,
+                    blue: 0.0,
+                },
+                0.01,
+                0.0,
+            ),
+            BACKGROUND_LABEL
+        );
+        assert_eq!(
+            pack_region_label(
+                PixelF32 {
+                    alpha: 0.0,
+                    red: 0.0,
+                    green: 0.0,
+                    blue: 0.0,
+                },
+                0.01,
+                0.0,
+            ),
+            BACKGROUND_LABEL
+        );
+        assert_eq!(
+            pack_region_label(
+                PixelF32 {
+                    alpha: 0.0,
+                    red: 0.0,
+                    green: 0.0,
+                    blue: 0.0,
+                },
+                0.0,
+                0.0,
+            ),
+            BACKGROUND_LABEL
+        );
+    }
+
+    #[test]
+    fn color_tolerance_groups_nearby_region_colors() {
+        let pixel = |red: f32| PixelF32 {
+            alpha: 1.0,
+            red,
+            green: 0.25,
+            blue: 0.75,
+        };
+        assert_ne!(
+            pack_region_label(pixel(0.500), 0.01, 0.0),
+            pack_region_label(pixel(0.507), 0.01, 0.0)
+        );
+        assert_eq!(
+            pack_region_label(pixel(0.500), 0.01, 0.02),
+            pack_region_label(pixel(0.507), 0.01, 0.02)
+        );
+    }
+
+    #[test]
+    fn disconnected_color_regions_form_independent_surfaces() {
+        let width = 9;
+        let height = 5;
+        let transparent = PixelF32 {
+            alpha: 0.0,
+            red: 0.0,
+            green: 0.0,
+            blue: 0.0,
+        };
+        let red = PixelF32 {
+            alpha: 1.0,
+            red: 1.0,
+            green: 0.0,
+            blue: 0.0,
+        };
+        let blue = PixelF32 {
+            alpha: 1.0,
+            red: 0.0,
+            green: 0.0,
+            blue: 1.0,
+        };
+        let mut source = vec![transparent; width * height];
+        for y in 0..height {
+            for x in 0..4 {
+                source[y * width + x] = red;
+            }
+            for x in 5..width {
+                source[y * width + x] = blue;
+            }
+        }
+        let mut settings = test_settings();
+        settings.region_radius = 2.0;
+        settings.region_shape = 2.0;
+        settings.edge_softness = 0.0;
+        let (heights, normals) = color_region_surface_maps(&source, width, height, settings);
+        assert_eq!(heights[2 * width], 0.0);
+        assert_eq!(heights[2 * width + 4], 0.0);
+        assert_eq!(heights[2 * width + 8], 0.0);
+        assert!((heights[2 * width + 1] - 0.25).abs() < 1.0e-6);
+        assert!((heights[2 * width + 6] - 0.25).abs() < 1.0e-6);
+        assert!(normals[2 * width + 1][0] < 0.0);
+        assert!(normals[2 * width + 2][0] > 0.0);
+        assert!(normals[2 * width + 6][0] < 0.0);
+        assert!(normals[2 * width + 7][0] > 0.0);
+    }
+
+    #[test]
+    fn region_distance_uses_full_resolution_square_pixel_units() {
+        let width = 7;
+        let height = 3;
+        let labels = vec![0; width * height];
+        let boundary = region_boundary_mask(&labels, width, height);
+        let horizontal_is_shorter =
+            region_boundary_distance(&labels, &boundary, width, height, (1.0, 4.0));
+        let vertical_is_shorter =
+            region_boundary_distance(&labels, &boundary, width, height, (2.0, 1.0));
+        let center = width + 3;
+        assert!((horizontal_is_shorter[center] - 3.0).abs() < 1.0e-6);
+        assert!((vertical_is_shorter[center] - 1.0).abs() < 1.0e-6);
+    }
+
+    #[test]
+    fn region_height_inversion_reverses_the_surface_slope() {
+        let width = 5;
+        let height = 3;
+        let source = vec![
+            PixelF32 {
+                alpha: 1.0,
+                red: 0.25,
+                green: 0.5,
+                blue: 0.75,
+            };
+            width * height
+        ];
+        let mut settings = test_settings();
+        settings.region_radius = 4.0;
+        settings.region_shape = 1.0;
+        settings.edge_softness = 0.0;
+        let (raised_height, raised_normal) =
+            color_region_surface_maps(&source, width, height, settings);
+        settings.invert_height = true;
+        let (recessed_height, recessed_normal) =
+            color_region_surface_maps(&source, width, height, settings);
+        let sample = width + 1;
+        assert!((raised_height[sample] + recessed_height[sample] - 1.0).abs() < 1.0e-6);
+        assert!((raised_normal[sample][0] + recessed_normal[sample][0]).abs() < 1.0e-6);
+    }
+
+    #[test]
+    fn pure_neumann_rhs_is_compatible_per_connected_component() {
+        let width = 7;
+        let height = 3;
+        let mut labels = vec![BACKGROUND_LABEL; width * height];
+        for y in 0..height {
+            for x in 0..3 {
+                labels[y * width + x] = 0x11_22_33;
+                labels[y * width + x + 4] = 0x11_22_33;
+            }
+        }
+        let boundary = region_boundary_mask(&labels, width, height);
+        let distance = region_boundary_distance(&labels, &boundary, width, height, (1.0, 1.0));
+        let components = region_components(&labels, width, height);
+        let profile = poisson_profiles(&distance, &components, 0.0);
+        let rhs = poisson_rhs(
+            &profile,
+            &boundary,
+            &components,
+            BoundaryCondition::Neumann,
+            3.0,
+            0.0,
+        );
+        assert_eq!(components.len(), 2);
+        for component in components {
+            let sum = component.iter().map(|&index| rhs[index]).sum::<f32>();
+            assert!(sum.abs() < 1.0e-5);
+        }
+    }
+
+    #[test]
+    fn neumann_poisson_height_is_finite_and_normalized() {
+        let width = 9;
+        let height = 9;
+        let labels = vec![0x44_55_66; width * height];
+        let boundary = region_boundary_mask(&labels, width, height);
+        let distance = region_boundary_distance(&labels, &boundary, width, height, (1.0, 1.0));
+        let heights = poisson_region_heights(
+            &labels,
+            &boundary,
+            &distance,
+            width,
+            height,
+            BoundaryCondition::Neumann,
+            300,
+            1.5,
+            0.0,
+            2.0,
+            false,
+            (1.0, 1.0),
+        );
+        assert!(heights.iter().all(|value| value.is_finite()));
+        assert!(heights.iter().all(|value| (0.0..=1.0).contains(value)));
+        assert!((heights.iter().copied().fold(f32::INFINITY, f32::min)).abs() < 1.0e-6);
+        let maximum = heights.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+        assert!((maximum - poisson_relief_scale(1.5, 0.0)).abs() < 1.0e-6);
+        assert!(heights[4 * width + 4] > heights[0]);
+    }
+
+    #[test]
+    fn dirichlet_poisson_keeps_region_boundary_at_zero() {
+        let width = 9;
+        let height = 9;
+        let labels = vec![0xAA_BB_CC; width * height];
+        let boundary = region_boundary_mask(&labels, width, height);
+        let distance = region_boundary_distance(&labels, &boundary, width, height, (1.0, 1.0));
+        let heights = poisson_region_heights(
+            &labels,
+            &boundary,
+            &distance,
+            width,
+            height,
+            BoundaryCondition::Dirichlet,
+            300,
+            1.5,
+            0.02,
+            2.0,
+            false,
+            (1.0, 1.0),
+        );
+        for (index, is_boundary) in boundary.iter().copied().enumerate() {
+            if is_boundary {
+                assert!(heights[index].abs() < 1.0e-6);
+            }
+        }
+        assert!(heights[4 * width + 4] > 0.7);
+    }
+
+    #[test]
+    fn disconnected_same_color_poisson_regions_normalize_independently() {
+        let width = 15;
+        let height = 7;
+        let mut labels = vec![BACKGROUND_LABEL; width * height];
+        for y in 0..height {
+            for x in 0..5 {
+                labels[y * width + x] = 0x12_34_56;
+            }
+            for x in 8..width {
+                labels[y * width + x] = 0x12_34_56;
+            }
+        }
+        let boundary = region_boundary_mask(&labels, width, height);
+        let distance = region_boundary_distance(&labels, &boundary, width, height, (1.0, 1.0));
+        let heights = poisson_region_heights(
+            &labels,
+            &boundary,
+            &distance,
+            width,
+            height,
+            BoundaryCondition::Neumann,
+            240,
+            1.5,
+            0.02,
+            1.0,
+            false,
+            (1.0, 1.0),
+        );
+        let components = region_components(&labels, width, height);
+        assert_eq!(components.len(), 2);
+        for component in components {
+            let minimum = component
+                .iter()
+                .map(|&index| heights[index])
+                .fold(f32::INFINITY, f32::min);
+            let maximum = component
+                .iter()
+                .map(|&index| heights[index])
+                .fold(f32::NEG_INFINITY, f32::max);
+            assert!(minimum.abs() < 1.0e-6);
+            assert!((maximum - poisson_relief_scale(1.5, 0.02)).abs() < 1.0e-6);
+        }
+    }
+
+    #[test]
+    fn one_pixel_neumann_region_stays_finite() {
+        let labels = [0x01_02_03];
+        let boundary = [true];
+        let distance = [0.0];
+        let raised = poisson_region_heights(
+            &labels,
+            &boundary,
+            &distance,
+            1,
+            1,
+            BoundaryCondition::Neumann,
+            200,
+            10.0,
+            0.0,
+            8.0,
+            false,
+            (1.0, 1.0),
+        );
+        let inverted = poisson_region_heights(
+            &labels,
+            &boundary,
+            &distance,
+            1,
+            1,
+            BoundaryCondition::Neumann,
+            200,
+            10.0,
+            0.0,
+            8.0,
+            true,
+            (1.0, 1.0),
+        );
+        assert_eq!(raised, vec![0.0]);
+        assert_eq!(inverted, vec![1.0]);
+    }
+
+    #[test]
+    fn poisson_stencil_uses_physical_pixel_scale() {
+        let labels = vec![1; 9];
+        let rhs = vec![0.0; 9];
+        let heights = vec![0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0];
+        let isotropic = poisson_candidate(
+            4,
+            &heights,
+            &labels,
+            &rhs,
+            3,
+            3,
+            BoundaryCondition::Neumann,
+            0.0,
+            1.0,
+            1.0,
+        );
+        let wide_pixels = poisson_candidate(
+            4,
+            &heights,
+            &labels,
+            &rhs,
+            3,
+            3,
+            BoundaryCondition::Neumann,
+            0.0,
+            0.25,
+            1.0,
+        );
+        assert!((isotropic - 0.5).abs() < 1.0e-6);
+        assert!((wide_pixels - 0.2).abs() < 1.0e-6);
+    }
+
+    #[test]
+    fn prepared_poisson_stencil_is_bitwise_identical_to_reference_candidate() {
+        let labels = [1, 1, BACKGROUND_LABEL, 1, 1, 2, BACKGROUND_LABEL, 2, 2];
+        let heights = [0.1, 0.2, 0.0, 0.3, 0.4, 0.5, 0.0, 0.6, 0.7];
+        let rhs = [0.9, -0.2, 0.0, 0.4, 0.8, -0.7, 0.0, 0.3, 0.6];
+        let weight_x = 0.37;
+        let weight_y = 1.41;
+        let lambda_squared = 0.0625;
+
+        for condition in [BoundaryCondition::Dirichlet, BoundaryCondition::Neumann] {
+            for index in [0, 1, 3, 4, 5, 7, 8] {
+                let reference = poisson_candidate(
+                    index,
+                    &heights,
+                    &labels,
+                    &rhs,
+                    3,
+                    3,
+                    condition,
+                    lambda_squared,
+                    weight_x,
+                    weight_y,
+                );
+                let prepared = poisson_candidate_from_stencil(
+                    prepare_poisson_stencil(
+                        index,
+                        &labels,
+                        3,
+                        3,
+                        condition,
+                        lambda_squared,
+                        weight_x,
+                        weight_y,
+                    ),
+                    &heights,
+                    &rhs,
+                    3,
+                    weight_x,
+                    weight_y,
+                );
+                assert_eq!(prepared.to_bits(), reference.to_bits(), "index {index}");
+            }
+        }
+    }
+
+    #[cfg(feature = "gpu_wgpu")]
+    #[test]
+    fn gpu_screened_poisson_tracks_the_cpu_reference() {
+        let Ok(context) = WgpuContext::new() else {
+            eprintln!("Skipping ImageRelight CPU/GPU comparison because wgpu is unavailable");
+            return;
+        };
+        let width = 9;
+        let height = 7;
+        let labels = vec![3; width * height];
+        let boundary = region_boundary_mask(&labels, width, height);
+        let distance = region_boundary_distance(&labels, &boundary, width, height, (1.0, 1.0));
+        let components = region_components(&labels, width, height);
+        let profile = poisson_profiles(&distance, &components, 3.0);
+        let lambda_squared = 0.02_f32.powi(2);
+        let rhs = poisson_rhs(
+            &profile,
+            &boundary,
+            &components,
+            BoundaryCondition::Neumann,
+            1.5,
+            lambda_squared,
+        );
+        let omega = poisson_sor_omega(width, height);
+        let iterations = 80;
+        let cpu = solve_poisson_cpu(
+            &labels,
+            &boundary,
+            &rhs,
+            &components,
+            width,
+            height,
+            BoundaryCondition::Neumann,
+            iterations,
+            lambda_squared,
+            1.0,
+            1.0,
+            omega,
+        );
+        let gpu = context
+            .solve(
+                &labels,
+                &boundary,
+                &rhs,
+                SolveParams {
+                    width,
+                    height,
+                    condition: GpuBoundaryCondition::Neumann,
+                    iterations,
+                    lambda_squared,
+                    weight_x: 1.0,
+                    weight_y: 1.0,
+                    omega,
+                },
+            )
+            .expect("GPU Poisson solve should succeed");
+
+        for (index, (gpu, cpu)) in gpu.into_iter().zip(cpu).enumerate() {
+            assert!(
+                (gpu - cpu).abs() <= 5.0e-4,
+                "CPU/GPU mismatch at {index}: {gpu} vs {cpu}"
+            );
+        }
+    }
+
+    #[test]
+    fn neumann_stencil_has_zero_flux_at_region_boundaries() {
+        let labels = [7, 7, BACKGROUND_LABEL];
+        let rhs = [0.0; 3];
+        let heights = [0.7, 0.7, 0.0];
+        let neumann = poisson_candidate(
+            0,
+            &heights,
+            &labels,
+            &rhs,
+            3,
+            1,
+            BoundaryCondition::Neumann,
+            0.0,
+            1.0,
+            1.0,
+        );
+        let dirichlet = poisson_candidate(
+            0,
+            &heights,
+            &labels,
+            &rhs,
+            3,
+            1,
+            BoundaryCondition::Dirichlet,
+            0.0,
+            1.0,
+            1.0,
+        );
+        assert!((neumann - 0.7).abs() < 1.0e-6);
+        assert!(dirichlet < neumann);
+    }
+
+    #[test]
+    fn poisson_invert_is_a_unit_interval_complement() {
+        let width = 7;
+        let height = 7;
+        let labels = vec![0x98_76_54; width * height];
+        let boundary = region_boundary_mask(&labels, width, height);
+        let distance = region_boundary_distance(&labels, &boundary, width, height, (1.0, 1.0));
+        let solve = |invert| {
+            poisson_region_heights(
+                &labels,
+                &boundary,
+                &distance,
+                width,
+                height,
+                BoundaryCondition::Neumann,
+                200,
+                1.5,
+                0.02,
+                2.0,
+                invert,
+                (1.0, 1.0),
+            )
+        };
+        let raised = solve(false);
+        let recessed = solve(true);
+        for (a, b) in raised.iter().zip(recessed) {
+            assert!((*a + b - 1.0).abs() < 1.0e-6);
+        }
+    }
+
+    #[test]
+    fn zero_drive_large_neumann_surface_is_exactly_flat() {
+        let width = 129;
+        let height = 129;
+        let labels = vec![0x24_68_AC; width * height];
+        let boundary = region_boundary_mask(&labels, width, height);
+        let distance = region_boundary_distance(&labels, &boundary, width, height, (1.0, 1.0));
+        let solve = |invert| {
+            poisson_region_heights(
+                &labels,
+                &boundary,
+                &distance,
+                width,
+                height,
+                BoundaryCondition::Neumann,
+                160,
+                0.0,
+                0.0,
+                8.0,
+                invert,
+                (1.0, 1.0),
+            )
+        };
+        assert!(solve(false).iter().all(|value| *value == 0.0));
+        assert!(solve(true).iter().all(|value| *value == 1.0));
+    }
+
+    #[test]
+    fn curvature_monotonically_controls_poisson_relief() {
+        let width = 33;
+        let height = 33;
+        let labels = vec![0x13_57_9B; width * height];
+        let boundary = region_boundary_mask(&labels, width, height);
+        let distance = region_boundary_distance(&labels, &boundary, width, height, (1.0, 1.0));
+        let solve_max = |curvature| {
+            poisson_region_heights(
+                &labels,
+                &boundary,
+                &distance,
+                width,
+                height,
+                BoundaryCondition::Neumann,
+                160,
+                curvature,
+                0.0,
+                8.0,
+                false,
+                (1.0, 1.0),
+            )
+            .into_iter()
+            .fold(f32::NEG_INFINITY, f32::max)
+        };
+        let low = solve_max(0.25);
+        let high = solve_max(2.0);
+        assert!(low > 0.0);
+        assert!(high > low);
+        assert!((low - poisson_relief_scale(0.25, 0.0)).abs() < 1.0e-6);
+        assert!((high - poisson_relief_scale(2.0, 0.0)).abs() < 1.0e-6);
+    }
+
+    fn test_surface_maps(value: f32) -> SurfaceMaps {
+        SurfaceMaps::new(vec![value], vec![[0.0, 0.0, 1.0]])
+    }
+
+    #[test]
+    fn surface_cache_hits_and_single_entry_invalidates() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let source = vec![PixelF32 {
+            alpha: 1.0,
+            red: 0.25,
+            green: 0.5,
+            blue: 0.75,
+        }];
+        let settings = test_settings();
+        let key_a = SurfaceCacheKey::new(&source, 1, 1, ae::Point { h: 0, v: 0 }, settings);
+        let mut changed_settings = settings;
+        changed_settings.normal_strength = 2.0;
+        let key_b = SurfaceCacheKey::new(&source, 1, 1, ae::Point { h: 0, v: 0 }, changed_settings);
+        let cache = SurfaceCache::default();
+        let builds = AtomicUsize::new(0);
+        let first = cache.get_or_build(key_a.clone(), || {
+            builds.fetch_add(1, Ordering::SeqCst);
+            test_surface_maps(1.0)
+        });
+        let hit = cache.get_or_build(key_a.clone(), || {
+            builds.fetch_add(1, Ordering::SeqCst);
+            test_surface_maps(2.0)
+        });
+        assert!(Arc::ptr_eq(&first.heights, &hit.heights));
+        assert_eq!(builds.load(Ordering::SeqCst), 1);
+
+        let changed = cache.get_or_build(key_b, || {
+            builds.fetch_add(1, Ordering::SeqCst);
+            test_surface_maps(3.0)
+        });
+        assert!(!Arc::ptr_eq(&first.heights, &changed.heights));
+        let rebuilt = cache.get_or_build(key_a.clone(), || {
+            builds.fetch_add(1, Ordering::SeqCst);
+            test_surface_maps(4.0)
+        });
+        assert!(!Arc::ptr_eq(&first.heights, &rebuilt.heights));
+        assert_eq!(builds.load(Ordering::SeqCst), 3);
+
+        cache.clear();
+        let after_clear = cache.get_or_build(key_a.clone(), || {
+            builds.fetch_add(1, Ordering::SeqCst);
+            test_surface_maps(5.0)
+        });
+        assert!(!Arc::ptr_eq(&rebuilt.heights, &after_clear.heights));
+        assert_eq!(builds.load(Ordering::SeqCst), 4);
+    }
+
+    #[test]
+    fn surface_cache_key_tracks_source_origin_settings_and_nan_bits() {
+        let source = [PixelF32 {
+            alpha: 1.0,
+            red: f32::from_bits(0x7FC0_0001),
+            green: 0.5,
+            blue: 0.75,
+        }];
+        let settings = test_settings();
+        let base = SurfaceCacheKey::new(&source, 1, 1, ae::Point { h: 0, v: 0 }, settings);
+        let mut changed_source = source;
+        changed_source[0].red = f32::from_bits(0x7FC0_0002);
+        assert_ne!(
+            base,
+            SurfaceCacheKey::new(&changed_source, 1, 1, ae::Point { h: 0, v: 0 }, settings,)
+        );
+        assert_ne!(
+            base,
+            SurfaceCacheKey::new(&source, 1, 1, ae::Point { h: 1, v: 0 }, settings,)
+        );
+        let mut changed_settings = settings;
+        changed_settings.edge_softness = f32::from_bits(0x7FC0_0001);
+        let first_nan =
+            SurfaceCacheKey::new(&source, 1, 1, ae::Point { h: 0, v: 0 }, changed_settings);
+        changed_settings.edge_softness = f32::from_bits(0x7FC0_0002);
+        assert_ne!(
+            first_nan,
+            SurfaceCacheKey::new(&source, 1, 1, ae::Point { h: 0, v: 0 }, changed_settings,)
+        );
+    }
+
+    #[test]
+    fn competing_tiles_build_cached_surface_once() {
+        use std::sync::Barrier;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::time::Duration;
+
+        let cache = Arc::new(SurfaceCache::default());
+        let builds = Arc::new(AtomicUsize::new(0));
+        let barrier = Arc::new(Barrier::new(8));
+        let source = [PixelF32 {
+            alpha: 1.0,
+            red: 0.2,
+            green: 0.4,
+            blue: 0.6,
+        }];
+        let key = SurfaceCacheKey::new(&source, 1, 1, ae::Point { h: 0, v: 0 }, test_settings());
+        let workers: Vec<_> = (0..8)
+            .map(|_| {
+                let cache = Arc::clone(&cache);
+                let builds = Arc::clone(&builds);
+                let barrier = Arc::clone(&barrier);
+                let key = key.clone();
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    cache.get_or_build(key, || {
+                        builds.fetch_add(1, Ordering::SeqCst);
+                        std::thread::sleep(Duration::from_millis(5));
+                        test_surface_maps(0.5)
+                    })
+                })
+            })
+            .collect();
+        let maps: Vec<_> = workers
+            .into_iter()
+            .map(|worker| worker.join().expect("cache worker did not panic"))
+            .collect();
+        assert_eq!(builds.load(Ordering::SeqCst), 1);
+        let first = &maps[0].heights;
+        assert!(
+            maps.iter()
+                .skip(1)
+                .all(|maps| Arc::ptr_eq(&maps.heights, first))
+        );
+    }
+}

--- a/plugins/image-relight/src/lib.rs
+++ b/plugins/image-relight/src/lib.rs
@@ -3534,6 +3534,10 @@ mod tests {
 
     #[cfg(feature = "gpu_wgpu")]
     #[test]
+    #[cfg_attr(
+        target_os = "windows",
+        ignore = "requires an interactive Windows GPU driver; run explicitly with --ignored"
+    )]
     fn gpu_screened_poisson_tracks_the_cpu_reference() {
         let Ok(context) = WgpuContext::new() else {
             eprintln!("Skipping ImageRelight CPU/GPU comparison because wgpu is unavailable");

--- a/plugins/image-transform/Cargo.toml
+++ b/plugins/image-transform/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "image_transform"
 description = "Applies affine image transforms with selectable reconstruction filters and outside-image sampling."
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 
 [lib]

--- a/plugins/image-transform/Cargo.toml
+++ b/plugins/image-transform/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "image_transform"
+description = "Applies affine image transforms with selectable reconstruction filters and outside-image sampling."
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib"]
+
+[features]
+default = []
+catch-panics = []
+
+[dependencies]
+after-effects = { workspace = true }
+utils = { path = "../../crates/utils" }
+
+[dev-dependencies]
+pipl = { workspace = true }
+
+[build-dependencies]
+chrono.workspace = true
+pipl.workspace = true
+winres = "0.1.12"
+
+[lints]
+workspace = true

--- a/plugins/image-transform/Justfile
+++ b/plugins/image-transform/Justfile
@@ -1,0 +1,12 @@
+# Read package.name from Cargo.toml for build naming.
+CrateName := if os() == "windows" {
+    `$inPackage = $false; foreach ($line in Get-Content -Path Cargo.toml) { if ($line -match '^\s*\[package\]\s*$') { $inPackage = $true; continue }; if ($line -match '^\s*\[.+\]\s*$') { if ($inPackage) { break } }; if ($inPackage -and $line -match '^\s*name\s*=\s*"([^"]+)"') { $matches[1]; break } }`
+} else {
+    `awk -F'"' 'BEGIN{in_pkg=0} /^[[:space:]]*\[package\][[:space:]]*$/{in_pkg=1;next} /^[[:space:]]*\[/{if(in_pkg)exit} in_pkg && /^[[:space:]]*name[[:space:]]*=/ {print $2; exit}' Cargo.toml`
+}
+
+PluginName       := "AOD_ImageTransform"
+BundleIdentifier := "com.aodaruma." + PluginName
+BinaryName       := snakecase(CrateName)
+
+import "../../AdobePlugin.just"

--- a/plugins/image-transform/README.md
+++ b/plugins/image-transform/README.md
@@ -1,0 +1,19 @@
+# image-transform ( AOD_ImageTransform )
+
+Affine image transform for After Effects with independent anchor, position, scale, rotation, skew,
+skew axis, and opacity controls.
+
+## Sampling
+
+- Nearest, Bilinear, Bicubic (Catmull-Rom), Mitchell-Netravali, Lanczos, Cubic B-spline, and
+  EWA Quadratic reconstruction filters.
+- Mitchell B/C, Lanczos lobe count, and EWA radius appear only for the corresponding filter.
+- `Sample Outside Image` enables Clamp, Tile, or Mirror sampling. When disabled, samples beyond the
+  source image are transparent.
+- Geometry accounts for pixel aspect ratio and render downsampling.
+
+This plugin provides **AOD_ImageTransform.aex**.
+
+## Building the Plugin
+
+See the [main README](../../README.md) for build instructions.

--- a/plugins/image-transform/build.rs
+++ b/plugins/image-transform/build.rs
@@ -1,0 +1,70 @@
+use chrono::Datelike;
+use pipl::*;
+
+const PF_PLUG_IN_VERSION: u16 = 13;
+const PF_PLUG_IN_SUBVERS: u16 = 28;
+
+#[cfg(target_os = "windows")]
+fn embed_binary_safe_pipl(pipl: &[u8]) {
+    let out_dir = std::path::PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR is set"));
+    let pipl_path = out_dir.join("image_transform.pipl");
+    std::fs::write(&pipl_path, pipl).expect("write binary PiPL resource");
+
+    let escaped_path = pipl_path.to_string_lossy().replace('\\', "\\\\");
+    let mut resource = winres::WindowsResource::new();
+    resource.append_rc_content(&format!("16000 PiPL DISCARDABLE \"{escaped_path}\""));
+    resource.compile().expect("compile binary PiPL resource");
+}
+
+#[rustfmt::skip]
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(does_dialog)");
+    println!("cargo::rustc-check-cfg=cfg(threaded_rendering)");
+    println!("cargo:rustc-env=BUILD_YEAR={}", chrono::Local::now().year());
+
+    let version: Vec<u32> = env!("CARGO_PKG_VERSION")
+        .split('.')
+        .map(|part| part.parse().expect("numeric package version"))
+        .collect();
+    assert_eq!(version.len(), 3, "CARGO_PKG_VERSION must be major.minor.patch");
+
+    let properties = || vec![
+        Property::Kind(PIPLType::AEEffect),
+        Property::Name("AOD_ImageTransform"),
+        Property::Category("Aodaruma"),
+        #[cfg(target_os = "windows")]
+        Property::CodeWin64X86("EffectMain"),
+        #[cfg(target_os = "macos")]
+        Property::CodeMacIntel64("EffectMain"),
+        #[cfg(target_os = "macos")]
+        Property::CodeMacARM64("EffectMain"),
+        Property::AE_PiPL_Version { major: 2, minor: 0 },
+        Property::AE_Effect_Spec_Version { major: PF_PLUG_IN_VERSION, minor: PF_PLUG_IN_SUBVERS },
+        Property::AE_Effect_Version {
+            version: version[0],
+            subversion: version[1],
+            bugversion: version[2],
+            stage: Stage::Develop,
+            build: 1,
+        },
+        Property::AE_Effect_Info_Flags(0),
+        Property::AE_Effect_Global_OutFlags(
+            OutFlags::UseOutputExtent
+                | OutFlags::DeepColorAware
+                | OutFlags::SendUpdateParamsUI,
+        ),
+        Property::AE_Effect_Global_OutFlags_2(
+            OutFlags2::FloatColorAware
+                | OutFlags2::SupportsSmartRender
+                | OutFlags2::ParamGroupStartCollapsedFlag
+                | OutFlags2::RevealsZeroAlpha,
+        ),
+        Property::AE_Effect_Match_Name("ImageTransform"),
+        Property::AE_Reserved_Info(8),
+        Property::AE_Effect_Support_URL("https://github.com/Aodaruma/aod-AE-plugin"),
+    ];
+
+    pipl::plugin_build(properties());
+    #[cfg(target_os = "windows")]
+    embed_binary_safe_pipl(&pipl::build_pipl(properties()).expect("build PiPL"));
+}

--- a/plugins/image-transform/src/lib.rs
+++ b/plugins/image-transform/src/lib.rs
@@ -1,0 +1,950 @@
+#![allow(clippy::drop_non_drop, clippy::question_mark)]
+
+use after_effects as ae;
+use std::env;
+
+use ae::pf::*;
+use utils::ToPixel;
+use utils::image::{SampleEdge, SampleFilter, read_layer, sample_filtered, sanitize_pixel};
+
+const PLUGIN_DESCRIPTION: &str = "Applies an AE-style affine image transform with selectable reconstruction and outside-image sampling.";
+
+#[derive(Eq, PartialEq, Hash, Clone, Copy, Debug)]
+enum Params {
+    TransformStart,
+    AnchorPoint,
+    Position,
+    SeparateScale,
+    Scale,
+    ScaleX,
+    ScaleY,
+    Rotation,
+    Skew,
+    SkewAxis,
+    Opacity,
+    TransformEnd,
+    SamplingStart,
+    Interpolation,
+    MitchellB,
+    MitchellC,
+    LanczosLobes,
+    EwaRadius,
+    SampleOutside,
+    OutsideMode,
+    SamplingEnd,
+}
+
+#[derive(Default)]
+struct Plugin {
+    aegp_id: Option<ae::aegp::PluginId>,
+}
+
+ae::define_effect!(Plugin, (), Params);
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct Matrix2 {
+    m00: f32,
+    m01: f32,
+    m10: f32,
+    m11: f32,
+}
+
+impl Matrix2 {
+    #[cfg(test)]
+    const fn identity() -> Self {
+        Self {
+            m00: 1.0,
+            m01: 0.0,
+            m10: 0.0,
+            m11: 1.0,
+        }
+    }
+
+    fn rotation(angle: f32) -> Self {
+        let (sin, cos) = angle.sin_cos();
+        Self {
+            m00: cos,
+            m01: -sin,
+            m10: sin,
+            m11: cos,
+        }
+    }
+
+    const fn scale(x: f32, y: f32) -> Self {
+        Self {
+            m00: x,
+            m01: 0.0,
+            m10: 0.0,
+            m11: y,
+        }
+    }
+
+    fn shear_x(angle: f32) -> Self {
+        Self {
+            m00: 1.0,
+            m01: angle.tan(),
+            m10: 0.0,
+            m11: 1.0,
+        }
+    }
+
+    /// Matrix multiplication in application order: `self * rhs`.
+    const fn mul(self, rhs: Self) -> Self {
+        Self {
+            m00: self.m00 * rhs.m00 + self.m01 * rhs.m10,
+            m01: self.m00 * rhs.m01 + self.m01 * rhs.m11,
+            m10: self.m10 * rhs.m00 + self.m11 * rhs.m10,
+            m11: self.m10 * rhs.m01 + self.m11 * rhs.m11,
+        }
+    }
+
+    fn transform(self, point: [f32; 2]) -> [f32; 2] {
+        [
+            self.m00 * point[0] + self.m01 * point[1],
+            self.m10 * point[0] + self.m11 * point[1],
+        ]
+    }
+
+    fn inverse(self) -> Option<Self> {
+        let determinant = self.m00 * self.m11 - self.m01 * self.m10;
+        if !determinant.is_finite() || determinant.abs() <= 1.0e-8 {
+            return None;
+        }
+        let inverse = determinant.recip();
+        Some(Self {
+            m00: self.m11 * inverse,
+            m01: -self.m01 * inverse,
+            m10: -self.m10 * inverse,
+            m11: self.m00 * inverse,
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct TransformSettings {
+    anchor: [f32; 2],
+    position: [f32; 2],
+    scale: [f32; 2],
+    rotation: f32,
+    skew: f32,
+    skew_axis: f32,
+    opacity: f32,
+    filter: SampleFilter,
+    edge: SampleEdge,
+    pixel_scale: [f32; 2],
+}
+
+impl AdobePluginGlobal for Plugin {
+    fn params_setup(
+        &self,
+        params: &mut ae::Parameters<Params>,
+        _in_data: InData,
+        _: OutData,
+    ) -> Result<(), Error> {
+        params.add_group(
+            Params::TransformStart,
+            Params::TransformEnd,
+            "Transform",
+            false,
+            |params| {
+                params.add(
+                    Params::AnchorPoint,
+                    "Anchor Point",
+                    PointDef::setup(|d| {
+                        d.set_default((50.0, 50.0));
+                    }),
+                )?;
+                params.add(
+                    Params::Position,
+                    "Position",
+                    PointDef::setup(|d| {
+                        d.set_default((50.0, 50.0));
+                    }),
+                )?;
+                params.add_with_flags(
+                    Params::SeparateScale,
+                    "Separate Dimensions",
+                    CheckBoxDef::setup(|d| {
+                        d.set_default(false);
+                    }),
+                    ParamFlag::SUPERVISE,
+                    ParamUIFlags::empty(),
+                )?;
+                add_scale_slider(params, Params::Scale, "Scale", true)?;
+                add_scale_slider(params, Params::ScaleX, "Scale X", false)?;
+                add_scale_slider(params, Params::ScaleY, "Scale Y", false)?;
+                params.add(
+                    Params::Rotation,
+                    "Rotation",
+                    AngleDef::setup(|d| {
+                        d.set_default(0.0);
+                    }),
+                )?;
+                params.add(
+                    Params::Skew,
+                    "Skew",
+                    AngleDef::setup(|d| {
+                        d.set_default(0.0);
+                    }),
+                )?;
+                params.add(
+                    Params::SkewAxis,
+                    "Skew Axis",
+                    AngleDef::setup(|d| {
+                        d.set_default(0.0);
+                    }),
+                )?;
+                params.add(
+                    Params::Opacity,
+                    "Opacity",
+                    FloatSliderDef::setup(|d| {
+                        d.set_valid_min(0.0);
+                        d.set_valid_max(100.0);
+                        d.set_slider_min(0.0);
+                        d.set_slider_max(100.0);
+                        d.set_default(100.0);
+                        d.set_precision(2);
+                    }),
+                )?;
+                Ok(())
+            },
+        )?;
+
+        params.add_group(
+            Params::SamplingStart,
+            Params::SamplingEnd,
+            "Sampling",
+            true,
+            |params| {
+                params.add_with_flags(
+                    Params::Interpolation,
+                    "Interpolation",
+                    PopupDef::setup(|d| {
+                        d.set_options(&[
+                            "Nearest",
+                            "Bilinear",
+                            "Bicubic",
+                            "Mitchell-Netravali",
+                            "Lanczos",
+                            "Cubic B-Spline",
+                            "EWA Quadratic",
+                        ]);
+                        d.set_default(2);
+                    }),
+                    ParamFlag::SUPERVISE,
+                    ParamUIFlags::empty(),
+                )?;
+                add_hidden_float_slider(
+                    params,
+                    Params::MitchellB,
+                    "Mitchell B",
+                    0.0,
+                    1.0,
+                    1.0 / 3.0,
+                    3,
+                )?;
+                add_hidden_float_slider(
+                    params,
+                    Params::MitchellC,
+                    "Mitchell C",
+                    0.0,
+                    1.0,
+                    1.0 / 3.0,
+                    3,
+                )?;
+                add_hidden_float_slider(
+                    params,
+                    Params::LanczosLobes,
+                    "Lanczos Lobes",
+                    1.0,
+                    8.0,
+                    3.0,
+                    2,
+                )?;
+                add_hidden_float_slider(params, Params::EwaRadius, "EWA Radius", 0.5, 8.0, 2.0, 2)?;
+                params.add_with_flags(
+                    Params::SampleOutside,
+                    "Sample Outside Image",
+                    CheckBoxDef::setup(|d| {
+                        d.set_default(false);
+                    }),
+                    ParamFlag::SUPERVISE,
+                    ParamUIFlags::empty(),
+                )?;
+                params.add_with_flags(
+                    Params::OutsideMode,
+                    "Outside Pixels",
+                    PopupDef::setup(|d| {
+                        d.set_options(&["Clamp", "Tile", "Mirror"]);
+                        d.set_default(1);
+                    }),
+                    ParamFlag::empty(),
+                    ParamUIFlags::INVISIBLE | ParamUIFlags::DISABLED,
+                )?;
+                Ok(())
+            },
+        )?;
+
+        Ok(())
+    }
+
+    fn handle_command(
+        &mut self,
+        cmd: ae::Command,
+        in_data: InData,
+        mut out_data: OutData,
+        params: &mut ae::Parameters<Params>,
+    ) -> Result<(), ae::Error> {
+        match cmd {
+            ae::Command::About => {
+                out_data.set_return_msg(
+                    format!(
+                        "AOD_ImageTransform - {version}\r\r{PLUGIN_DESCRIPTION}\rCopyright (c) 2026-{build_year} Aodaruma",
+                        version = env!("CARGO_PKG_VERSION"),
+                        build_year = env!("BUILD_YEAR")
+                    )
+                    .as_str(),
+                );
+            }
+            ae::Command::GlobalSetup => {
+                out_data.set_out_flag(OutFlags::SendUpdateParamsUi, true);
+                out_data.set_out_flag2(OutFlags2::SupportsSmartRender, true);
+                out_data.set_out_flag2(OutFlags2::ParamGroupStartCollapsedFlag, true);
+                out_data.set_out_flag2(OutFlags2::RevealsZeroAlpha, true);
+                if let Ok(suite) = ae::aegp::suites::Utility::new()
+                    && let Ok(plugin_id) = suite.register_with_aegp("AOD_ImageTransform")
+                {
+                    self.aegp_id = Some(plugin_id);
+                }
+            }
+            ae::Command::Render {
+                in_layer,
+                out_layer,
+            } => {
+                self.do_render(in_data, in_layer, out_layer, params, RenderPath::Legacy)?;
+            }
+            ae::Command::SmartPreRender { mut extra } => {
+                let mut request = extra.output_request();
+                request.preserve_rgb_of_zero_alpha = 1;
+                let callbacks = extra.callbacks();
+                let query = callbacks.checkout_layer(
+                    0,
+                    1000,
+                    &request,
+                    in_data.current_time(),
+                    in_data.time_step(),
+                    in_data.time_scale(),
+                )?;
+                let mut full_request = request;
+                full_request.rect = query.max_result_rect;
+                let input = callbacks.checkout_layer(
+                    0,
+                    0,
+                    &full_request,
+                    in_data.current_time(),
+                    in_data.time_step(),
+                    in_data.time_scale(),
+                )?;
+                let full_rect: ae::Rect = input.max_result_rect.into();
+                let _ = extra.union_result_rect(full_rect);
+                let _ = extra.union_max_result_rect(full_rect);
+                extra.set_returns_extra_pixels(true);
+            }
+            ae::Command::SmartRender { extra } => {
+                let callbacks = extra.callbacks();
+                let input = callbacks.checkout_layer_pixels(0)?;
+                let render_result = (|| -> Result<(), Error> {
+                    let output = callbacks.checkout_output()?;
+                    if let (Some(input), Some(output)) = (input, output) {
+                        self.do_render(in_data, input, output, params, RenderPath::Smart)?;
+                    }
+                    Ok(())
+                })();
+                let checkin_result = callbacks.checkin_layer_pixels(0);
+                render_result?;
+                checkin_result?;
+            }
+            ae::Command::UserChangedParam { param_index } => {
+                if matches!(
+                    params.type_at(param_index),
+                    Params::SeparateScale | Params::Interpolation | Params::SampleOutside
+                ) {
+                    out_data.set_out_flag(OutFlags::RefreshUi, true);
+                }
+            }
+            ae::Command::UpdateParamsUi => {
+                let mut cloned = params.cloned();
+                self.update_params_ui(in_data, &mut cloned)?;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+}
+
+impl Plugin {
+    fn update_params_ui(
+        &self,
+        in_data: InData,
+        params: &mut Parameters<Params>,
+    ) -> Result<(), Error> {
+        let separate = params.get(Params::SeparateScale)?.as_checkbox()?.value();
+        self.set_param_visible(in_data, params, Params::Scale, !separate)?;
+        self.set_param_visible(in_data, params, Params::ScaleX, separate)?;
+        self.set_param_visible(in_data, params, Params::ScaleY, separate)?;
+        Self::set_param_enabled(params, Params::Scale, !separate)?;
+        Self::set_param_enabled(params, Params::ScaleX, separate)?;
+        Self::set_param_enabled(params, Params::ScaleY, separate)?;
+
+        let interpolation = params.get(Params::Interpolation)?.as_popup()?.value();
+        self.set_param_visible(in_data, params, Params::MitchellB, interpolation == 4)?;
+        self.set_param_visible(in_data, params, Params::MitchellC, interpolation == 4)?;
+        self.set_param_visible(in_data, params, Params::LanczosLobes, interpolation == 5)?;
+        self.set_param_visible(in_data, params, Params::EwaRadius, interpolation == 7)?;
+
+        let sample_outside = params.get(Params::SampleOutside)?.as_checkbox()?.value();
+        self.set_param_visible(in_data, params, Params::OutsideMode, sample_outside)?;
+        Self::set_param_enabled(params, Params::OutsideMode, sample_outside)?;
+        Ok(())
+    }
+
+    fn set_param_visible(
+        &self,
+        in_data: InData,
+        params: &mut Parameters<Params>,
+        id: Params,
+        visible: bool,
+    ) -> Result<(), Error> {
+        if in_data.is_premiere() {
+            return Self::set_param_ui_flag(params, id, ParamUIFlags::INVISIBLE, !visible);
+        }
+        if let Some(plugin_id) = self.aegp_id {
+            let effect = in_data.effect();
+            if let Some(index) = params.index(id)
+                && let Ok(effect_ref) = effect.aegp_effect(plugin_id)
+                && let Ok(stream) = effect_ref.new_stream_by_index(plugin_id, index as i32)
+            {
+                return stream.set_dynamic_stream_flag(
+                    ae::aegp::DynamicStreamFlags::Hidden,
+                    false,
+                    !visible,
+                );
+            }
+        }
+        Self::set_param_ui_flag(params, id, ParamUIFlags::INVISIBLE, !visible)
+    }
+
+    fn set_param_enabled(
+        params: &mut Parameters<Params>,
+        id: Params,
+        enabled: bool,
+    ) -> Result<(), Error> {
+        Self::set_param_ui_flag(params, id, ParamUIFlags::DISABLED, !enabled)
+    }
+
+    fn set_param_ui_flag(
+        params: &mut Parameters<Params>,
+        id: Params,
+        flag: ParamUIFlags,
+        status: bool,
+    ) -> Result<(), Error> {
+        let current = (params.get(id)?.ui_flags().bits() & flag.bits()) != 0;
+        if current == status {
+            return Ok(());
+        }
+        let mut param = params.get_mut(id)?;
+        param.set_ui_flag(flag, status);
+        param.update_param_ui()?;
+        Ok(())
+    }
+
+    fn do_render(
+        &self,
+        in_data: InData,
+        in_layer: Layer,
+        mut out_layer: Layer,
+        params: &mut Parameters<Params>,
+        render_path: RenderPath,
+    ) -> Result<(), Error> {
+        let src_width = in_layer.width();
+        let src_height = in_layer.height();
+        let out_height = out_layer.height();
+        if src_width == 0 || src_height == 0 || out_layer.width() == 0 || out_height == 0 {
+            return Ok(());
+        }
+
+        let settings = read_settings(params, in_data)?;
+        let inverse = transform_matrix(settings).inverse();
+        let source = read_layer(&in_layer);
+        let source_origin = source_buffer_origin(in_data, &in_layer, render_path);
+        let output_origin = output_buffer_origin(in_data, &out_layer, source_origin, render_path);
+        let out_world_type = out_layer.world_type();
+
+        out_layer.iterate(0, out_height as i32, None, |x, y, mut destination| {
+            let layer_point = [x as f32 + output_origin[0], y as f32 + output_origin[1]];
+            let source_point = inverse
+                .map(|matrix| inverse_map(layer_point, settings, matrix))
+                .unwrap_or([f32::INFINITY; 2]);
+            let local = layer_to_local(source_point, source_origin);
+            let sampled = sample_filtered(
+                &source,
+                src_width,
+                src_height,
+                local[0],
+                local[1],
+                settings.edge,
+                settings.filter,
+            );
+            let pixel = apply_opacity(sampled, settings.opacity);
+            match out_world_type {
+                ae::aegp::WorldType::U8 => destination.set_from_u8(pixel.to_pixel8()),
+                ae::aegp::WorldType::U15 => destination.set_from_u16(pixel.to_pixel16()),
+                ae::aegp::WorldType::F32 | ae::aegp::WorldType::None => {
+                    destination.set_from_f32(pixel)
+                }
+            }
+            Ok(())
+        })?;
+        Ok(())
+    }
+}
+
+fn add_scale_slider(
+    params: &mut Parameters<Params>,
+    id: Params,
+    name: &str,
+    visible: bool,
+) -> Result<(), Error> {
+    let mut ui_flags = ParamUIFlags::empty();
+    if !visible {
+        ui_flags |= ParamUIFlags::INVISIBLE | ParamUIFlags::DISABLED;
+    }
+    params.add_with_flags(
+        id,
+        name,
+        FloatSliderDef::setup(|d| {
+            d.set_valid_min(-10000.0);
+            d.set_valid_max(10000.0);
+            d.set_slider_min(-1000.0);
+            d.set_slider_max(1000.0);
+            d.set_default(100.0);
+            d.set_precision(2);
+        }),
+        ParamFlag::empty(),
+        ui_flags,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn add_hidden_float_slider(
+    params: &mut Parameters<Params>,
+    id: Params,
+    name: &str,
+    minimum: f32,
+    maximum: f32,
+    default: f64,
+    precision: i16,
+) -> Result<(), Error> {
+    params.add_with_flags(
+        id,
+        name,
+        FloatSliderDef::setup(|d| {
+            d.set_valid_min(minimum);
+            d.set_valid_max(maximum);
+            d.set_slider_min(minimum);
+            d.set_slider_max(maximum);
+            d.set_default(default);
+            d.set_precision(precision);
+        }),
+        ParamFlag::empty(),
+        ParamUIFlags::INVISIBLE,
+    )
+}
+
+fn read_settings(params: &Parameters<Params>, in_data: InData) -> Result<TransformSettings, Error> {
+    let separate = params.get(Params::SeparateScale)?.as_checkbox()?.value();
+    let scale = if separate {
+        [
+            slider(params, Params::ScaleX)? * 0.01,
+            slider(params, Params::ScaleY)? * 0.01,
+        ]
+    } else {
+        let uniform = slider(params, Params::Scale)? * 0.01;
+        [uniform, uniform]
+    };
+    let interpolation = params.get(Params::Interpolation)?.as_popup()?.value();
+    let filter = match interpolation {
+        1 => SampleFilter::Nearest,
+        3 => SampleFilter::Bicubic,
+        4 => SampleFilter::Mitchell {
+            b: slider(params, Params::MitchellB)?.clamp(0.0, 1.0),
+            c: slider(params, Params::MitchellC)?.clamp(0.0, 1.0),
+        },
+        5 => SampleFilter::Lanczos {
+            lobes: slider(params, Params::LanczosLobes)?.clamp(1.0, 8.0),
+        },
+        6 => SampleFilter::CubicBSpline,
+        7 => SampleFilter::EwaQuadratic {
+            radius: slider(params, Params::EwaRadius)?.clamp(0.5, 8.0),
+        },
+        _ => SampleFilter::Bilinear,
+    };
+    let requested_edge = match params.get(Params::OutsideMode)?.as_popup()?.value() {
+        2 => SampleEdge::Tile,
+        3 => SampleEdge::Mirror,
+        _ => SampleEdge::Clamp,
+    };
+    let edge = selected_edge(
+        params.get(Params::SampleOutside)?.as_checkbox()?.value(),
+        requested_edge,
+    );
+    let [pixel_scale_x, pixel_scale_y] = render_pixel_scale(in_data);
+    Ok(TransformSettings {
+        anchor: point(params, Params::AnchorPoint)?,
+        position: point(params, Params::Position)?,
+        scale: [finite_or(scale[0], 1.0), finite_or(scale[1], 1.0)],
+        rotation: angle(params, Params::Rotation)?.to_radians(),
+        skew: angle(params, Params::Skew)?.to_radians(),
+        skew_axis: angle(params, Params::SkewAxis)?.to_radians(),
+        opacity: (slider(params, Params::Opacity)? * 0.01).clamp(0.0, 1.0),
+        filter,
+        edge,
+        pixel_scale: [pixel_scale_x, pixel_scale_y],
+    })
+}
+
+fn slider(params: &Parameters<Params>, id: Params) -> Result<f32, Error> {
+    Ok(finite_or(
+        params.get(id)?.as_float_slider()?.value() as f32,
+        0.0,
+    ))
+}
+
+fn angle(params: &Parameters<Params>, id: Params) -> Result<f32, Error> {
+    Ok(finite_or(
+        params.get(id)?.as_angle()?.float_value()? as f32,
+        0.0,
+    ))
+}
+
+fn point(params: &Parameters<Params>, id: Params) -> Result<[f32; 2], Error> {
+    let param = params.get(id)?;
+    let point = param.as_point()?;
+    let value = match point.float_value() {
+        Ok(value) => [value.x as f32, value.y as f32],
+        Err(_) => {
+            let value = point.value();
+            [value.0, value.1]
+        }
+    };
+    Ok([finite_or(value[0], 0.0), finite_or(value[1], 0.0)])
+}
+
+fn finite_or(value: f32, fallback: f32) -> f32 {
+    if value.is_finite() { value } else { fallback }
+}
+
+fn render_pixel_scale(in_data: InData) -> [f32; 2] {
+    let pixel_aspect = rational_or_one(in_data.pixel_aspect_ratio());
+    let downsample_x = rational_or_one(in_data.downsample_x());
+    let downsample_y = rational_or_one(in_data.downsample_y());
+    [
+        pixel_aspect / downsample_x.max(1.0e-6),
+        1.0 / downsample_y.max(1.0e-6),
+    ]
+}
+
+fn rational_or_one(value: RationalScale) -> f32 {
+    if value.num > 0 && value.den > 0 {
+        let ratio = value.num as f32 / value.den as f32;
+        if ratio.is_finite() && ratio > 0.0 {
+            return ratio;
+        }
+    }
+    1.0
+}
+
+fn transform_matrix(settings: TransformSettings) -> Matrix2 {
+    let scale = Matrix2::scale(settings.scale[0], settings.scale[1]);
+    let skew = Matrix2::rotation(settings.skew_axis)
+        .mul(Matrix2::shear_x(settings.skew))
+        .mul(Matrix2::rotation(-settings.skew_axis));
+    Matrix2::rotation(settings.rotation).mul(skew).mul(scale)
+}
+
+fn inverse_map(destination: [f32; 2], settings: TransformSettings, inverse: Matrix2) -> [f32; 2] {
+    let destination_physical = [
+        (destination[0] - settings.position[0]) * settings.pixel_scale[0],
+        (destination[1] - settings.position[1]) * settings.pixel_scale[1],
+    ];
+    let source_physical = inverse.transform(destination_physical);
+    [
+        settings.anchor[0] + source_physical[0] / settings.pixel_scale[0],
+        settings.anchor[1] + source_physical[1] / settings.pixel_scale[1],
+    ]
+}
+
+#[cfg(test)]
+fn forward_map(source: [f32; 2], settings: TransformSettings) -> [f32; 2] {
+    let source_physical = [
+        (source[0] - settings.anchor[0]) * settings.pixel_scale[0],
+        (source[1] - settings.anchor[1]) * settings.pixel_scale[1],
+    ];
+    let destination_physical = transform_matrix(settings).transform(source_physical);
+    [
+        settings.position[0] + destination_physical[0] / settings.pixel_scale[0],
+        settings.position[1] + destination_physical[1] / settings.pixel_scale[1],
+    ]
+}
+
+fn layer_to_local(point: [f32; 2], origin: [f32; 2]) -> [f32; 2] {
+    [point[0] - origin[0], point[1] - origin[1]]
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RenderPath {
+    Legacy,
+    Smart,
+}
+
+fn resolve_world_origin(
+    native: ae::Point,
+    fallback: [f32; 2],
+    render_path: RenderPath,
+) -> [f32; 2] {
+    // Smart Render checkouts carry their requested rectangle's layer-space
+    // top-left directly in PF_EffectWorld::origin. It is more precise than
+    // PF_InData's legacy frame-level offsets, especially for tiles and extra
+    // pixels. Zero is also a valid Smart Render tile origin and must be trusted.
+    // Legacy Render worlds commonly leave both fields at zero, so only that
+    // path deliberately falls through to the PF_InData mapping.
+    if render_path == RenderPath::Smart || native.h != 0 || native.v != 0 {
+        [native.h as f32, native.v as f32]
+    } else {
+        fallback
+    }
+}
+
+fn source_origin_from_pre_effect(pre_effect_origin: ae::Point) -> [f32; 2] {
+    // pre_effect_source_origin is the input-buffer position at which layer
+    // point (0, 0) appears. Therefore input-buffer point (0, 0) represents
+    // layer point (-pre_effect_source_origin).
+    [-(pre_effect_origin.h as f32), -(pre_effect_origin.v as f32)]
+}
+
+fn output_origin_from_shift(source_origin: [f32; 2], output_shift: ae::Point) -> [f32; 2] {
+    // output_origin is the output-buffer position of input-buffer point
+    // (0, 0). Consequently output-buffer point (0, 0) is that same layer
+    // coordinate shifted in the opposite direction.
+    [
+        source_origin[0] - output_shift.h as f32,
+        source_origin[1] - output_shift.v as f32,
+    ]
+}
+
+fn source_buffer_origin(in_data: InData, layer: &Layer, render_path: RenderPath) -> [f32; 2] {
+    resolve_world_origin(
+        layer.origin(),
+        source_origin_from_pre_effect(in_data.pre_effect_source_origin()),
+        render_path,
+    )
+}
+
+fn output_buffer_origin(
+    in_data: InData,
+    layer: &Layer,
+    source_origin: [f32; 2],
+    render_path: RenderPath,
+) -> [f32; 2] {
+    resolve_world_origin(
+        layer.origin(),
+        output_origin_from_shift(source_origin, in_data.output_origin()),
+        render_path,
+    )
+}
+
+fn selected_edge(sample_outside: bool, requested: SampleEdge) -> SampleEdge {
+    if sample_outside {
+        requested
+    } else {
+        SampleEdge::Transparent
+    }
+}
+
+fn apply_opacity(pixel: PixelF32, opacity: f32) -> PixelF32 {
+    let opacity = finite_or(opacity, 1.0).clamp(0.0, 1.0);
+    sanitize_pixel(
+        PixelF32 {
+            alpha: pixel.alpha * opacity,
+            red: pixel.red * opacity,
+            green: pixel.green * opacity,
+            blue: pixel.blue * opacity,
+        },
+        false,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn settings() -> TransformSettings {
+        TransformSettings {
+            anchor: [50.0, 40.0],
+            position: [50.0, 40.0],
+            scale: [1.0, 1.0],
+            rotation: 0.0,
+            skew: 0.0,
+            skew_axis: 0.0,
+            opacity: 1.0,
+            filter: SampleFilter::Bilinear,
+            edge: SampleEdge::Transparent,
+            pixel_scale: [1.0, 1.0],
+        }
+    }
+
+    fn assert_point_close(actual: [f32; 2], expected: [f32; 2]) {
+        assert!((actual[0] - expected[0]).abs() < 1.0e-4);
+        assert!((actual[1] - expected[1]).abs() < 1.0e-4);
+    }
+
+    #[test]
+    fn identity_inverse_mapping_preserves_coordinates() {
+        let settings = settings();
+        let inverse = transform_matrix(settings)
+            .inverse()
+            .expect("identity is invertible");
+        for point in [[0.0, 0.0], [50.0, 40.0], [123.5, -17.25]] {
+            assert_point_close(inverse_map(point, settings, inverse), point);
+        }
+    }
+
+    #[test]
+    fn inverse_mapping_undoes_full_affine_transform() {
+        let mut settings = settings();
+        settings.position = [170.0, -30.0];
+        settings.scale = [-1.25, 0.65];
+        settings.rotation = 37.0_f32.to_radians();
+        settings.skew = -21.0_f32.to_radians();
+        settings.skew_axis = 14.0_f32.to_radians();
+        settings.pixel_scale = [2.4, 3.0];
+        let inverse = transform_matrix(settings)
+            .inverse()
+            .expect("non-zero scales are invertible");
+        for source in [[0.0, 0.0], [50.0, 40.0], [103.0, -18.0]] {
+            let destination = forward_map(source, settings);
+            assert_point_close(inverse_map(destination, settings, inverse), source);
+        }
+    }
+
+    #[test]
+    fn anchor_maps_to_position() {
+        let mut settings = settings();
+        settings.position = [300.0, 125.0];
+        settings.rotation = 90.0_f32.to_radians();
+        settings.scale = [2.0, 3.0];
+        assert_point_close(forward_map(settings.anchor, settings), settings.position);
+    }
+
+    #[test]
+    fn layer_origins_map_layer_space_to_checkout_space() {
+        assert_eq!(layer_to_local([45.0, 12.0], [-20.0, 10.0]), [65.0, 2.0]);
+        assert_eq!(layer_to_local([45.0, 12.0], [30.0, -8.0]), [15.0, 20.0]);
+    }
+
+    #[test]
+    fn legacy_origin_fallbacks_follow_pf_indata_sign_conventions() {
+        // The original source point (0, 0) appears at input local (20, 5), so
+        // input local (0, 0) is layer point (-20, -5).
+        let source_origin = source_origin_from_pre_effect(ae::Point { h: 20, v: 5 });
+        assert_eq!(source_origin, [-20.0, -5.0]);
+
+        // Input local (0, 0) appears at output local (7, 3), so output local
+        // (0, 0) is seven/three pixels earlier in layer space.
+        let output_origin = output_origin_from_shift(source_origin, ae::Point { h: 7, v: 3 });
+        assert_eq!(output_origin, [-27.0, -8.0]);
+
+        // At the documented output shift, identity mapping lands exactly on
+        // input local (0, 0).
+        let layer_point = [output_origin[0] + 7.0, output_origin[1] + 3.0];
+        assert_eq!(layer_to_local(layer_point, source_origin), [0.0, 0.0]);
+    }
+
+    #[test]
+    fn smart_world_origin_overrides_legacy_fallback_including_zero() {
+        let fallback = [-20.0, -5.0];
+        assert_eq!(
+            resolve_world_origin(ae::Point { h: 12, v: -8 }, fallback, RenderPath::Smart),
+            [12.0, -8.0]
+        );
+        assert_eq!(
+            resolve_world_origin(ae::Point { h: 0, v: 0 }, fallback, RenderPath::Smart),
+            [0.0, 0.0]
+        );
+        assert_eq!(
+            resolve_world_origin(ae::Point { h: 0, v: 0 }, fallback, RenderPath::Legacy),
+            fallback
+        );
+    }
+
+    #[test]
+    fn outside_checkbox_selects_transparent_or_requested_mapping() {
+        assert_eq!(
+            selected_edge(false, SampleEdge::Mirror),
+            SampleEdge::Transparent
+        );
+        assert_eq!(selected_edge(true, SampleEdge::Tile), SampleEdge::Tile);
+
+        let pixels = [PixelF32 {
+            alpha: 1.0,
+            red: 0.25,
+            green: 0.5,
+            blue: 0.75,
+        }];
+        let transparent = sample_filtered(
+            &pixels,
+            1,
+            1,
+            -2.0,
+            0.0,
+            selected_edge(false, SampleEdge::Clamp),
+            SampleFilter::Nearest,
+        );
+        let clamped = sample_filtered(
+            &pixels,
+            1,
+            1,
+            -2.0,
+            0.0,
+            selected_edge(true, SampleEdge::Clamp),
+            SampleFilter::Nearest,
+        );
+        assert_eq!(transparent.alpha, 0.0);
+        assert_eq!(clamped.red, 0.25);
+    }
+
+    #[test]
+    fn zero_scale_has_no_inverse() {
+        let mut settings = settings();
+        settings.scale[0] = 0.0;
+        assert!(transform_matrix(settings).inverse().is_none());
+    }
+
+    #[test]
+    fn opacity_preserves_premultiplication() {
+        let pixel = PixelF32 {
+            alpha: 0.8,
+            red: 0.4,
+            green: 0.2,
+            blue: 0.1,
+        };
+        let output = apply_opacity(pixel, 0.25);
+        assert!((output.alpha - 0.2).abs() < 1.0e-6);
+        assert!((output.red - 0.1).abs() < 1.0e-6);
+    }
+
+    #[test]
+    fn matrix_identity_is_neutral() {
+        assert_eq!(Matrix2::identity().transform([3.0, -2.0]), [3.0, -2.0]);
+    }
+}

--- a/plugins/rainbow-generate/Cargo.toml
+++ b/plugins/rainbow-generate/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rainbow_generate"
 description = "Generates parametric rainbows directly in perceptual and cylindrical color models across multiple geometric shapes."
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 
 [lib]
@@ -14,6 +14,7 @@ catch-panics = []
 [dependencies]
 after-effects = { workspace = true }
 utils = { path = "../../crates/utils" }
+palette.workspace = true
 
 
 [dev-dependencies]

--- a/plugins/rainbow-generate/Cargo.toml
+++ b/plugins/rainbow-generate/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "rainbow_generate"
+description = "Generates parametric rainbows directly in perceptual and cylindrical color models across multiple geometric shapes."
+version = "0.3.0"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib"]
+
+[features]
+default = []
+catch-panics = []
+
+[dependencies]
+after-effects = { workspace = true }
+utils = { path = "../../crates/utils" }
+
+
+[dev-dependencies]
+pipl = { workspace = true }
+
+[build-dependencies]
+chrono.workspace = true
+pipl.workspace = true
+winres = "0.1.12"
+
+[lints]
+workspace = true

--- a/plugins/rainbow-generate/Justfile
+++ b/plugins/rainbow-generate/Justfile
@@ -1,0 +1,12 @@
+# Read package.name from Cargo.toml for build naming.
+CrateName := if os() == "windows" {
+    `$inPackage = $false; foreach ($line in Get-Content -Path Cargo.toml) { if ($line -match '^\s*\[package\]\s*$') { $inPackage = $true; continue }; if ($line -match '^\s*\[.+\]\s*$') { if ($inPackage) { break } }; if ($inPackage -and $line -match '^\s*name\s*=\s*"([^"]+)"') { $matches[1]; break } }`
+} else {
+    `awk -F'"' 'BEGIN{in_pkg=0} /^[[:space:]]*\[package\][[:space:]]*$/{in_pkg=1;next} /^[[:space:]]*\[/{if(in_pkg)exit} in_pkg && /^[[:space:]]*name[[:space:]]*=/ {print $2; exit}' Cargo.toml`
+}
+
+PluginName       := "AOD_RainbowGenerate"
+BundleIdentifier := "com.aodaruma." + PluginName
+BinaryName       := snakecase(CrateName)
+
+import "../../AdobePlugin.just"

--- a/plugins/rainbow-generate/README.md
+++ b/plugins/rainbow-generate/README.md
@@ -9,8 +9,11 @@ This is the After Effects plugin **AOD_RainbowGenerate**, which provides the **A
 - **Geometry**: Linear, Reflected Linear, Radial (L2), Diamond (L1), Box (L-infinity), generalized Minkowski (Lp), Conic, Spiral, and Starburst gradients. Use two on-canvas points or a parametric center, angle, and length/radius.
 - **Shape Parameters**: `Minkowski Exponent` continuously moves between L1 diamond, L2 radial, and a box-like high-p norm. `Spiral Turns` and `Ray Count` parameterize the procedural shapes.
 - **Aspect**: A symmetric `-1..1` control. Negative values stretch vertically and positive values stretch horizontally; the internal reciprocal logarithmic mapping runs from `0.1x` through `1x` to `10x`.
-- **Color Model**: Generate the rainbow directly in OKLCH, HSV, HSL, CIELCh(ab), CIELCh(uv), JzCzHz, or IPT ICh. There are no endpoint color pickers. The first three popup entries retain their original indices and behavior.
-- **Perceptual Component Mapping**: `100%` chroma maps to `0.2` in OKLCH, `C*=80` in CIELCh(ab), `C*=100` in CIELCh(uv), `Cz=0.08` in JzCzHz, and `C=0.30` in IPT ICh. For JzCzHz, `100%` lightness is the Jz value of a 100-nit D65 white (`Jz=0.167174`); IPT exposes its intensity axis as `Intensity`.
+- **Skew**: Applies a horizontal inverse-coordinate shear to every shape. `0%` leaves the existing geometry unchanged and `100%` corresponds to a shear factor of `1`.
+- **Generation Mode**: `Parametric` remains the default and generates the rainbow directly from cylindrical components. `Two Color` exposes start/end color pickers and an independent interpolation-space selector.
+- **Color Model**: In Parametric mode, generate directly in OKLCH, HSV, HSL, CIELCh(ab), CIELCh(uv), JzCzHz, IPT ICh, OkHSL, OkHSV, or CAM16-UCS J'M'h'. The original seven popup entries retain their indices and behavior.
+- **Two Color Space**: Interpolate the selected colors in OKLab, OKLCH, CAM16-UCS J'a'b', or CAM16-UCS J'M'h'. Both polar spaces follow the shortest hue path and hold the chromatic endpoint's hue when the other endpoint is neutral. Endpoint conversion is prepared once per render rather than once per pixel.
+- **Perceptual Component Mapping**: `100%` chroma maps to `0.2` in OKLCH, `C*=80` in CIELCh(ab), `C*=100` in CIELCh(uv), `Cz=0.08` in JzCzHz, `C=0.30` in IPT ICh, and `M'=50` in CAM16-UCS. For JzCzHz, `100%` lightness is the Jz value of a 100-nit D65 white (`Jz=0.167174`); IPT exposes its intensity axis as `Intensity`; CAM16-UCS maps `100%` lightness to `J'=100`.
 - **Scale + Offset**: With `Split Range Start / End` off, each cylindrical component is an affine function of the eased geometry coordinate `t`: `component(t) = offset + scale * t`. `Hue Scale = 100%` is one full 360-degree cycle. Saturation/chroma and brightness/lightness scales are the percentage-point change across the range.
 - **Explicit Range Ends**: `Split Range Start / End` replaces the affine controls with explicit Hue, Saturation/Chroma, and Brightness/Lightness values for each end. The values interpolate continuously and unwrapped hue values allow reverse or multiple rainbow cycles.
 - **Easing**: Common easing presets plus a four-value cubic Bezier editor (`x1`, `y1`, `x2`, `y2`).
@@ -18,13 +21,21 @@ This is the After Effects plugin **AOD_RainbowGenerate**, which provides the **A
 
 Controls that do not apply to the selected mode are hidden dynamically. The standard cubic controls are intentionally host-native so animation, project serialization, and Premiere Pro fallback remain reliable.
 
-## Version 0.2 Design Change
+## Generation Modes
 
-Version 0.2 intentionally replaces the original two-color interpolation UI and render model with direct parametric rainbow generation. Projects created with the earlier development build should recreate their color settings with the new component controls.
+Direct parametric rainbow generation is the default. The optional Two Color mode restores endpoint color selection without changing the parameter indices or behavior of the existing parametric controls.
 
 ## Version 0.3 Color Models
 
 Version 0.3 appends four distinct cylindrical models without changing the existing OKLCH, HSV, and HSL popup indices. CIELCh(ab) uses D50 CIELAB with D65 chromatic adaptation for display output; CIELCh(uv) uses D65 CIELUV; JzCzHz provides an HDR-oriented lightness/opponent model normalized to an SDR 100-nit white; and IPT ICh provides an intensity/opponent model with a hue-uniformity-oriented nonlinearity. Component names update dynamically for Chroma, Lightness, Jz, and Intensity.
+
+## Version 0.4 Perceptual Models
+
+OkHSL and OkHSV are later sRGB-gamut color-picking spaces derived from OKLab. CAM16-UCS is a uniform color space derived from the more comprehensive CAM16 color appearance model and is available in polar J'M'h' form for parametric generation, plus Cartesian J'a'b' and polar J'M'h' forms for two-color interpolation.
+
+CAM16-UCS uses fixed display-referred viewing conditions so animated frames remain deterministic: D65 white, `40 cd/m²` adapting luminance, a `20%` background luminance factor, average surround, and automatic illuminant discounting. These parameters are baked once per render. The implementation uses `palette 0.7.7`; see [Third-Party Notices](THIRD_PARTY_NOTICES.md).
+
+Definitions: [OkHSL and OkHSV](https://bottosson.github.io/posts/colorpicker/), [CAM16 and CAM16-UCS](https://doi.org/10.1002/col.22131), and the [palette CAM16 API](https://docs.rs/palette/0.7.7/palette/cam16/).
 
 ## Building the Plugin
 

--- a/plugins/rainbow-generate/README.md
+++ b/plugins/rainbow-generate/README.md
@@ -1,0 +1,31 @@
+# rainbow-generate ( AOD_RainbowGenerate )
+
+Generates parametric gradients in perceptual and cylindrical color spaces across multiple geometric shapes.
+
+This is the After Effects plugin **AOD_RainbowGenerate**, which provides the **AOD_RainbowGenerate.aex** plugin file for Adobe After Effects.
+
+## Controls
+
+- **Geometry**: Linear, Reflected Linear, Radial (L2), Diamond (L1), Box (L-infinity), generalized Minkowski (Lp), Conic, Spiral, and Starburst gradients. Use two on-canvas points or a parametric center, angle, and length/radius.
+- **Shape Parameters**: `Minkowski Exponent` continuously moves between L1 diamond, L2 radial, and a box-like high-p norm. `Spiral Turns` and `Ray Count` parameterize the procedural shapes.
+- **Aspect**: A symmetric `-1..1` control. Negative values stretch vertically and positive values stretch horizontally; the internal reciprocal logarithmic mapping runs from `0.1x` through `1x` to `10x`.
+- **Color Model**: Generate the rainbow directly in OKLCH, HSV, HSL, CIELCh(ab), CIELCh(uv), JzCzHz, or IPT ICh. There are no endpoint color pickers. The first three popup entries retain their original indices and behavior.
+- **Perceptual Component Mapping**: `100%` chroma maps to `0.2` in OKLCH, `C*=80` in CIELCh(ab), `C*=100` in CIELCh(uv), `Cz=0.08` in JzCzHz, and `C=0.30` in IPT ICh. For JzCzHz, `100%` lightness is the Jz value of a 100-nit D65 white (`Jz=0.167174`); IPT exposes its intensity axis as `Intensity`.
+- **Scale + Offset**: With `Split Range Start / End` off, each cylindrical component is an affine function of the eased geometry coordinate `t`: `component(t) = offset + scale * t`. `Hue Scale = 100%` is one full 360-degree cycle. Saturation/chroma and brightness/lightness scales are the percentage-point change across the range.
+- **Explicit Range Ends**: `Split Range Start / End` replaces the affine controls with explicit Hue, Saturation/Chroma, and Brightness/Lightness values for each end. The values interpolate continuously and unwrapped hue values allow reverse or multiple rainbow cycles.
+- **Easing**: Common easing presets plus a four-value cubic Bezier editor (`x1`, `y1`, `x2`, `y2`).
+- **Output**: Blend with the source and optionally preserve its alpha.
+
+Controls that do not apply to the selected mode are hidden dynamically. The standard cubic controls are intentionally host-native so animation, project serialization, and Premiere Pro fallback remain reliable.
+
+## Version 0.2 Design Change
+
+Version 0.2 intentionally replaces the original two-color interpolation UI and render model with direct parametric rainbow generation. Projects created with the earlier development build should recreate their color settings with the new component controls.
+
+## Version 0.3 Color Models
+
+Version 0.3 appends four distinct cylindrical models without changing the existing OKLCH, HSV, and HSL popup indices. CIELCh(ab) uses D50 CIELAB with D65 chromatic adaptation for display output; CIELCh(uv) uses D65 CIELUV; JzCzHz provides an HDR-oriented lightness/opponent model normalized to an SDR 100-nit white; and IPT ICh provides an intensity/opponent model with a hue-uniformity-oriented nonlinearity. Component names update dynamically for Chroma, Lightness, Jz, and Intensity.
+
+## Building the Plugin
+
+See the [main README](../../README.md) for instructions on how to build the plugin.

--- a/plugins/rainbow-generate/THIRD_PARTY_NOTICES.md
+++ b/plugins/rainbow-generate/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,27 @@
+# Third-Party Notices
+
+## palette 0.7.7
+
+This plugin uses the `palette` crate, available under the MIT OR Apache-2.0 license. The MIT license option is reproduced below.
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Erik Hedvall
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/rainbow-generate/build.rs
+++ b/plugins/rainbow-generate/build.rs
@@ -1,0 +1,101 @@
+use chrono::Datelike;
+use pipl::*;
+
+const PF_PLUG_IN_VERSION: u16 = 13;
+const PF_PLUG_IN_SUBVERS: u16 = 28;
+
+#[cfg(target_os = "windows")]
+fn embed_binary_safe_pipl(pipl: &[u8]) {
+    let out_dir = std::path::PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR is set"));
+    let pipl_path = out_dir.join("rainbow_generate.pipl");
+    std::fs::write(&pipl_path, pipl).expect("write binary PiPL resource");
+
+    let escaped_path = pipl_path.to_string_lossy().replace('\\', "\\\\");
+    let mut resource = winres::WindowsResource::new();
+    resource.append_rc_content(&format!("16000 PiPL DISCARDABLE \"{escaped_path}\""));
+    resource.compile().expect("compile binary PiPL resource");
+}
+
+#[rustfmt::skip]
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(does_dialog)");
+    println!("cargo::rustc-check-cfg=cfg(threaded_rendering)");
+
+    let current_year = chrono::Local::now().year();
+    println!("cargo:rustc-env=BUILD_YEAR={}", current_year);
+
+    let pkg_version = env!("CARGO_PKG_VERSION");
+    let version_parts: Vec<&str> = pkg_version.split('.').collect();
+    if version_parts.len() != 3 {
+        panic!("CARGO_PKG_VERSION must be in the format 'major.minor.patch'");
+    }
+    let major: u32 = version_parts[0].parse().expect("Invalid major version");
+    let minor: u32 = version_parts[1].parse().expect("Invalid minor version");
+    let patch: u32 = version_parts[2].parse().expect("Invalid patch version");
+
+    // Determine the stage based on building whether debug or release
+    /*
+    // pipl load error occured when stage = Stage::Release in pipl == v0.1.1, so temporarily fixed to Develop
+    let stage = if cfg!(debug_assertions) {
+        Stage::Develop
+    } else {
+        Stage::Release
+    };
+    */
+    let stage = Stage::Develop;
+
+    // --------------------------------------------------
+    // Build the plugin with PiPL
+    let properties = || vec![
+        Property::Kind(PIPLType::AEEffect),
+        Property::Name("AOD_RainbowGenerate"),
+        Property::Category("Aodaruma"),
+
+        #[cfg(target_os = "windows")]
+        Property::CodeWin64X86("EffectMain"),
+        #[cfg(target_os = "macos")]
+        Property::CodeMacIntel64("EffectMain"),
+        #[cfg(target_os = "macos")]
+        Property::CodeMacARM64("EffectMain"),
+
+        Property::AE_PiPL_Version { major: 2, minor: 0 },
+        Property::AE_Effect_Spec_Version { major: PF_PLUG_IN_VERSION, minor: PF_PLUG_IN_SUBVERS },
+        Property::AE_Effect_Version {
+            version: major,
+            subversion: minor,
+            bugversion: patch,
+            stage,
+            build: 1,
+        },
+        Property::AE_Effect_Info_Flags(0),
+        Property::AE_Effect_Global_OutFlags(
+            // set up from https://docs.rs/pipl/latest/pipl/struct.OutFlags.html
+            OutFlags::PixIndependent
+            | OutFlags::UseOutputExtent
+            | OutFlags::DeepColorAware
+            | OutFlags::WideTimeInput
+            | OutFlags::SendUpdateParamsUI
+            ,
+        ),
+        Property::AE_Effect_Global_OutFlags_2(
+            // set up from https://docs.rs/pipl/latest/pipl/struct.OutFlags2.html
+            OutFlags2::FloatColorAware
+            // This effect has no sequence data. Keep that capability omitted
+            // even though pipl prints an older-host compatibility warning.
+            | OutFlags2::SupportsThreadedRendering
+            | OutFlags2::AutomaticWideTimeInput
+            | OutFlags2::SupportsSmartRender
+            | OutFlags2::RevealsZeroAlpha
+            | OutFlags2::ParamGroupStartCollapsedFlag
+            // | OutFlags2::SupportsGpuRenderF32
+            ,
+        ),
+        Property::AE_Effect_Match_Name("RainbowGenerate"),
+        Property::AE_Reserved_Info(8),
+        Property::AE_Effect_Support_URL("https://github.com/Aodaruma/aod-AE-plugin"),
+    ];
+
+    pipl::plugin_build(properties());
+    #[cfg(target_os = "windows")]
+    embed_binary_safe_pipl(&pipl::build_pipl(properties()).expect("build PiPL"));
+}

--- a/plugins/rainbow-generate/src/gradient.rs
+++ b/plugins/rainbow-generate/src/gradient.rs
@@ -1,0 +1,793 @@
+use std::f32::consts::TAU;
+
+const OKLCH_CHROMA_AT_100_PERCENT: f32 = 0.2;
+const CIELAB_CHROMA_AT_100_PERCENT: f32 = 80.0;
+const CIELUV_CHROMA_AT_100_PERCENT: f32 = 100.0;
+const JZ_CHROMA_AT_100_PERCENT: f32 = 0.08;
+const JZ_AT_100_PERCENT: f32 = 0.167_174;
+const IPT_CHROMA_AT_100_PERCENT: f32 = 0.3;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum Shape {
+    Linear,
+    Radial,
+    Diamond,
+    Conic,
+    Box,
+    Minkowski,
+    ReflectedLinear,
+    Spiral,
+    Starburst,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ColorModel {
+    Oklch,
+    Hsv,
+    Hsl,
+    CielchAb,
+    CielchUv,
+    Jzczhz,
+    IptIch,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ExtendMode {
+    Clamp,
+    Repeat,
+    Mirror,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum Easing {
+    Linear,
+    EaseIn,
+    EaseOut,
+    EaseInOut,
+    Smoothstep,
+    Smootherstep,
+    Custom,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct Geometry {
+    pub shape: Shape,
+    pub start: [f32; 2],
+    pub end: [f32; 2],
+    pub aspect: f32,
+    pub exponent: f32,
+    pub spiral_turns: f32,
+    pub ray_count: f32,
+}
+
+/// Parametric rainbow endpoints in cylindrical component order:
+/// `[unwrapped hue turns, saturation/chroma amount, value/lightness]`.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct Rainbow {
+    pub start: [f32; 3],
+    pub end: [f32; 3],
+    pub color_model: ColorModel,
+    pub extend: ExtendMode,
+    pub easing: Easing,
+    pub bezier: [f32; 4],
+    pub clamp_gamut: bool,
+}
+
+pub(crate) fn geometry_value(point: [f32; 2], geometry: Geometry) -> f32 {
+    let dx = geometry.end[0] - geometry.start[0];
+    let dy = geometry.end[1] - geometry.start[1];
+    let length_sq = dx.mul_add(dx, dy * dy);
+    if length_sq <= 1.0e-12 {
+        return 0.0;
+    }
+
+    if geometry.shape == Shape::Linear {
+        return ((point[0] - geometry.start[0]) * dx + (point[1] - geometry.start[1]) * dy)
+            / length_sq;
+    }
+
+    let length = length_sq.sqrt();
+    let ux = dx / length;
+    let uy = dy / length;
+    let px = point[0] - geometry.start[0];
+    let py = point[1] - geometry.start[1];
+    let local_x = px * ux + py * uy;
+    let aspect = if geometry.aspect.is_finite() {
+        geometry.aspect.clamp(1.0e-4, 1.0e4)
+    } else {
+        1.0
+    };
+    let local_y = (-px * uy + py * ux) * aspect;
+    let normalized_x = local_x / length;
+    let normalized_y = local_y / length;
+
+    match geometry.shape {
+        Shape::Linear => unreachable!(),
+        Shape::Radial => normalized_x.hypot(normalized_y),
+        Shape::Diamond => normalized_x.abs() + normalized_y.abs(),
+        Shape::Box => normalized_x.abs().max(normalized_y.abs()),
+        Shape::Minkowski => lp_norm(normalized_x, normalized_y, geometry.exponent),
+        Shape::ReflectedLinear => normalized_x.abs(),
+        Shape::Conic => local_y.atan2(local_x).rem_euclid(TAU) / TAU,
+        Shape::Spiral => {
+            let radius = normalized_x.hypot(normalized_y);
+            let angle = local_y.atan2(local_x).rem_euclid(TAU) / TAU;
+            let turns = if geometry.spiral_turns.is_finite() {
+                geometry.spiral_turns.clamp(-128.0, 128.0)
+            } else {
+                0.0
+            };
+            (radius + angle * turns).rem_euclid(1.0)
+        }
+        Shape::Starburst => {
+            let angle = local_y.atan2(local_x);
+            let rays = if geometry.ray_count.is_finite() {
+                geometry.ray_count.clamp(1.0, 512.0).round()
+            } else {
+                1.0
+            };
+            0.5 - 0.5 * (angle * rays).cos()
+        }
+    }
+}
+
+fn lp_norm(x: f32, y: f32, exponent: f32) -> f32 {
+    let x = x.abs();
+    let y = y.abs();
+    let maximum = x.max(y);
+    if maximum <= 1.0e-12 {
+        return 0.0;
+    }
+    let exponent = if exponent.is_finite() {
+        exponent.clamp(0.25, 64.0)
+    } else {
+        2.0
+    };
+    maximum * ((x / maximum).powf(exponent) + (y / maximum).powf(exponent)).powf(1.0 / exponent)
+}
+
+pub(crate) fn aspect_ratio_from_balance(balance: f32) -> f32 {
+    let balance = if balance.is_finite() {
+        balance.clamp(-1.0, 1.0)
+    } else {
+        0.0
+    };
+    10.0_f32.powf(balance)
+}
+
+pub(crate) fn sample_rainbow(raw_t: f32, rainbow: Rainbow) -> [f32; 3] {
+    let extended = extend_value(raw_t, rainbow.extend);
+    let t = ease_value(extended, rainbow.easing, rainbow.bezier);
+    let components = lerp3(rainbow.start, rainbow.end, t);
+    components_to_rgb(components, rainbow.color_model, rainbow.clamp_gamut)
+}
+
+fn components_to_rgb(components: [f32; 3], color_model: ColorModel, clamp_gamut: bool) -> [f32; 3] {
+    let hue = finite_or(components[0], 0.0).rem_euclid(1.0);
+    let second = finite_or(components[1], 0.0).max(0.0);
+    let third = finite_or(components[2], 0.0).max(0.0);
+    let mut rgb = match color_model {
+        ColorModel::Oklch => {
+            let lch = [third, second * OKLCH_CHROMA_AT_100_PERCENT, hue];
+            linear_to_srgb3(oklab_to_linear_srgb(oklch_to_oklab(lch)))
+        }
+        ColorModel::Hsv => hsv_to_srgb([hue, second, third]),
+        ColorModel::Hsl => hsl_to_srgb([hue, second, third.clamp(0.0, 1.0)]),
+        ColorModel::CielchAb => xyz_d65_to_srgb(cielch_ab_to_xyz_d65([
+            third * 100.0,
+            second * CIELAB_CHROMA_AT_100_PERCENT,
+            hue,
+        ])),
+        ColorModel::CielchUv => xyz_d65_to_srgb(cielch_uv_to_xyz_d65([
+            third * 100.0,
+            second * CIELUV_CHROMA_AT_100_PERCENT,
+            hue,
+        ])),
+        ColorModel::Jzczhz => xyz_d65_to_srgb(jzczhz_to_xyz_d65([
+            third * JZ_AT_100_PERCENT,
+            second * JZ_CHROMA_AT_100_PERCENT,
+            hue,
+        ])),
+        ColorModel::IptIch => xyz_d65_to_srgb(ipt_ich_to_xyz_d65([
+            third,
+            second * IPT_CHROMA_AT_100_PERCENT,
+            hue,
+        ])),
+    };
+    for channel in &mut rgb {
+        if !channel.is_finite() {
+            *channel = 0.0;
+        } else if clamp_gamut {
+            *channel = channel.clamp(0.0, 1.0);
+        }
+    }
+    rgb
+}
+
+pub(crate) fn extend_value(value: f32, mode: ExtendMode) -> f32 {
+    if !value.is_finite() {
+        return 0.0;
+    }
+    match mode {
+        ExtendMode::Clamp => value.clamp(0.0, 1.0),
+        ExtendMode::Repeat => value.rem_euclid(1.0),
+        ExtendMode::Mirror => {
+            let phase = value.rem_euclid(2.0);
+            if phase <= 1.0 { phase } else { 2.0 - phase }
+        }
+    }
+}
+
+pub(crate) fn ease_value(value: f32, easing: Easing, custom: [f32; 4]) -> f32 {
+    let x = value.clamp(0.0, 1.0);
+    match easing {
+        Easing::Linear => x,
+        Easing::Smoothstep => x * x * (3.0 - 2.0 * x),
+        Easing::Smootherstep => x * x * x * (x * (x * 6.0 - 15.0) + 10.0),
+        Easing::EaseIn => cubic_bezier_y_for_x(x, [0.42, 0.0, 1.0, 1.0]),
+        Easing::EaseOut => cubic_bezier_y_for_x(x, [0.0, 0.0, 0.58, 1.0]),
+        Easing::EaseInOut => cubic_bezier_y_for_x(x, [0.42, 0.0, 0.58, 1.0]),
+        Easing::Custom => cubic_bezier_y_for_x(x, custom),
+    }
+}
+
+fn cubic_bezier_y_for_x(x: f32, control: [f32; 4]) -> f32 {
+    if x <= 0.0 {
+        return 0.0;
+    }
+    if x >= 1.0 {
+        return 1.0;
+    }
+    let [x1, y1, x2, y2] = control;
+    let x1 = x1.clamp(0.0, 1.0);
+    let x2 = x2.clamp(0.0, 1.0);
+    let mut t = x;
+    for _ in 0..8 {
+        let estimate = cubic_bezier(t, x1, x2) - x;
+        let derivative = cubic_bezier_derivative(t, x1, x2);
+        if derivative.abs() <= 1.0e-6 {
+            break;
+        }
+        let candidate = t - estimate / derivative;
+        if !(0.0..=1.0).contains(&candidate) {
+            break;
+        }
+        t = candidate;
+    }
+    let mut low = 0.0;
+    let mut high = 1.0;
+    for _ in 0..12 {
+        if cubic_bezier(t, x1, x2) < x {
+            low = t;
+        } else {
+            high = t;
+        }
+        t = (low + high) * 0.5;
+    }
+    cubic_bezier(t, y1, y2)
+}
+
+fn cubic_bezier(t: f32, p1: f32, p2: f32) -> f32 {
+    let mt = 1.0 - t;
+    3.0 * mt * mt * t * p1 + 3.0 * mt * t * t * p2 + t * t * t
+}
+
+fn cubic_bezier_derivative(t: f32, p1: f32, p2: f32) -> f32 {
+    let mt = 1.0 - t;
+    3.0 * mt * mt * p1 + 6.0 * mt * t * (p2 - p1) + 3.0 * t * t * (1.0 - p2)
+}
+
+fn oklch_to_oklab(lch: [f32; 3]) -> [f32; 3] {
+    let angle = lch[2] * TAU;
+    [lch[0], lch[1] * angle.cos(), lch[1] * angle.sin()]
+}
+
+fn oklab_to_linear_srgb(lab: [f32; 3]) -> [f32; 3] {
+    let l = lab[0] + 0.396_337_78 * lab[1] + 0.215_803_76 * lab[2];
+    let m = lab[0] - 0.105_561_346 * lab[1] - 0.063_854_17 * lab[2];
+    let s = lab[0] - 0.089_484_18 * lab[1] - 1.291_485_5 * lab[2];
+    let l = l * l * l;
+    let m = m * m * m;
+    let s = s * s * s;
+    [
+        4.076_741_7 * l - 3.307_711_6 * m + 0.230_969_94 * s,
+        -1.268_438 * l + 2.609_757_4 * m - 0.341_319_38 * s,
+        -0.004_196_086_3 * l - 0.703_418_6 * m + 1.707_614_7 * s,
+    ]
+}
+
+fn cielch_ab_to_xyz_d65(lch: [f32; 3]) -> [f32; 3] {
+    let [a, b] = polar_components(lch[1], lch[2]);
+    let fy = (lch[0] + 16.0) / 116.0;
+    let fx = fy + a / 500.0;
+    let fz = fy - b / 200.0;
+    let xyz_d50 = [
+        0.964_22 * cie_lab_inverse(fx),
+        cie_lab_inverse(fy),
+        0.825_21 * cie_lab_inverse(fz),
+    ];
+
+    // Bradford-adapted D50 -> D65 matrix from CSS Color 4.
+    mul_matrix3(
+        [
+            [0.955_576_6, -0.023_039_3, 0.063_163_6],
+            [-0.028_289_5, 1.009_941_6, 0.021_007_7],
+            [0.012_298_2, -0.020_483, 1.329_909_8],
+        ],
+        xyz_d50,
+    )
+}
+
+fn cie_lab_inverse(value: f32) -> f32 {
+    const EPSILON: f32 = 216.0 / 24_389.0;
+    const KAPPA: f32 = 24_389.0 / 27.0;
+    let cube = value * value * value;
+    if cube > EPSILON {
+        cube
+    } else {
+        (116.0 * value - 16.0) / KAPPA
+    }
+}
+
+fn cielch_uv_to_xyz_d65(lch: [f32; 3]) -> [f32; 3] {
+    let lightness = lch[0].max(0.0);
+    if lightness <= 1.0e-7 {
+        return [0.0; 3];
+    }
+
+    const WHITE: [f32; 3] = [0.950_47, 1.0, 1.088_83];
+    const KAPPA: f32 = 24_389.0 / 27.0;
+    let white_denominator = WHITE[0] + 15.0 * WHITE[1] + 3.0 * WHITE[2];
+    let white_u_prime = 4.0 * WHITE[0] / white_denominator;
+    let white_v_prime = 9.0 * WHITE[1] / white_denominator;
+    let [u, v] = polar_components(lch[1], lch[2]);
+    let u_prime = u / (13.0 * lightness) + white_u_prime;
+    let v_prime = v / (13.0 * lightness) + white_v_prime;
+    let y = if lightness > 8.0 {
+        ((lightness + 16.0) / 116.0).powi(3)
+    } else {
+        lightness / KAPPA
+    };
+    let denominator = nonzero_with_sign(4.0 * v_prime);
+    [
+        y * 9.0 * u_prime / denominator,
+        y,
+        y * (12.0 - 3.0 * u_prime - 20.0 * v_prime) / denominator,
+    ]
+}
+
+fn jzczhz_to_xyz_d65(jch: [f32; 3]) -> [f32; 3] {
+    const B: f32 = 1.15;
+    const G: f32 = 0.66;
+    const D: f32 = -0.56;
+    const D0: f32 = 1.629_55e-11;
+    let [az, bz] = polar_components(jch[1], jch[2]);
+    let jz_plus_d0 = jch[0].max(0.0) + D0;
+    let iz = jz_plus_d0 / nonzero_with_sign(1.0 + D - D * jz_plus_d0);
+    let lms_prime = mul_matrix3(
+        [
+            [1.0, 0.138_605_04, 0.058_047_317],
+            [1.0, -0.138_605_04, -0.058_047_317],
+            [1.0, -0.096_019_24, -0.811_891_9],
+        ],
+        [iz, az, bz],
+    );
+    let lms = lms_prime.map(jz_pq_inverse);
+    let [x_prime, y_prime, z_prime] = mul_matrix3(
+        [
+            [1.924_226_4, -1.004_792_3, 0.037_651_405],
+            [0.350_316_76, 0.726_481_2, -0.065_384_425],
+            [-0.090_982_81, -0.312_728_3, 1.522_766_6],
+        ],
+        lms,
+    );
+    let x = (x_prime + (B - 1.0) * z_prime) / B;
+    let y = (y_prime + (G - 1.0) * x) / G;
+
+    // JzAzBz is defined for absolute XYZ. The UI normalization anchors
+    // 100% Jz to a 100 cd/m2 D65 white, so return relative XYZ here.
+    [x / 100.0, y / 100.0, z_prime / 100.0]
+}
+
+fn jz_pq_inverse(value: f32) -> f32 {
+    const C1: f32 = 3424.0 / 4096.0;
+    const C2: f32 = 2413.0 / 128.0;
+    const C3: f32 = 2392.0 / 128.0;
+    const N: f32 = 2610.0 / 16_384.0;
+    const P: f32 = 1.7 * 2523.0 / 32.0;
+    let powered = value.max(0.0).powf(1.0 / P);
+    let numerator = (powered - C1).max(0.0);
+    let denominator = (C2 - C3 * powered).max(1.0e-7);
+    10_000.0 * (numerator / denominator).powf(1.0 / N)
+}
+
+fn ipt_ich_to_xyz_d65(ich: [f32; 3]) -> [f32; 3] {
+    let [p, t] = polar_components(ich[1], ich[2]);
+    let lms_prime = mul_matrix3(
+        [
+            [1.0, 0.097_568_93, 0.205_226_44],
+            [1.0, -0.113_876_484, 0.133_217_16],
+            [1.0, 0.032_615_11, -0.676_887_16],
+        ],
+        [ich[0].max(0.0), p, t],
+    );
+    let lms = lms_prime.map(|value| signed_pow(value, 1.0 / 0.43));
+    mul_matrix3(
+        [
+            [1.850_243, -1.138_301_6, 0.238_434_96],
+            [0.366_830_77, 0.643_884_54, -0.010_673_444],
+            [0.0, 0.0, 1.088_850_1],
+        ],
+        lms,
+    )
+}
+
+fn polar_components(chroma: f32, hue: f32) -> [f32; 2] {
+    let angle = hue * TAU;
+    [chroma * angle.cos(), chroma * angle.sin()]
+}
+
+fn xyz_d65_to_srgb(xyz: [f32; 3]) -> [f32; 3] {
+    linear_to_srgb3(mul_matrix3(
+        [
+            [3.240_454_2, -1.537_138_5, -0.498_531_4],
+            [-0.969_266, 1.876_010_8, 0.041_556],
+            [0.055_643_4, -0.204_025_9, 1.057_225_2],
+        ],
+        xyz,
+    ))
+}
+
+fn mul_matrix3(matrix: [[f32; 3]; 3], vector: [f32; 3]) -> [f32; 3] {
+    matrix.map(|row| row[0].mul_add(vector[0], row[1].mul_add(vector[1], row[2] * vector[2])))
+}
+
+fn signed_pow(value: f32, exponent: f32) -> f32 {
+    value.signum() * value.abs().powf(exponent)
+}
+
+fn nonzero_with_sign(value: f32) -> f32 {
+    if value.abs() >= 1.0e-7 {
+        value
+    } else if value.is_sign_negative() {
+        -1.0e-7
+    } else {
+        1.0e-7
+    }
+}
+
+fn linear_to_srgb3(rgb: [f32; 3]) -> [f32; 3] {
+    rgb.map(linear_to_srgb)
+}
+
+fn linear_to_srgb(value: f32) -> f32 {
+    if value <= 0.003_130_8 {
+        12.92 * value
+    } else {
+        1.055 * value.powf(1.0 / 2.4) - 0.055
+    }
+}
+
+fn hsv_to_srgb(hsv: [f32; 3]) -> [f32; 3] {
+    let hue = hsv[0].rem_euclid(1.0) * 6.0;
+    let chroma = hsv[2] * hsv[1];
+    let x = chroma * (1.0 - (hue.rem_euclid(2.0) - 1.0).abs());
+    let rgb = match hue.floor() as i32 {
+        0 => [chroma, x, 0.0],
+        1 => [x, chroma, 0.0],
+        2 => [0.0, chroma, x],
+        3 => [0.0, x, chroma],
+        4 => [x, 0.0, chroma],
+        _ => [chroma, 0.0, x],
+    };
+    let m = hsv[2] - chroma;
+    [rgb[0] + m, rgb[1] + m, rgb[2] + m]
+}
+
+fn hsl_to_srgb(hsl: [f32; 3]) -> [f32; 3] {
+    let hue = hsl[0].rem_euclid(1.0) * 6.0;
+    let chroma = (1.0 - (2.0 * hsl[2] - 1.0).abs()) * hsl[1];
+    let x = chroma * (1.0 - (hue.rem_euclid(2.0) - 1.0).abs());
+    let rgb = match hue.floor() as i32 {
+        0 => [chroma, x, 0.0],
+        1 => [x, chroma, 0.0],
+        2 => [0.0, chroma, x],
+        3 => [0.0, x, chroma],
+        4 => [x, 0.0, chroma],
+        _ => [chroma, 0.0, x],
+    };
+    let m = hsl[2] - chroma * 0.5;
+    [rgb[0] + m, rgb[1] + m, rgb[2] + m]
+}
+
+fn finite_or(value: f32, fallback: f32) -> f32 {
+    if value.is_finite() { value } else { fallback }
+}
+
+fn lerp(a: f32, b: f32, t: f32) -> f32 {
+    a + (b - a) * t
+}
+
+fn lerp3(a: [f32; 3], b: [f32; 3], t: f32) -> [f32; 3] {
+    [
+        lerp(a[0], b[0], t),
+        lerp(a[1], b[1], t),
+        lerp(a[2], b[2], t),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn close(a: f32, b: f32) {
+        assert!((a - b).abs() < 2.0e-4, "{a} != {b}");
+    }
+
+    fn close_within(a: f32, b: f32, tolerance: f32) {
+        assert!((a - b).abs() < tolerance, "{a} != {b} (tol {tolerance})");
+    }
+
+    fn all_color_models() -> [ColorModel; 7] {
+        [
+            ColorModel::Oklch,
+            ColorModel::Hsv,
+            ColorModel::Hsl,
+            ColorModel::CielchAb,
+            ColorModel::CielchUv,
+            ColorModel::Jzczhz,
+            ColorModel::IptIch,
+        ]
+    }
+
+    fn geometry(shape: Shape) -> Geometry {
+        Geometry {
+            shape,
+            start: [0.0, 0.0],
+            end: [10.0, 0.0],
+            aspect: 1.0,
+            exponent: 2.0,
+            spiral_turns: 3.0,
+            ray_count: 4.0,
+        }
+    }
+
+    fn rainbow(color_model: ColorModel) -> Rainbow {
+        Rainbow {
+            start: [0.0, 1.0, 0.75],
+            end: [1.0, 1.0, 0.75],
+            color_model,
+            extend: ExtendMode::Clamp,
+            easing: Easing::Linear,
+            bezier: [0.25, 0.1, 0.25, 1.0],
+            clamp_gamut: true,
+        }
+    }
+
+    #[test]
+    fn linear_geometry_hits_both_anchors() {
+        let geometry = geometry(Shape::Linear);
+        close(geometry_value(geometry.start, geometry), 0.0);
+        close(geometry_value(geometry.end, geometry), 1.0);
+    }
+
+    #[test]
+    fn radial_diamond_and_box_hit_radius() {
+        for shape in [Shape::Radial, Shape::Diamond, Shape::Box] {
+            close(geometry_value([10.0, 0.0], geometry(shape)), 1.0);
+        }
+    }
+
+    #[test]
+    fn minkowski_connects_diamond_radial_and_box_metrics() {
+        close(lp_norm(0.5, 0.5, 1.0), 1.0);
+        close(lp_norm(0.5, 0.5, 2.0), 0.5_f32.sqrt());
+        close(lp_norm(0.5, 0.5, 64.0), 0.5 * 2.0_f32.powf(1.0 / 64.0));
+    }
+
+    #[test]
+    fn reflected_and_starburst_are_parametric() {
+        close(
+            geometry_value([-5.0, 9.0], geometry(Shape::ReflectedLinear)),
+            0.5,
+        );
+        close(
+            geometry_value([10.0, 10.0], geometry(Shape::Starburst)),
+            1.0,
+        );
+    }
+
+    #[test]
+    fn conic_uses_clockwise_full_turn() {
+        let geometry = geometry(Shape::Conic);
+        close(geometry_value([0.0, 1.0], geometry), 0.25);
+        close(geometry_value([-1.0, 0.0], geometry), 0.5);
+        close(geometry_value([0.0, -1.0], geometry), 0.75);
+    }
+
+    #[test]
+    fn symmetric_aspect_is_reciprocal_around_zero() {
+        close(aspect_ratio_from_balance(0.0), 1.0);
+        close(aspect_ratio_from_balance(-1.0), 0.1);
+        close(aspect_ratio_from_balance(1.0), 10.0);
+        close(
+            aspect_ratio_from_balance(-0.4) * aspect_ratio_from_balance(0.4),
+            1.0,
+        );
+        close(aspect_ratio_from_balance(f32::NAN), 1.0);
+    }
+
+    #[test]
+    fn extend_modes_handle_negative_values() {
+        close(extend_value(-0.25, ExtendMode::Repeat), 0.75);
+        close(extend_value(-0.25, ExtendMode::Mirror), 0.25);
+        close(extend_value(-0.25, ExtendMode::Clamp), 0.0);
+    }
+
+    #[test]
+    fn all_easing_curves_preserve_endpoints() {
+        for easing in [
+            Easing::Linear,
+            Easing::EaseIn,
+            Easing::EaseOut,
+            Easing::EaseInOut,
+            Easing::Smoothstep,
+            Easing::Smootherstep,
+            Easing::Custom,
+        ] {
+            close(ease_value(0.0, easing, [0.2, 0.8, 0.7, 0.1]), 0.0);
+            close(ease_value(1.0, easing, [0.2, 0.8, 0.7, 0.1]), 1.0);
+        }
+    }
+
+    #[test]
+    fn hsv_default_range_generates_a_full_rainbow() {
+        let rainbow = rainbow(ColorModel::Hsv);
+        let start = sample_rainbow(0.0, rainbow);
+        let middle = sample_rainbow(0.5, rainbow);
+        let end = sample_rainbow(1.0, rainbow);
+        close(start[0], 0.75);
+        close(start[1], 0.0);
+        close(start[2], 0.0);
+        close(middle[0], 0.0);
+        close(middle[1], 0.75);
+        close(middle[2], 0.75);
+        for index in 0..3 {
+            close(start[index], end[index]);
+        }
+    }
+
+    #[test]
+    fn all_color_models_generate_finite_colors() {
+        for model in all_color_models() {
+            for t in [0.0, 0.25, 0.5, 0.75, 1.0] {
+                let rgb = sample_rainbow(t, rainbow(model));
+                assert!(rgb.iter().all(|channel| channel.is_finite()));
+                assert!(rgb.iter().all(|channel| (0.0..=1.0).contains(channel)));
+            }
+        }
+    }
+
+    #[test]
+    fn default_perceptual_rainbows_do_not_collapse_after_gamut_clamping() {
+        for model in [
+            ColorModel::Oklch,
+            ColorModel::CielchAb,
+            ColorModel::CielchUv,
+            ColorModel::Jzczhz,
+            ColorModel::IptIch,
+        ] {
+            let samples: Vec<_> = (0..8)
+                .map(|index| sample_rainbow(index as f32 / 8.0, rainbow(model)))
+                .collect();
+            let mut distinct = 0;
+            for (index, sample) in samples.iter().enumerate() {
+                let repeats_previous = samples[..index].iter().any(|previous| {
+                    sample
+                        .iter()
+                        .zip(previous)
+                        .map(|(a, b)| (a - b) * (a - b))
+                        .sum::<f32>()
+                        < 0.01
+                });
+                if !repeats_previous {
+                    distinct += 1;
+                }
+            }
+            assert!(
+                distinct >= 6,
+                "{model:?} produced only {distinct} distinct hues"
+            );
+        }
+    }
+
+    #[test]
+    fn every_color_model_is_periodic_over_one_hue_turn() {
+        for model in all_color_models() {
+            let start = components_to_rgb([0.137, 0.8, 0.65], model, true);
+            let end = components_to_rgb([1.137, 0.8, 0.65], model, true);
+            for index in 0..3 {
+                close(start[index], end[index]);
+            }
+        }
+    }
+
+    #[test]
+    fn d65_xyz_matrix_reconstructs_the_srgb_red_primary() {
+        let red = xyz_d65_to_srgb([0.412_456_4, 0.212_672_9, 0.019_333_9]);
+        close_within(red[0], 1.0, 3.0e-5);
+        close_within(red[1], 0.0, 3.0e-5);
+        close_within(red[2], 0.0, 3.0e-5);
+    }
+
+    #[test]
+    fn cielch_ab_matches_a_known_lab_conversion() {
+        // CIELAB D50 [50, 40, 30], expressed cylindrically.
+        let rgb = xyz_d65_to_srgb(cielch_ab_to_xyz_d65([50.0, 50.0, 0.102_416_38]));
+        for (actual, expected) in rgb.into_iter().zip([0.734_241, 0.344_121, 0.276_336]) {
+            close_within(actual, expected, 5.0e-4);
+        }
+    }
+
+    #[test]
+    fn cielch_uv_reconstructs_the_srgb_red_primary() {
+        let rgb = xyz_d65_to_srgb(cielch_uv_to_xyz_d65([
+            53.240_795,
+            179.041_37,
+            0.033_816_636,
+        ]));
+        for (actual, expected) in rgb.into_iter().zip([1.0, 0.0, 0.0]) {
+            close_within(actual, expected, 5.0e-4);
+        }
+    }
+
+    #[test]
+    fn jzczhz_reconstructs_a_100_nit_srgb_red_primary() {
+        let rgb = xyz_d65_to_srgb(jzczhz_to_xyz_d65([
+            0.098_974_02,
+            0.135_110_24,
+            42.477_23 / 360.0,
+        ]));
+        for (actual, expected) in rgb.into_iter().zip([1.0, 0.0, 0.0]) {
+            close_within(actual, expected, 4.0e-3);
+        }
+    }
+
+    #[test]
+    fn ipt_ich_reconstructs_the_srgb_red_primary() {
+        let rgb = xyz_d65_to_srgb(ipt_ich_to_xyz_d65([
+            0.456_192_67,
+            0.762_700_7,
+            35.494_137 / 360.0,
+        ]));
+        for (actual, expected) in rgb.into_iter().zip([1.0, 0.0, 0.0]) {
+            close_within(actual, expected, 8.0e-4);
+        }
+    }
+
+    #[test]
+    fn neutral_100_percent_axes_are_d65_white() {
+        for model in [
+            ColorModel::CielchAb,
+            ColorModel::CielchUv,
+            ColorModel::Jzczhz,
+            ColorModel::IptIch,
+        ] {
+            let rgb = components_to_rgb([0.42, 0.0, 1.0], model, true);
+            for channel in rgb {
+                close_within(channel, 1.0, 2.0e-3);
+            }
+        }
+    }
+
+    #[test]
+    fn unwrapped_hue_supports_multiple_cycles() {
+        let mut rainbow = rainbow(ColorModel::Hsv);
+        rainbow.end[0] = 3.0;
+        let at_one_third = sample_rainbow(1.0 / 3.0, rainbow);
+        let start = sample_rainbow(0.0, rainbow);
+        for index in 0..3 {
+            close(start[index], at_one_third[index]);
+        }
+    }
+}

--- a/plugins/rainbow-generate/src/gradient.rs
+++ b/plugins/rainbow-generate/src/gradient.rs
@@ -1,11 +1,24 @@
 use std::f32::consts::TAU;
 
+use palette::{
+    Okhsl, Okhsv, Srgb, Xyz,
+    cam16::{BakedParameters, Cam16Jmh, Cam16UcsJab, Cam16UcsJmh, Parameters, StaticWp},
+    convert::{FromColorUnclamped, IntoColorUnclamped},
+    white_point::D65,
+};
+
 const OKLCH_CHROMA_AT_100_PERCENT: f32 = 0.2;
 const CIELAB_CHROMA_AT_100_PERCENT: f32 = 80.0;
 const CIELUV_CHROMA_AT_100_PERCENT: f32 = 100.0;
 const JZ_CHROMA_AT_100_PERCENT: f32 = 0.08;
 const JZ_AT_100_PERCENT: f32 = 0.167_174;
 const IPT_CHROMA_AT_100_PERCENT: f32 = 0.3;
+const CAM16_UCS_COLORFULNESS_AT_100_PERCENT: f32 = 50.0;
+// CAM16's incomplete chromatic adaptation can assign a small residual M' to
+// display neutrals. Treat values below 2 as achromatic for hue interpolation.
+const CAM16_NEUTRAL_COLORFULNESS: f32 = 2.0;
+
+pub(crate) type Cam16ViewingConditions = BakedParameters<StaticWp<D65>, f32>;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum Shape {
@@ -29,6 +42,17 @@ pub(crate) enum ColorModel {
     CielchUv,
     Jzczhz,
     IptIch,
+    Okhsl,
+    Okhsv,
+    Cam16UcsJmh,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum TwoColorSpace {
+    Oklab,
+    Oklch,
+    Cam16UcsJab,
+    Cam16UcsJmh,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -55,22 +79,50 @@ pub(crate) struct Geometry {
     pub start: [f32; 2],
     pub end: [f32; 2],
     pub aspect: f32,
+    /// Horizontal inverse shear, expressed as rise/run (`100% == 1.0`).
+    pub skew: f32,
     pub exponent: f32,
     pub spiral_turns: f32,
     pub ray_count: f32,
 }
 
-/// Parametric rainbow endpoints in cylindrical component order:
-/// `[unwrapped hue turns, saturation/chroma amount, value/lightness]`.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy)]
+pub(crate) struct PreparedTwoColor {
+    start: [f32; 3],
+    end: [f32; 3],
+    start_rgb: [f32; 3],
+    end_rgb: [f32; 3],
+    color_space: TwoColorSpace,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum GradientColors {
+    /// Cylindrical component order: `[unwrapped hue turns,
+    /// saturation/chroma amount, value/lightness]`.
+    Parametric {
+        start: [f32; 3],
+        end: [f32; 3],
+        color_model: ColorModel,
+    },
+    TwoColor(PreparedTwoColor),
+}
+
+#[derive(Clone, Copy)]
 pub(crate) struct Rainbow {
-    pub start: [f32; 3],
-    pub end: [f32; 3],
-    pub color_model: ColorModel,
+    pub colors: GradientColors,
     pub extend: ExtendMode,
     pub easing: Easing,
     pub bezier: [f32; 4],
     pub clamp_gamut: bool,
+    pub cam16_parameters: Cam16ViewingConditions,
+}
+
+/// Fixed viewing conditions for display-referred CAM16-UCS rendering: D65,
+/// 40 cd/m² adapting luminance, a 20% background, average surround, and
+/// automatic illuminant discounting. Baking once per render avoids rebuilding
+/// the CAM16 dependent parameters for each pixel.
+pub(crate) fn cam16_viewing_conditions() -> Cam16ViewingConditions {
+    Parameters::default_static_wp(40.0f32).bake()
 }
 
 pub(crate) fn geometry_value(point: [f32; 2], geometry: Geometry) -> f32 {
@@ -81,28 +133,32 @@ pub(crate) fn geometry_value(point: [f32; 2], geometry: Geometry) -> f32 {
         return 0.0;
     }
 
-    if geometry.shape == Shape::Linear {
-        return ((point[0] - geometry.start[0]) * dx + (point[1] - geometry.start[1]) * dy)
-            / length_sq;
-    }
-
     let length = length_sq.sqrt();
     let ux = dx / length;
     let uy = dy / length;
     let px = point[0] - geometry.start[0];
     let py = point[1] - geometry.start[1];
     let local_x = px * ux + py * uy;
+    let local_y = -px * uy + py * ux;
+    let skew = if geometry.skew.is_finite() {
+        geometry.skew.clamp(-10.0, 10.0)
+    } else {
+        0.0
+    };
+    // Coordinates are transformed back into the unskewed gradient domain. This
+    // is the inverse of the forward local-space shear x' = x + skew * y.
+    let local_x = local_x - skew * local_y;
     let aspect = if geometry.aspect.is_finite() {
         geometry.aspect.clamp(1.0e-4, 1.0e4)
     } else {
         1.0
     };
-    let local_y = (-px * uy + py * ux) * aspect;
+    let local_y = local_y * aspect;
     let normalized_x = local_x / length;
     let normalized_y = local_y / length;
 
     match geometry.shape {
-        Shape::Linear => unreachable!(),
+        Shape::Linear => normalized_x,
         Shape::Radial => normalized_x.hypot(normalized_y),
         Shape::Diamond => normalized_x.abs() + normalized_y.abs(),
         Shape::Box => normalized_x.abs().max(normalized_y.abs()),
@@ -155,14 +211,132 @@ pub(crate) fn aspect_ratio_from_balance(balance: f32) -> f32 {
     10.0_f32.powf(balance)
 }
 
-pub(crate) fn sample_rainbow(raw_t: f32, rainbow: Rainbow) -> [f32; 3] {
+pub(crate) fn sample_rainbow(raw_t: f32, rainbow: &Rainbow) -> [f32; 3] {
     let extended = extend_value(raw_t, rainbow.extend);
     let t = ease_value(extended, rainbow.easing, rainbow.bezier);
-    let components = lerp3(rainbow.start, rainbow.end, t);
-    components_to_rgb(components, rainbow.color_model, rainbow.clamp_gamut)
+    match rainbow.colors {
+        GradientColors::Parametric {
+            start,
+            end,
+            color_model,
+        } => components_to_rgb(
+            lerp3(start, end, t),
+            color_model,
+            rainbow.cam16_parameters,
+            rainbow.clamp_gamut,
+        ),
+        GradientColors::TwoColor(prepared) => interpolate_prepared_two_color(
+            prepared,
+            t,
+            rainbow.cam16_parameters,
+            rainbow.clamp_gamut,
+        ),
+    }
 }
 
-fn components_to_rgb(components: [f32; 3], color_model: ColorModel, clamp_gamut: bool) -> [f32; 3] {
+pub(crate) fn prepare_two_color(
+    start_rgb: [f32; 3],
+    end_rgb: [f32; 3],
+    color_space: TwoColorSpace,
+    cam16_parameters: Cam16ViewingConditions,
+) -> GradientColors {
+    let (start, end) = match color_space {
+        TwoColorSpace::Oklab | TwoColorSpace::Oklch => {
+            let start_oklab = linear_srgb_to_oklab(start_rgb.map(srgb_to_linear));
+            let end_oklab = linear_srgb_to_oklab(end_rgb.map(srgb_to_linear));
+            if color_space == TwoColorSpace::Oklab {
+                (start_oklab, end_oklab)
+            } else {
+                prepare_polar_endpoints(
+                    oklab_to_oklch(start_oklab),
+                    oklab_to_oklch(end_oklab),
+                    1.0e-7,
+                    1.0,
+                )
+            }
+        }
+        TwoColorSpace::Cam16UcsJab => (
+            srgb_to_cam16_ucs_jab(start_rgb, cam16_parameters),
+            srgb_to_cam16_ucs_jab(end_rgb, cam16_parameters),
+        ),
+        TwoColorSpace::Cam16UcsJmh => prepare_polar_endpoints(
+            srgb_to_cam16_ucs_jmh(start_rgb, cam16_parameters),
+            srgb_to_cam16_ucs_jmh(end_rgb, cam16_parameters),
+            CAM16_NEUTRAL_COLORFULNESS,
+            360.0,
+        ),
+    };
+    GradientColors::TwoColor(PreparedTwoColor {
+        start,
+        end,
+        start_rgb,
+        end_rgb,
+        color_space,
+    })
+}
+
+fn prepare_polar_endpoints(
+    mut start: [f32; 3],
+    mut end: [f32; 3],
+    neutral_threshold: f32,
+    hue_period: f32,
+) -> ([f32; 3], [f32; 3]) {
+    // The component order is [lightness, chroma/colorfulness, hue]. Hue is
+    // undefined on the neutral axis, so borrow it from the chromatic endpoint.
+    if start[1] <= neutral_threshold {
+        start[2] = end[2];
+    }
+    if end[1] <= neutral_threshold {
+        end[2] = start[2];
+    }
+    end[2] = start[2] + shortest_hue_delta(start[2], end[2], hue_period);
+    (start, end)
+}
+
+fn interpolate_prepared_two_color(
+    prepared: PreparedTwoColor,
+    t: f32,
+    cam16_parameters: Cam16ViewingConditions,
+    clamp_gamut: bool,
+) -> [f32; 3] {
+    let PreparedTwoColor {
+        start,
+        end,
+        start_rgb,
+        end_rgb,
+        color_space,
+    } = prepared;
+    if t <= 0.0 {
+        let mut rgb = start_rgb;
+        sanitize_rgb(&mut rgb, clamp_gamut);
+        return rgb;
+    }
+    if t >= 1.0 {
+        let mut rgb = end_rgb;
+        sanitize_rgb(&mut rgb, clamp_gamut);
+        return rgb;
+    }
+    let components = lerp3(start, end, t);
+    let mut rgb = match color_space {
+        TwoColorSpace::Oklab => linear_to_srgb3(oklab_to_linear_srgb(components)),
+        TwoColorSpace::Oklch => linear_to_srgb3(oklab_to_linear_srgb(oklch_to_oklab(components))),
+        TwoColorSpace::Cam16UcsJab => cam16_ucs_jab_to_srgb(components, cam16_parameters),
+        TwoColorSpace::Cam16UcsJmh => cam16_ucs_jmh_to_srgb(components, cam16_parameters),
+    };
+    sanitize_rgb(&mut rgb, clamp_gamut);
+    rgb
+}
+
+fn shortest_hue_delta(start: f32, end: f32, period: f32) -> f32 {
+    (end - start + period * 0.5).rem_euclid(period) - period * 0.5
+}
+
+fn components_to_rgb(
+    components: [f32; 3],
+    color_model: ColorModel,
+    cam16_parameters: Cam16ViewingConditions,
+    clamp_gamut: bool,
+) -> [f32; 3] {
     let hue = finite_or(components[0], 0.0).rem_euclid(1.0);
     let second = finite_or(components[1], 0.0).max(0.0);
     let third = finite_or(components[2], 0.0).max(0.0);
@@ -193,14 +367,26 @@ fn components_to_rgb(components: [f32; 3], color_model: ColorModel, clamp_gamut:
             second * IPT_CHROMA_AT_100_PERCENT,
             hue,
         ])),
+        ColorModel::Okhsl => palette_srgb_to_array(Srgb::from_color_unclamped(Okhsl::new(
+            hue * 360.0,
+            second,
+            third,
+        ))),
+        ColorModel::Okhsv => palette_srgb_to_array(Srgb::from_color_unclamped(Okhsv::new(
+            hue * 360.0,
+            second,
+            third,
+        ))),
+        ColorModel::Cam16UcsJmh => cam16_ucs_jmh_to_srgb(
+            [
+                third * 100.0,
+                second * CAM16_UCS_COLORFULNESS_AT_100_PERCENT,
+                hue * 360.0,
+            ],
+            cam16_parameters,
+        ),
     };
-    for channel in &mut rgb {
-        if !channel.is_finite() {
-            *channel = 0.0;
-        } else if clamp_gamut {
-            *channel = channel.clamp(0.0, 1.0);
-        }
-    }
+    sanitize_rgb(&mut rgb, clamp_gamut);
     rgb
 }
 
@@ -280,6 +466,71 @@ fn cubic_bezier_derivative(t: f32, p1: f32, p2: f32) -> f32 {
 fn oklch_to_oklab(lch: [f32; 3]) -> [f32; 3] {
     let angle = lch[2] * TAU;
     [lch[0], lch[1] * angle.cos(), lch[1] * angle.sin()]
+}
+
+fn oklab_to_oklch(lab: [f32; 3]) -> [f32; 3] {
+    [
+        lab[0],
+        lab[1].hypot(lab[2]),
+        lab[2].atan2(lab[1]).rem_euclid(TAU) / TAU,
+    ]
+}
+
+fn linear_srgb_to_oklab(rgb: [f32; 3]) -> [f32; 3] {
+    let l = 0.412_221_46 * rgb[0] + 0.536_332_55 * rgb[1] + 0.051_445_995 * rgb[2];
+    let m = 0.211_903_5 * rgb[0] + 0.680_699_5 * rgb[1] + 0.107_396_96 * rgb[2];
+    let s = 0.088_302_46 * rgb[0] + 0.281_718_85 * rgb[1] + 0.629_978_7 * rgb[2];
+    let l = l.cbrt();
+    let m = m.cbrt();
+    let s = s.cbrt();
+    [
+        0.210_454_26 * l + 0.793_617_8 * m - 0.004_072_047 * s,
+        1.977_998_5 * l - 2.428_592_2 * m + 0.450_593_7 * s,
+        0.025_904_037 * l + 0.782_771_77 * m - 0.808_675_77 * s,
+    ]
+}
+
+fn srgb_to_cam16_ucs_jmh(rgb: [f32; 3], parameters: Cam16ViewingConditions) -> [f32; 3] {
+    let xyz: Xyz<D65, f32> = Srgb::from(rgb).into_color_unclamped();
+    let ucs = Cam16UcsJmh::from_color_unclamped(Cam16Jmh::from_xyz(xyz, parameters));
+    [
+        ucs.lightness,
+        ucs.colorfulness,
+        ucs.hue.into_positive_degrees(),
+    ]
+}
+
+fn srgb_to_cam16_ucs_jab(rgb: [f32; 3], parameters: Cam16ViewingConditions) -> [f32; 3] {
+    let xyz: Xyz<D65, f32> = Srgb::from(rgb).into_color_unclamped();
+    let ucs = Cam16UcsJab::from_color_unclamped(Cam16Jmh::from_xyz(xyz, parameters));
+    [ucs.lightness, ucs.a, ucs.b]
+}
+
+fn cam16_ucs_jmh_to_srgb(components: [f32; 3], parameters: Cam16ViewingConditions) -> [f32; 3] {
+    let ucs = Cam16UcsJmh::new(components[0], components[1], components[2]);
+    let cam16 = Cam16Jmh::from_color_unclamped(ucs);
+    palette_srgb_to_array(Srgb::from_color_unclamped(cam16.into_xyz(parameters)))
+}
+
+fn cam16_ucs_jab_to_srgb(components: [f32; 3], parameters: Cam16ViewingConditions) -> [f32; 3] {
+    let ucs = Cam16UcsJab::new(components[0], components[1], components[2]);
+    let cam16 = Cam16Jmh::from_color_unclamped(ucs);
+    palette_srgb_to_array(Srgb::from_color_unclamped(cam16.into_xyz(parameters)))
+}
+
+fn palette_srgb_to_array(rgb: Srgb<f32>) -> [f32; 3] {
+    let (red, green, blue) = rgb.into_components();
+    [red, green, blue]
+}
+
+fn sanitize_rgb(rgb: &mut [f32; 3], clamp_gamut: bool) {
+    for channel in rgb {
+        if !channel.is_finite() {
+            *channel = 0.0;
+        } else if clamp_gamut {
+            *channel = channel.clamp(0.0, 1.0);
+        }
+    }
 }
 
 fn oklab_to_linear_srgb(lab: [f32; 3]) -> [f32; 3] {
@@ -468,6 +719,14 @@ fn linear_to_srgb(value: f32) -> f32 {
     }
 }
 
+fn srgb_to_linear(value: f32) -> f32 {
+    if value <= 0.040_45 {
+        value / 12.92
+    } else {
+        ((value + 0.055) / 1.055).powf(2.4)
+    }
+}
+
 fn hsv_to_srgb(hsv: [f32; 3]) -> [f32; 3] {
     let hue = hsv[0].rem_euclid(1.0) * 6.0;
     let chroma = hsv[2] * hsv[1];
@@ -528,7 +787,7 @@ mod tests {
         assert!((a - b).abs() < tolerance, "{a} != {b} (tol {tolerance})");
     }
 
-    fn all_color_models() -> [ColorModel; 7] {
+    fn legacy_color_models() -> [ColorModel; 7] {
         [
             ColorModel::Oklch,
             ColorModel::Hsv,
@@ -540,12 +799,28 @@ mod tests {
         ]
     }
 
+    fn all_color_models() -> [ColorModel; 10] {
+        [
+            ColorModel::Oklch,
+            ColorModel::Hsv,
+            ColorModel::Hsl,
+            ColorModel::CielchAb,
+            ColorModel::CielchUv,
+            ColorModel::Jzczhz,
+            ColorModel::IptIch,
+            ColorModel::Okhsl,
+            ColorModel::Okhsv,
+            ColorModel::Cam16UcsJmh,
+        ]
+    }
+
     fn geometry(shape: Shape) -> Geometry {
         Geometry {
             shape,
             start: [0.0, 0.0],
             end: [10.0, 0.0],
             aspect: 1.0,
+            skew: 0.0,
             exponent: 2.0,
             spiral_turns: 3.0,
             ray_count: 4.0,
@@ -554,13 +829,28 @@ mod tests {
 
     fn rainbow(color_model: ColorModel) -> Rainbow {
         Rainbow {
-            start: [0.0, 1.0, 0.75],
-            end: [1.0, 1.0, 0.75],
-            color_model,
+            colors: GradientColors::Parametric {
+                start: [0.0, 1.0, 0.75],
+                end: [1.0, 1.0, 0.75],
+                color_model,
+            },
             extend: ExtendMode::Clamp,
             easing: Easing::Linear,
             bezier: [0.25, 0.1, 0.25, 1.0],
             clamp_gamut: true,
+            cam16_parameters: cam16_viewing_conditions(),
+        }
+    }
+
+    fn two_color_rainbow(start: [f32; 3], end: [f32; 3], color_space: TwoColorSpace) -> Rainbow {
+        let cam16_parameters = cam16_viewing_conditions();
+        Rainbow {
+            colors: prepare_two_color(start, end, color_space, cam16_parameters),
+            extend: ExtendMode::Clamp,
+            easing: Easing::Linear,
+            bezier: [0.25, 0.1, 0.25, 1.0],
+            clamp_gamut: true,
+            cam16_parameters,
         }
     }
 
@@ -569,6 +859,28 @@ mod tests {
         let geometry = geometry(Shape::Linear);
         close(geometry_value(geometry.start, geometry), 0.0);
         close(geometry_value(geometry.end, geometry), 1.0);
+    }
+
+    #[test]
+    fn skew_is_an_inverse_horizontal_shear_for_every_shape() {
+        for shape in [
+            Shape::Linear,
+            Shape::Radial,
+            Shape::Diamond,
+            Shape::Conic,
+            Shape::Box,
+            Shape::Minkowski,
+            Shape::ReflectedLinear,
+            Shape::Spiral,
+            Shape::Starburst,
+        ] {
+            let mut skewed = geometry(shape);
+            skewed.skew = 0.5;
+            let reference = geometry_value([5.0, 4.0], geometry(shape));
+            // Forward-shear the reference coordinate: x' = x + 0.5y.
+            let transformed = geometry_value([7.0, 4.0], skewed);
+            close(reference, transformed);
+        }
     }
 
     #[test]
@@ -643,9 +955,9 @@ mod tests {
     #[test]
     fn hsv_default_range_generates_a_full_rainbow() {
         let rainbow = rainbow(ColorModel::Hsv);
-        let start = sample_rainbow(0.0, rainbow);
-        let middle = sample_rainbow(0.5, rainbow);
-        let end = sample_rainbow(1.0, rainbow);
+        let start = sample_rainbow(0.0, &rainbow);
+        let middle = sample_rainbow(0.5, &rainbow);
+        let end = sample_rainbow(1.0, &rainbow);
         close(start[0], 0.75);
         close(start[1], 0.0);
         close(start[2], 0.0);
@@ -661,7 +973,7 @@ mod tests {
     fn all_color_models_generate_finite_colors() {
         for model in all_color_models() {
             for t in [0.0, 0.25, 0.5, 0.75, 1.0] {
-                let rgb = sample_rainbow(t, rainbow(model));
+                let rgb = sample_rainbow(t, &rainbow(model));
                 assert!(rgb.iter().all(|channel| channel.is_finite()));
                 assert!(rgb.iter().all(|channel| (0.0..=1.0).contains(channel)));
             }
@@ -676,9 +988,10 @@ mod tests {
             ColorModel::CielchUv,
             ColorModel::Jzczhz,
             ColorModel::IptIch,
+            ColorModel::Cam16UcsJmh,
         ] {
             let samples: Vec<_> = (0..8)
-                .map(|index| sample_rainbow(index as f32 / 8.0, rainbow(model)))
+                .map(|index| sample_rainbow(index as f32 / 8.0, &rainbow(model)))
                 .collect();
             let mut distinct = 0;
             for (index, sample) in samples.iter().enumerate() {
@@ -704,11 +1017,40 @@ mod tests {
     #[test]
     fn every_color_model_is_periodic_over_one_hue_turn() {
         for model in all_color_models() {
-            let start = components_to_rgb([0.137, 0.8, 0.65], model, true);
-            let end = components_to_rgb([1.137, 0.8, 0.65], model, true);
+            let parameters = cam16_viewing_conditions();
+            let start = components_to_rgb([0.137, 0.8, 0.65], model, parameters, true);
+            let end = components_to_rgb([1.137, 0.8, 0.65], model, parameters, true);
             for index in 0..3 {
                 close(start[index], end[index]);
             }
+        }
+    }
+
+    #[test]
+    fn legacy_color_models_retain_their_finite_periodic_mapping() {
+        for model in legacy_color_models() {
+            let parameters = cam16_viewing_conditions();
+            let start = components_to_rgb([0.271, 0.63, 0.71], model, parameters, true);
+            let end = components_to_rgb([1.271, 0.63, 0.71], model, parameters, true);
+            assert!(start.into_iter().all(f32::is_finite));
+            for (start, end) in start.into_iter().zip(end) {
+                close(start, end);
+            }
+        }
+    }
+
+    #[test]
+    fn ok_picker_spaces_keep_their_documented_black_and_white_endpoints() {
+        let parameters = cam16_viewing_conditions();
+        for model in [ColorModel::Okhsl, ColorModel::Okhsv] {
+            let black = components_to_rgb([0.33, 1.0, 0.0], model, parameters, true);
+            for channel in black {
+                close_within(channel, 0.0, 1.0e-6);
+            }
+        }
+        let white = components_to_rgb([0.71, 1.0, 1.0], ColorModel::Okhsl, parameters, true);
+        for channel in white {
+            close_within(channel, 1.0, 2.0e-5);
         }
     }
 
@@ -772,10 +1114,16 @@ mod tests {
             ColorModel::CielchUv,
             ColorModel::Jzczhz,
             ColorModel::IptIch,
+            ColorModel::Cam16UcsJmh,
         ] {
-            let rgb = components_to_rgb([0.42, 0.0, 1.0], model, true);
+            let rgb = components_to_rgb([0.42, 0.0, 1.0], model, cam16_viewing_conditions(), true);
+            let tolerance = if model == ColorModel::Cam16UcsJmh {
+                1.0e-2
+            } else {
+                2.0e-3
+            };
             for channel in rgb {
-                close_within(channel, 1.0, 2.0e-3);
+                close_within(channel, 1.0, tolerance);
             }
         }
     }
@@ -783,11 +1131,114 @@ mod tests {
     #[test]
     fn unwrapped_hue_supports_multiple_cycles() {
         let mut rainbow = rainbow(ColorModel::Hsv);
-        rainbow.end[0] = 3.0;
-        let at_one_third = sample_rainbow(1.0 / 3.0, rainbow);
-        let start = sample_rainbow(0.0, rainbow);
+        let GradientColors::Parametric { ref mut end, .. } = rainbow.colors else {
+            unreachable!();
+        };
+        end[0] = 3.0;
+        let at_one_third = sample_rainbow(1.0 / 3.0, &rainbow);
+        let start = sample_rainbow(0.0, &rainbow);
         for index in 0..3 {
             close(start[index], at_one_third[index]);
         }
+    }
+
+    #[test]
+    fn two_color_oklab_preserves_endpoints() {
+        let rainbow = two_color_rainbow([1.0, 0.1, 0.0], [0.0, 0.2, 1.0], TwoColorSpace::Oklab);
+        for (actual, expected) in sample_rainbow(0.0, &rainbow)
+            .into_iter()
+            .zip([1.0, 0.1, 0.0])
+        {
+            close_within(actual, expected, 3.0e-5);
+        }
+        for (actual, expected) in sample_rainbow(1.0, &rainbow)
+            .into_iter()
+            .zip([0.0, 0.2, 1.0])
+        {
+            close_within(actual, expected, 3.0e-5);
+        }
+    }
+
+    #[test]
+    fn two_color_oklch_uses_shortest_hue_path() {
+        let start = linear_to_srgb3(oklab_to_linear_srgb(oklch_to_oklab([
+            0.7,
+            0.1,
+            350.0 / 360.0,
+        ])));
+        let end = linear_to_srgb3(oklab_to_linear_srgb(oklch_to_oklab([
+            0.7,
+            0.1,
+            10.0 / 360.0,
+        ])));
+        let parameters = cam16_viewing_conditions();
+        let GradientColors::TwoColor(prepared) =
+            prepare_two_color(start, end, TwoColorSpace::Oklch, parameters)
+        else {
+            unreachable!()
+        };
+        let middle = interpolate_prepared_two_color(prepared, 0.5, parameters, false);
+        let middle_lch = oklab_to_oklch(linear_srgb_to_oklab(middle.map(srgb_to_linear)));
+        assert!(
+            middle_lch[2] < 0.01 || middle_lch[2] > 0.99,
+            "{:?}",
+            middle_lch
+        );
+    }
+
+    #[test]
+    fn every_two_color_space_preserves_endpoints_and_remains_finite() {
+        let start = [0.82, 0.24, 0.11];
+        let end = [0.08, 0.31, 0.88];
+        for color_space in [
+            TwoColorSpace::Oklab,
+            TwoColorSpace::Oklch,
+            TwoColorSpace::Cam16UcsJab,
+            TwoColorSpace::Cam16UcsJmh,
+        ] {
+            let rainbow = two_color_rainbow(start, end, color_space);
+            for (actual, expected) in sample_rainbow(0.0, &rainbow).into_iter().zip(start) {
+                close_within(actual, expected, 8.0e-4);
+            }
+            for (actual, expected) in sample_rainbow(1.0, &rainbow).into_iter().zip(end) {
+                close_within(actual, expected, 8.0e-4);
+            }
+            for step in 0..=8 {
+                assert!(
+                    sample_rainbow(step as f32 / 8.0, &rainbow)
+                        .into_iter()
+                        .all(f32::is_finite),
+                    "{color_space:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn cam16_ucs_jmh_uses_shortest_hue_and_borrows_neutral_hue() {
+        let parameters = cam16_viewing_conditions();
+        let start_rgb = cam16_ucs_jmh_to_srgb([60.0, 18.0, 350.0], parameters);
+        let end_rgb = cam16_ucs_jmh_to_srgb([60.0, 18.0, 10.0], parameters);
+        let GradientColors::TwoColor(PreparedTwoColor { start, end, .. }) =
+            prepare_two_color(start_rgb, end_rgb, TwoColorSpace::Cam16UcsJmh, parameters)
+        else {
+            unreachable!()
+        };
+        assert!((end[2] - start[2]).abs() < 30.0, "{start:?} -> {end:?}");
+
+        let GradientColors::TwoColor(PreparedTwoColor {
+            start: neutral,
+            end: chromatic,
+            ..
+        }) = prepare_two_color(
+            [0.5, 0.5, 0.5],
+            [0.8, 0.1, 0.05],
+            TwoColorSpace::Cam16UcsJmh,
+            parameters,
+        )
+        else {
+            unreachable!()
+        };
+        close_within(neutral[2], chromatic[2], 1.0e-4);
     }
 }

--- a/plugins/rainbow-generate/src/lib.rs
+++ b/plugins/rainbow-generate/src/lib.rs
@@ -8,8 +8,9 @@ use std::env;
 
 use ae::pf::*;
 use gradient::{
-    ColorModel, Easing, ExtendMode, Geometry, Rainbow, Shape, aspect_ratio_from_balance,
-    geometry_value, sample_rainbow,
+    ColorModel, Easing, ExtendMode, Geometry, GradientColors, Rainbow, Shape, TwoColorSpace,
+    aspect_ratio_from_balance, cam16_viewing_conditions, geometry_value, prepare_two_color,
+    sample_rainbow,
 };
 use params::Params;
 use utils::ToPixel;
@@ -40,6 +41,7 @@ const ENDPOINT_COLOR_PARAMS: [Params; 6] = [
     Params::EndComponent2,
     Params::EndComponent3,
 ];
+const TWO_COLOR_PARAMS: [Params; 3] = [Params::TwoColorSpace, Params::StartColor, Params::EndColor];
 
 impl AdobePluginGlobal for Plugin {
     fn params_setup(
@@ -126,6 +128,7 @@ impl AdobePluginGlobal for Plugin {
                         | Params::ColorModel
                         | Params::Easing
                         | Params::SplitRangeEnds
+                        | Params::GenerationMode
                 ) =>
             {
                 out_data.set_out_flag(OutFlags::RefreshUi, true);
@@ -150,6 +153,7 @@ impl Plugin {
         let two_points = params.get(Params::CoordinateMode)?.as_popup()?.value() == 1;
         let color_model =
             color_model_from_popup(params.get(Params::ColorModel)?.as_popup()?.value());
+        let parametric_generation = params.get(Params::GenerationMode)?.as_popup()?.value() != 2;
         let custom_easing = params.get(Params::Easing)?.as_popup()?.value() == 7;
         let split_range_ends = params.get(Params::SplitRangeEnds)?.as_checkbox()?.value();
         Self::set_component_names(params, color_model)?;
@@ -207,13 +211,23 @@ impl Plugin {
             self.set_param_visible(in_data, params, id, visible)?;
             Self::set_param_enabled(params, id, visible)?;
         }
+        for id in [Params::ColorModel, Params::SplitRangeEnds] {
+            self.set_param_visible(in_data, params, id, parametric_generation)?;
+            Self::set_param_enabled(params, id, parametric_generation)?;
+        }
         for id in AFFINE_COLOR_PARAMS {
-            self.set_param_visible(in_data, params, id, !split_range_ends)?;
-            Self::set_param_enabled(params, id, !split_range_ends)?;
+            let visible = parametric_generation && !split_range_ends;
+            self.set_param_visible(in_data, params, id, visible)?;
+            Self::set_param_enabled(params, id, visible)?;
         }
         for id in ENDPOINT_COLOR_PARAMS {
-            self.set_param_visible(in_data, params, id, split_range_ends)?;
-            Self::set_param_enabled(params, id, split_range_ends)?;
+            let visible = parametric_generation && split_range_ends;
+            self.set_param_visible(in_data, params, id, visible)?;
+            Self::set_param_enabled(params, id, visible)?;
+        }
+        for id in TWO_COLOR_PARAMS {
+            self.set_param_visible(in_data, params, id, !parametric_generation)?;
+            Self::set_param_enabled(params, id, !parametric_generation)?;
         }
 
         for id in [
@@ -359,7 +373,7 @@ impl Plugin {
                 (x as f32 + origin_x + 0.5) / downsample[0],
                 (y as f32 + origin_y + 0.5) / downsample[1],
             ];
-            let rainbow_rgb = sample_rainbow(geometry_value(point, geometry), rainbow);
+            let rainbow_rgb = sample_rainbow(geometry_value(point, geometry), &rainbow);
             let input = read_pixel(&in_layer, x as usize, y as usize);
             let output =
                 composite_rainbow(input, rainbow_rgb, mix, preserve_alpha, rainbow.clamp_gamut);
@@ -416,6 +430,7 @@ fn read_geometry(
         start,
         end,
         aspect: aspect_ratio_from_balance(slider(params, Params::Aspect, 0.0)),
+        skew: slider(params, Params::Skew, 0.0).clamp(-1000.0, 1000.0) * 0.01,
         exponent: slider(params, Params::ShapeExponent, 2.0).clamp(0.25, 64.0),
         spiral_turns: slider(params, Params::SpiralTurns, 3.0).clamp(-128.0, 128.0),
         ray_count: slider(params, Params::RayCount, 12.0).clamp(1.0, 512.0),
@@ -423,34 +438,49 @@ fn read_geometry(
 }
 
 fn read_rainbow(params: &Parameters<Params>) -> Result<Rainbow, Error> {
-    let split = params.get(Params::SplitRangeEnds)?.as_checkbox()?.value();
-    let (start, end) = if split {
-        (
-            [
-                slider(params, Params::StartHue, 0.0) / 360.0,
-                slider(params, Params::StartComponent2, 100.0) * 0.01,
-                slider(params, Params::StartComponent3, 75.0) * 0.01,
-            ],
-            [
-                slider(params, Params::EndHue, 360.0) / 360.0,
-                slider(params, Params::EndComponent2, 100.0) * 0.01,
-                slider(params, Params::EndComponent3, 75.0) * 0.01,
-            ],
+    let cam16_parameters = cam16_viewing_conditions();
+    let colors = if params.get(Params::GenerationMode)?.as_popup()?.value() == 2 {
+        prepare_two_color(
+            color_rgb(params, Params::StartColor)?,
+            color_rgb(params, Params::EndColor)?,
+            two_color_space_from_popup(params.get(Params::TwoColorSpace)?.as_popup()?.value()),
+            cam16_parameters,
         )
     } else {
-        affine_rainbow_endpoints(
-            slider(params, Params::HueScale, 100.0),
-            slider(params, Params::HueOffset, 0.0),
-            slider(params, Params::Component2Scale, 0.0),
-            slider(params, Params::Component2Offset, 100.0),
-            slider(params, Params::Component3Scale, 0.0),
-            slider(params, Params::Component3Offset, 75.0),
-        )
+        let split = params.get(Params::SplitRangeEnds)?.as_checkbox()?.value();
+        let (start, end) = if split {
+            (
+                [
+                    slider(params, Params::StartHue, 0.0) / 360.0,
+                    slider(params, Params::StartComponent2, 100.0) * 0.01,
+                    slider(params, Params::StartComponent3, 75.0) * 0.01,
+                ],
+                [
+                    slider(params, Params::EndHue, 360.0) / 360.0,
+                    slider(params, Params::EndComponent2, 100.0) * 0.01,
+                    slider(params, Params::EndComponent3, 75.0) * 0.01,
+                ],
+            )
+        } else {
+            affine_rainbow_endpoints(
+                slider(params, Params::HueScale, 100.0),
+                slider(params, Params::HueOffset, 0.0),
+                slider(params, Params::Component2Scale, 0.0),
+                slider(params, Params::Component2Offset, 100.0),
+                slider(params, Params::Component3Scale, 0.0),
+                slider(params, Params::Component3Offset, 75.0),
+            )
+        };
+        GradientColors::Parametric {
+            start,
+            end,
+            color_model: color_model_from_popup(
+                params.get(Params::ColorModel)?.as_popup()?.value(),
+            ),
+        }
     };
     Ok(Rainbow {
-        start,
-        end,
-        color_model: color_model_from_popup(params.get(Params::ColorModel)?.as_popup()?.value()),
+        colors,
         extend: extend_from_popup(params.get(Params::Extend)?.as_popup()?.value()),
         easing: easing_from_popup(params.get(Params::Easing)?.as_popup()?.value()),
         bezier: [
@@ -460,7 +490,17 @@ fn read_rainbow(params: &Parameters<Params>) -> Result<Rainbow, Error> {
             slider(params, Params::BezierY2, 1.0),
         ],
         clamp_gamut: params.get(Params::ClampGamut)?.as_checkbox()?.value(),
+        cam16_parameters,
     })
+}
+
+fn color_rgb(params: &Parameters<Params>, id: Params) -> Result<[f32; 3], Error> {
+    let color = params.get(id)?.as_color()?.float_value()?;
+    Ok([
+        finite_or(color.red, 0.0).clamp(0.0, 1.0),
+        finite_or(color.green, 0.0).clamp(0.0, 1.0),
+        finite_or(color.blue, 0.0).clamp(0.0, 1.0),
+    ])
 }
 
 fn affine_rainbow_endpoints(
@@ -539,7 +579,19 @@ fn color_model_from_popup(value: i32) -> ColorModel {
         5 => ColorModel::CielchUv,
         6 => ColorModel::Jzczhz,
         7 => ColorModel::IptIch,
+        8 => ColorModel::Okhsl,
+        9 => ColorModel::Okhsv,
+        10 => ColorModel::Cam16UcsJmh,
         _ => ColorModel::Oklch,
+    }
+}
+
+fn two_color_space_from_popup(value: i32) -> TwoColorSpace {
+    match value {
+        2 => TwoColorSpace::Oklch,
+        3 => TwoColorSpace::Cam16UcsJab,
+        4 => TwoColorSpace::Cam16UcsJmh,
+        _ => TwoColorSpace::Oklab,
     }
 }
 
@@ -551,6 +603,9 @@ fn component_names(color_model: ColorModel) -> (&'static str, &'static str) {
         ColorModel::CielchAb | ColorModel::CielchUv => ("Chroma", "Lightness"),
         ColorModel::Jzczhz => ("Chroma (Cz)", "Lightness (Jz)"),
         ColorModel::IptIch => ("Chroma", "Intensity"),
+        ColorModel::Okhsl => ("Saturation", "Lightness"),
+        ColorModel::Okhsv => ("Saturation", "Value"),
+        ColorModel::Cam16UcsJmh => ("Colorfulness (M')", "Lightness (J')"),
     }
 }
 
@@ -696,6 +751,17 @@ mod render_tests {
         assert_eq!(color_model_from_popup(5), ColorModel::CielchUv);
         assert_eq!(color_model_from_popup(6), ColorModel::Jzczhz);
         assert_eq!(color_model_from_popup(7), ColorModel::IptIch);
+        assert_eq!(color_model_from_popup(8), ColorModel::Okhsl);
+        assert_eq!(color_model_from_popup(9), ColorModel::Okhsv);
+        assert_eq!(color_model_from_popup(10), ColorModel::Cam16UcsJmh);
+    }
+
+    #[test]
+    fn two_color_space_popup_indices_are_append_only() {
+        assert_eq!(two_color_space_from_popup(1), TwoColorSpace::Oklab);
+        assert_eq!(two_color_space_from_popup(2), TwoColorSpace::Oklch);
+        assert_eq!(two_color_space_from_popup(3), TwoColorSpace::Cam16UcsJab);
+        assert_eq!(two_color_space_from_popup(4), TwoColorSpace::Cam16UcsJmh);
     }
 
     #[test]
@@ -722,5 +788,14 @@ mod render_tests {
             ("Chroma (Cz)", "Lightness (Jz)")
         );
         assert_eq!(component_names(ColorModel::IptIch), ("Chroma", "Intensity"));
+        assert_eq!(
+            component_names(ColorModel::Okhsl),
+            ("Saturation", "Lightness")
+        );
+        assert_eq!(component_names(ColorModel::Okhsv), ("Saturation", "Value"));
+        assert_eq!(
+            component_names(ColorModel::Cam16UcsJmh),
+            ("Colorfulness (M')", "Lightness (J')")
+        );
     }
 }

--- a/plugins/rainbow-generate/src/lib.rs
+++ b/plugins/rainbow-generate/src/lib.rs
@@ -1,0 +1,726 @@
+#![allow(clippy::drop_non_drop, clippy::question_mark)]
+
+mod gradient;
+mod params;
+
+use after_effects as ae;
+use std::env;
+
+use ae::pf::*;
+use gradient::{
+    ColorModel, Easing, ExtendMode, Geometry, Rainbow, Shape, aspect_ratio_from_balance,
+    geometry_value, sample_rainbow,
+};
+use params::Params;
+use utils::ToPixel;
+use utils::image::{finite_or, read_pixel, sanitize_pixel, unpremultiplied_rgb};
+
+#[derive(Default)]
+struct Plugin {
+    aegp_id: Option<ae::aegp::PluginId>,
+}
+
+ae::define_effect!(Plugin, (), Params);
+
+const PLUGIN_DESCRIPTION: &str = "Generates parametric rainbows directly in perceptual and cylindrical color models across multiple geometric shapes.";
+
+const AFFINE_COLOR_PARAMS: [Params; 6] = [
+    Params::HueScale,
+    Params::HueOffset,
+    Params::Component2Scale,
+    Params::Component2Offset,
+    Params::Component3Scale,
+    Params::Component3Offset,
+];
+const ENDPOINT_COLOR_PARAMS: [Params; 6] = [
+    Params::StartHue,
+    Params::StartComponent2,
+    Params::StartComponent3,
+    Params::EndHue,
+    Params::EndComponent2,
+    Params::EndComponent3,
+];
+
+impl AdobePluginGlobal for Plugin {
+    fn params_setup(
+        &self,
+        params: &mut ae::Parameters<Params>,
+        _in_data: InData,
+        _: OutData,
+    ) -> Result<(), Error> {
+        params::setup(params)
+    }
+
+    fn handle_command(
+        &mut self,
+        cmd: ae::Command,
+        in_data: InData,
+        mut out_data: OutData,
+        params: &mut ae::Parameters<Params>,
+    ) -> Result<(), ae::Error> {
+        match cmd {
+            ae::Command::About => {
+                out_data.set_return_msg(
+                    format!(
+                        "AOD_RainbowGenerate - {version}\r\r{PLUGIN_DESCRIPTION}\rCopyright (c) 2026-{build_year} Aodaruma",
+                        version = env!("CARGO_PKG_VERSION"),
+                        build_year = env!("BUILD_YEAR")
+                    )
+                    .as_str(),
+                );
+            }
+            ae::Command::GlobalSetup => {
+                out_data.set_out_flag(OutFlags::PixIndependent, true);
+                out_data.set_out_flag(OutFlags::UseOutputExtent, true);
+                out_data.set_out_flag(OutFlags::DeepColorAware, true);
+                out_data.set_out_flag(OutFlags::WideTimeInput, true);
+                out_data.set_out_flag(OutFlags::SendUpdateParamsUi, true);
+                out_data.set_out_flag2(OutFlags2::FloatColorAware, true);
+                out_data.set_out_flag2(OutFlags2::SupportsThreadedRendering, true);
+                out_data.set_out_flag2(OutFlags2::AutomaticWideTimeInput, true);
+                out_data.set_out_flag2(OutFlags2::SupportsSmartRender, true);
+                out_data.set_out_flag2(OutFlags2::RevealsZeroAlpha, true);
+                out_data.set_out_flag2(OutFlags2::ParamGroupStartCollapsedFlag, true);
+                if let Ok(suite) = ae::aegp::suites::Utility::new()
+                    && let Ok(plugin_id) = suite.register_with_aegp("AOD_RainbowGenerate")
+                {
+                    self.aegp_id = Some(plugin_id);
+                }
+            }
+            ae::Command::Render {
+                in_layer,
+                out_layer,
+            } => self.do_render(in_data, in_layer, out_layer, params)?,
+            ae::Command::SmartPreRender { mut extra } => {
+                let request = extra.output_request();
+                let input = extra.callbacks().checkout_layer(
+                    0,
+                    0,
+                    &request,
+                    in_data.current_time(),
+                    in_data.time_step(),
+                    in_data.time_scale(),
+                )?;
+                let _ = extra.union_result_rect(input.result_rect.into());
+                let _ = extra.union_max_result_rect(input.max_result_rect.into());
+            }
+            ae::Command::SmartRender { extra } => {
+                let callbacks = extra.callbacks();
+                let input = callbacks.checkout_layer_pixels(0)?;
+                let render_result: Result<(), Error> = (|| {
+                    let output = callbacks.checkout_output()?;
+                    if let (Some(input), Some(output)) = (input, output) {
+                        self.do_render(in_data, input, output, params)?;
+                    }
+                    Ok(())
+                })();
+                let checkin_result = callbacks.checkin_layer_pixels(0);
+                render_result?;
+                checkin_result?;
+            }
+            ae::Command::UserChangedParam { param_index }
+                if matches!(
+                    params.type_at(param_index),
+                    Params::Shape
+                        | Params::CoordinateMode
+                        | Params::ColorModel
+                        | Params::Easing
+                        | Params::SplitRangeEnds
+                ) =>
+            {
+                out_data.set_out_flag(OutFlags::RefreshUi, true);
+            }
+            ae::Command::UpdateParamsUi => {
+                let mut copy = params.cloned();
+                self.update_params_ui(in_data, &mut copy)?;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+}
+
+impl Plugin {
+    fn update_params_ui(
+        &self,
+        in_data: InData,
+        params: &mut Parameters<Params>,
+    ) -> Result<(), Error> {
+        let shape = shape_from_popup(params.get(Params::Shape)?.as_popup()?.value());
+        let two_points = params.get(Params::CoordinateMode)?.as_popup()?.value() == 1;
+        let color_model =
+            color_model_from_popup(params.get(Params::ColorModel)?.as_popup()?.value());
+        let custom_easing = params.get(Params::Easing)?.as_popup()?.value() == 7;
+        let split_range_ends = params.get(Params::SplitRangeEnds)?.as_checkbox()?.value();
+        Self::set_component_names(params, color_model)?;
+
+        Self::set_param_name(
+            params,
+            Params::PointA,
+            if shape == Shape::Linear {
+                "Start Point"
+            } else {
+                "Center"
+            },
+        )?;
+        Self::set_param_name(
+            params,
+            Params::PointB,
+            if shape == Shape::Linear {
+                "End Point"
+            } else if shape == Shape::ReflectedLinear {
+                "Axis / Scale"
+            } else {
+                "Radius / Direction"
+            },
+        )?;
+
+        for id in [Params::PointA, Params::PointB] {
+            self.set_param_visible(in_data, params, id, two_points)?;
+            Self::set_param_enabled(params, id, two_points)?;
+        }
+        for id in [Params::Center, Params::Angle] {
+            self.set_param_visible(in_data, params, id, !two_points)?;
+            Self::set_param_enabled(params, id, !two_points)?;
+        }
+        let uses_length = !two_points && !matches!(shape, Shape::Conic | Shape::Starburst);
+        self.set_param_visible(in_data, params, Params::Length, uses_length)?;
+        Self::set_param_enabled(params, Params::Length, uses_length)?;
+
+        let uses_aspect = matches!(
+            shape,
+            Shape::Radial
+                | Shape::Diamond
+                | Shape::Box
+                | Shape::Minkowski
+                | Shape::Spiral
+                | Shape::Starburst
+        );
+        self.set_param_visible(in_data, params, Params::Aspect, uses_aspect)?;
+        Self::set_param_enabled(params, Params::Aspect, uses_aspect)?;
+
+        for (id, visible) in [
+            (Params::ShapeExponent, shape == Shape::Minkowski),
+            (Params::SpiralTurns, shape == Shape::Spiral),
+            (Params::RayCount, shape == Shape::Starburst),
+        ] {
+            self.set_param_visible(in_data, params, id, visible)?;
+            Self::set_param_enabled(params, id, visible)?;
+        }
+        for id in AFFINE_COLOR_PARAMS {
+            self.set_param_visible(in_data, params, id, !split_range_ends)?;
+            Self::set_param_enabled(params, id, !split_range_ends)?;
+        }
+        for id in ENDPOINT_COLOR_PARAMS {
+            self.set_param_visible(in_data, params, id, split_range_ends)?;
+            Self::set_param_enabled(params, id, split_range_ends)?;
+        }
+
+        for id in [
+            Params::BezierX1,
+            Params::BezierY1,
+            Params::BezierX2,
+            Params::BezierY2,
+        ] {
+            self.set_param_visible(in_data, params, id, custom_easing)?;
+            Self::set_param_enabled(params, id, custom_easing)?;
+        }
+        Ok(())
+    }
+
+    fn set_param_visible(
+        &self,
+        in_data: InData,
+        params: &mut Parameters<Params>,
+        id: Params,
+        visible: bool,
+    ) -> Result<(), Error> {
+        if in_data.is_premiere() {
+            return Self::set_param_ui_flag(params, id, ParamUIFlags::INVISIBLE, !visible);
+        }
+        if let Some(plugin_id) = self.aegp_id {
+            let effect = in_data.effect();
+            if let Some(index) = params.index(id)
+                && let Ok(effect_ref) = effect.aegp_effect(plugin_id)
+                && let Ok(stream) = effect_ref.new_stream_by_index(plugin_id, index as i32)
+            {
+                return stream.set_dynamic_stream_flag(
+                    ae::aegp::DynamicStreamFlags::Hidden,
+                    false,
+                    !visible,
+                );
+            }
+        }
+        Self::set_param_ui_flag(params, id, ParamUIFlags::INVISIBLE, !visible)
+    }
+
+    fn set_param_enabled(
+        params: &mut Parameters<Params>,
+        id: Params,
+        enabled: bool,
+    ) -> Result<(), Error> {
+        Self::set_param_ui_flag(params, id, ParamUIFlags::DISABLED, !enabled)
+    }
+
+    fn set_param_ui_flag(
+        params: &mut Parameters<Params>,
+        id: Params,
+        flag: ParamUIFlags,
+        status: bool,
+    ) -> Result<(), Error> {
+        let current = (params.get(id)?.ui_flags().bits() & flag.bits()) != 0;
+        if current == status {
+            return Ok(());
+        }
+        let mut param = params.get_mut(id)?;
+        param.set_ui_flag(flag, status);
+        param.update_param_ui()?;
+        Ok(())
+    }
+
+    fn set_param_name(
+        params: &mut Parameters<Params>,
+        id: Params,
+        name: &str,
+    ) -> Result<(), Error> {
+        let unchanged = {
+            let param = params.get(id)?;
+            param
+                .as_ref()
+                .name
+                .iter()
+                .take_while(|&&byte| byte != 0)
+                .map(|&byte| byte as u8)
+                .eq(name.bytes())
+        };
+        if unchanged {
+            return Ok(());
+        }
+        let mut param = params.get_mut(id)?;
+        param.set_name(name)?;
+        param.update_param_ui()?;
+        Ok(())
+    }
+
+    fn set_component_names(
+        params: &mut Parameters<Params>,
+        color_model: ColorModel,
+    ) -> Result<(), Error> {
+        let (secondary, tertiary) = component_names(color_model);
+        for (id, prefix, component, suffix) in [
+            (Params::Component2Scale, "", secondary, "Scale (%)"),
+            (Params::Component2Offset, "", secondary, "Offset (%)"),
+            (Params::Component3Scale, "", tertiary, "Scale (%)"),
+            (Params::Component3Offset, "", tertiary, "Offset (%)"),
+            (Params::StartComponent2, "Start ", secondary, "(%)"),
+            (Params::StartComponent3, "Start ", tertiary, "(%)"),
+            (Params::EndComponent2, "End ", secondary, "(%)"),
+            (Params::EndComponent3, "End ", tertiary, "(%)"),
+        ] {
+            let name = format!("{prefix}{component} {suffix}");
+            Self::set_param_name(params, id, &name)?;
+        }
+        Ok(())
+    }
+
+    fn do_render(
+        &self,
+        in_data: InData,
+        in_layer: Layer,
+        mut out_layer: Layer,
+        params: &mut Parameters<Params>,
+    ) -> Result<(), Error> {
+        let width = out_layer.width();
+        let height = out_layer.height();
+        if width == 0 || height == 0 {
+            return Ok(());
+        }
+
+        let shape = shape_from_popup(params.get(Params::Shape)?.as_popup()?.value());
+        let two_points = params.get(Params::CoordinateMode)?.as_popup()?.value() == 1;
+        let downsample = downsample(in_data);
+        let geometry = read_geometry(params, shape, two_points, downsample)?;
+        let rainbow = read_rainbow(params)?;
+        let mix = slider(params, Params::Mix, 100.0).clamp(0.0, 100.0) * 0.01;
+        let preserve_alpha = params
+            .get(Params::PreserveInputAlpha)?
+            .as_checkbox()?
+            .value();
+        // PF_PointDef values are already adjusted for both downsampling and any
+        // pre-effect buffer expansion. PF_EffectWorld::origin is the matching
+        // layer-space origin for a Smart Render tile/full-frame checkout.
+        let origin = out_layer.origin();
+        let origin_x = origin.h as f32;
+        let origin_y = origin.v as f32;
+        let out_world_type = out_layer.world_type();
+
+        out_layer.iterate(0, height as i32, None, |x, y, mut destination| {
+            let point = [
+                (x as f32 + origin_x + 0.5) / downsample[0],
+                (y as f32 + origin_y + 0.5) / downsample[1],
+            ];
+            let rainbow_rgb = sample_rainbow(geometry_value(point, geometry), rainbow);
+            let input = read_pixel(&in_layer, x as usize, y as usize);
+            let output =
+                composite_rainbow(input, rainbow_rgb, mix, preserve_alpha, rainbow.clamp_gamut);
+            match out_world_type {
+                ae::aegp::WorldType::U8 => destination.set_from_u8(output.to_pixel8()),
+                ae::aegp::WorldType::U15 => destination.set_from_u16(output.to_pixel16()),
+                ae::aegp::WorldType::F32 | ae::aegp::WorldType::None => {
+                    destination.set_from_f32(output)
+                }
+            }
+            Ok(())
+        })?;
+        Ok(())
+    }
+}
+
+fn read_geometry(
+    params: &Parameters<Params>,
+    shape: Shape,
+    two_points: bool,
+    downsample: [f32; 2],
+) -> Result<Geometry, Error> {
+    let (start, end) = if two_points {
+        (
+            point_to_full(point(params, Params::PointA)?, downsample),
+            point_to_full(point(params, Params::PointB)?, downsample),
+        )
+    } else {
+        let center = point_to_full(point(params, Params::Center)?, downsample);
+        let angle = finite_or(
+            params.get(Params::Angle)?.as_angle()?.float_value()? as f32,
+            0.0,
+        )
+        .to_radians();
+        let length = slider(params, Params::Length, 500.0).max(0.01);
+        let direction = [angle.cos() * length, angle.sin() * length];
+        if shape == Shape::Linear {
+            (
+                [
+                    center[0] - direction[0] * 0.5,
+                    center[1] - direction[1] * 0.5,
+                ],
+                [
+                    center[0] + direction[0] * 0.5,
+                    center[1] + direction[1] * 0.5,
+                ],
+            )
+        } else {
+            (center, [center[0] + direction[0], center[1] + direction[1]])
+        }
+    };
+    Ok(Geometry {
+        shape,
+        start,
+        end,
+        aspect: aspect_ratio_from_balance(slider(params, Params::Aspect, 0.0)),
+        exponent: slider(params, Params::ShapeExponent, 2.0).clamp(0.25, 64.0),
+        spiral_turns: slider(params, Params::SpiralTurns, 3.0).clamp(-128.0, 128.0),
+        ray_count: slider(params, Params::RayCount, 12.0).clamp(1.0, 512.0),
+    })
+}
+
+fn read_rainbow(params: &Parameters<Params>) -> Result<Rainbow, Error> {
+    let split = params.get(Params::SplitRangeEnds)?.as_checkbox()?.value();
+    let (start, end) = if split {
+        (
+            [
+                slider(params, Params::StartHue, 0.0) / 360.0,
+                slider(params, Params::StartComponent2, 100.0) * 0.01,
+                slider(params, Params::StartComponent3, 75.0) * 0.01,
+            ],
+            [
+                slider(params, Params::EndHue, 360.0) / 360.0,
+                slider(params, Params::EndComponent2, 100.0) * 0.01,
+                slider(params, Params::EndComponent3, 75.0) * 0.01,
+            ],
+        )
+    } else {
+        affine_rainbow_endpoints(
+            slider(params, Params::HueScale, 100.0),
+            slider(params, Params::HueOffset, 0.0),
+            slider(params, Params::Component2Scale, 0.0),
+            slider(params, Params::Component2Offset, 100.0),
+            slider(params, Params::Component3Scale, 0.0),
+            slider(params, Params::Component3Offset, 75.0),
+        )
+    };
+    Ok(Rainbow {
+        start,
+        end,
+        color_model: color_model_from_popup(params.get(Params::ColorModel)?.as_popup()?.value()),
+        extend: extend_from_popup(params.get(Params::Extend)?.as_popup()?.value()),
+        easing: easing_from_popup(params.get(Params::Easing)?.as_popup()?.value()),
+        bezier: [
+            slider(params, Params::BezierX1, 0.25),
+            slider(params, Params::BezierY1, 0.1),
+            slider(params, Params::BezierX2, 0.25),
+            slider(params, Params::BezierY2, 1.0),
+        ],
+        clamp_gamut: params.get(Params::ClampGamut)?.as_checkbox()?.value(),
+    })
+}
+
+fn affine_rainbow_endpoints(
+    hue_scale: f32,
+    hue_offset: f32,
+    component2_scale: f32,
+    component2_offset: f32,
+    component3_scale: f32,
+    component3_offset: f32,
+) -> ([f32; 3], [f32; 3]) {
+    let start = [
+        finite_or(hue_offset, 0.0) / 360.0,
+        finite_or(component2_offset, 100.0) * 0.01,
+        finite_or(component3_offset, 75.0) * 0.01,
+    ];
+    let end = [
+        start[0] + finite_or(hue_scale, 100.0) * 0.01,
+        start[1] + finite_or(component2_scale, 0.0) * 0.01,
+        start[2] + finite_or(component3_scale, 0.0) * 0.01,
+    ];
+    (start, end)
+}
+
+fn point(params: &Parameters<Params>, id: Params) -> Result<[f32; 2], Error> {
+    let param = params.get(id)?;
+    let point = param.as_point()?;
+    Ok(match point.float_value() {
+        Ok(value) => [value.x as f32, value.y as f32],
+        Err(_) => {
+            let (x, y) = point.value();
+            [x, y]
+        }
+    })
+}
+
+fn downsample(in_data: InData) -> [f32; 2] {
+    [
+        f32::from(in_data.downsample_x()).abs().max(1.0e-6),
+        f32::from(in_data.downsample_y()).abs().max(1.0e-6),
+    ]
+}
+
+fn point_to_full(point: [f32; 2], downsample: [f32; 2]) -> [f32; 2] {
+    [point[0] / downsample[0], point[1] / downsample[1]]
+}
+
+fn slider(params: &Parameters<Params>, id: Params, fallback: f32) -> f32 {
+    let Ok(param) = params.get(id) else {
+        return fallback;
+    };
+    let Ok(slider) = param.as_float_slider() else {
+        return fallback;
+    };
+    finite_or(slider.value() as f32, fallback)
+}
+
+fn shape_from_popup(value: i32) -> Shape {
+    match value {
+        2 => Shape::Radial,
+        3 => Shape::Diamond,
+        4 => Shape::Conic,
+        5 => Shape::Box,
+        6 => Shape::Minkowski,
+        7 => Shape::ReflectedLinear,
+        8 => Shape::Spiral,
+        9 => Shape::Starburst,
+        _ => Shape::Linear,
+    }
+}
+
+fn color_model_from_popup(value: i32) -> ColorModel {
+    match value {
+        2 => ColorModel::Hsv,
+        3 => ColorModel::Hsl,
+        4 => ColorModel::CielchAb,
+        5 => ColorModel::CielchUv,
+        6 => ColorModel::Jzczhz,
+        7 => ColorModel::IptIch,
+        _ => ColorModel::Oklch,
+    }
+}
+
+fn component_names(color_model: ColorModel) -> (&'static str, &'static str) {
+    match color_model {
+        ColorModel::Oklch => ("Chroma", "Lightness"),
+        ColorModel::Hsv => ("Saturation", "Brightness"),
+        ColorModel::Hsl => ("Saturation", "Lightness"),
+        ColorModel::CielchAb | ColorModel::CielchUv => ("Chroma", "Lightness"),
+        ColorModel::Jzczhz => ("Chroma (Cz)", "Lightness (Jz)"),
+        ColorModel::IptIch => ("Chroma", "Intensity"),
+    }
+}
+
+fn extend_from_popup(value: i32) -> ExtendMode {
+    match value {
+        2 => ExtendMode::Repeat,
+        3 => ExtendMode::Mirror,
+        _ => ExtendMode::Clamp,
+    }
+}
+
+fn easing_from_popup(value: i32) -> Easing {
+    match value {
+        2 => Easing::EaseIn,
+        3 => Easing::EaseOut,
+        4 => Easing::EaseInOut,
+        5 => Easing::Smoothstep,
+        6 => Easing::Smootherstep,
+        7 => Easing::Custom,
+        _ => Easing::Linear,
+    }
+}
+
+fn lerp(a: f32, b: f32, t: f32) -> f32 {
+    a + (b - a) * t
+}
+
+fn composite_rainbow(
+    input: PixelF32,
+    rainbow_rgb: [f32; 3],
+    mix: f32,
+    preserve_alpha: bool,
+    clamp_gamut: bool,
+) -> PixelF32 {
+    let mix = finite_or(mix, 1.0).clamp(0.0, 1.0);
+    let input_alpha = finite_or(input.alpha, 0.0).clamp(0.0, 1.0);
+    let mut output = if preserve_alpha {
+        let input_rgb = unpremultiplied_rgb(input);
+        let rgb = [
+            lerp(input_rgb[0], rainbow_rgb[0], mix),
+            lerp(input_rgb[1], rainbow_rgb[1], mix),
+            lerp(input_rgb[2], rainbow_rgb[2], mix),
+        ];
+        PixelF32 {
+            alpha: input_alpha,
+            red: rgb[0] * input_alpha,
+            green: rgb[1] * input_alpha,
+            blue: rgb[2] * input_alpha,
+        }
+    } else {
+        PixelF32 {
+            alpha: lerp(input_alpha, 1.0, mix),
+            red: lerp(
+                finite_or(input.red, 0.0),
+                finite_or(rainbow_rgb[0], 0.0),
+                mix,
+            ),
+            green: lerp(
+                finite_or(input.green, 0.0),
+                finite_or(rainbow_rgb[1], 0.0),
+                mix,
+            ),
+            blue: lerp(
+                finite_or(input.blue, 0.0),
+                finite_or(rainbow_rgb[2], 0.0),
+                mix,
+            ),
+        }
+    };
+    output = sanitize_pixel(output, false);
+    if clamp_gamut {
+        output.red = output.red.clamp(0.0, output.alpha);
+        output.green = output.green.clamp(0.0, output.alpha);
+        output.blue = output.blue.clamp(0.0, output.alpha);
+    }
+    output
+}
+
+#[cfg(test)]
+mod render_tests {
+    use super::*;
+
+    #[test]
+    fn rainbow_mix_interpolates_associated_color() {
+        let transparent = PixelF32 {
+            alpha: 0.0,
+            red: 0.0,
+            green: 0.0,
+            blue: 0.0,
+        };
+        let output = composite_rainbow(transparent, [1.0, 0.0, 0.0], 0.5, false, false);
+        assert!((output.alpha - 0.5).abs() < 1.0e-6);
+        assert!((output.red - 0.5).abs() < 1.0e-6);
+    }
+
+    #[test]
+    fn display_gamut_clamps_in_straight_color_space() {
+        let output = composite_rainbow(
+            PixelF32 {
+                alpha: 0.0,
+                red: 0.0,
+                green: 0.0,
+                blue: 0.0,
+            },
+            [4.0, -1.0, 0.5],
+            1.0,
+            false,
+            true,
+        );
+        assert_eq!(output.alpha, 1.0);
+        assert_eq!(output.red, 1.0);
+        assert_eq!(output.green, 0.0);
+        assert_eq!(output.blue, 0.5);
+    }
+
+    #[test]
+    fn point_coordinates_restore_each_downsample_axis() {
+        assert_eq!(point_to_full([50.0, 25.0], [0.5, 0.25]), [100.0, 100.0]);
+    }
+
+    #[test]
+    fn affine_defaults_define_one_full_rainbow_cycle() {
+        let (start, end) = affine_rainbow_endpoints(100.0, 0.0, 0.0, 100.0, 0.0, 75.0);
+        assert_eq!(start, [0.0, 1.0, 0.75]);
+        assert_eq!(end, [1.0, 1.0, 0.75]);
+    }
+
+    #[test]
+    fn affine_scales_are_range_deltas() {
+        let (start, end) = affine_rainbow_endpoints(250.0, -90.0, -40.0, 100.0, 30.0, 50.0);
+        assert_eq!(start, [-0.25, 1.0, 0.5]);
+        for (actual, expected) in end.into_iter().zip([2.25, 0.6, 0.8]) {
+            assert!((actual - expected).abs() < 1.0e-6);
+        }
+    }
+
+    #[test]
+    fn color_model_popup_indices_are_append_only() {
+        assert_eq!(color_model_from_popup(1), ColorModel::Oklch);
+        assert_eq!(color_model_from_popup(2), ColorModel::Hsv);
+        assert_eq!(color_model_from_popup(3), ColorModel::Hsl);
+        assert_eq!(color_model_from_popup(4), ColorModel::CielchAb);
+        assert_eq!(color_model_from_popup(5), ColorModel::CielchUv);
+        assert_eq!(color_model_from_popup(6), ColorModel::Jzczhz);
+        assert_eq!(color_model_from_popup(7), ColorModel::IptIch);
+    }
+
+    #[test]
+    fn dynamic_component_names_follow_each_model() {
+        assert_eq!(component_names(ColorModel::Oklch), ("Chroma", "Lightness"));
+        assert_eq!(
+            component_names(ColorModel::Hsv),
+            ("Saturation", "Brightness")
+        );
+        assert_eq!(
+            component_names(ColorModel::Hsl),
+            ("Saturation", "Lightness")
+        );
+        assert_eq!(
+            component_names(ColorModel::CielchAb),
+            ("Chroma", "Lightness")
+        );
+        assert_eq!(
+            component_names(ColorModel::CielchUv),
+            ("Chroma", "Lightness")
+        );
+        assert_eq!(
+            component_names(ColorModel::Jzczhz),
+            ("Chroma (Cz)", "Lightness (Jz)")
+        );
+        assert_eq!(component_names(ColorModel::IptIch), ("Chroma", "Intensity"));
+    }
+}

--- a/plugins/rainbow-generate/src/params.rs
+++ b/plugins/rainbow-generate/src/params.rs
@@ -46,6 +46,15 @@ pub(crate) enum Params {
     Mix,
     PreserveInputAlpha,
     OutputEnd,
+    GenerationStart,
+    GenerationMode,
+    TwoColorSpace,
+    StartColor,
+    EndColor,
+    GenerationEnd,
+    TransformStart,
+    Skew,
+    TransformEnd,
 }
 
 pub(crate) fn setup(params: &mut ae::Parameters<Params>) -> Result<(), Error> {
@@ -194,7 +203,7 @@ pub(crate) fn setup(params: &mut ae::Parameters<Params>) -> Result<(), Error> {
     params.add_group(
         Params::RainbowStart,
         Params::RainbowEnd,
-        "Parametric Rainbow",
+        "Gradient Mapping",
         false,
         |params| {
             params.add_with_flags(
@@ -210,6 +219,9 @@ pub(crate) fn setup(params: &mut ae::Parameters<Params>) -> Result<(), Error> {
                         "CIELCh(uv)",
                         "JzCzHz",
                         "IPT ICh",
+                        "OkHSL",
+                        "OkHSV",
+                        "CAM16-UCS J'M'h'",
                     ]);
                     d.set_default(1);
                 }),
@@ -475,6 +487,93 @@ pub(crate) fn setup(params: &mut ae::Parameters<Params>) -> Result<(), Error> {
                 "Preserve Input Alpha",
                 CheckBoxDef::setup(|d| {
                     d.set_default(false);
+                }),
+            )?;
+            Ok(())
+        },
+    )?;
+
+    // Keep all parameters above append-only for project compatibility. Generation
+    // mode and the two-color controls were introduced after the v0.3 parameter set.
+    params.add_group(
+        Params::GenerationStart,
+        Params::GenerationEnd,
+        "Generation",
+        false,
+        |params| {
+            params.add_with_flags(
+                Params::GenerationMode,
+                "Mode",
+                PopupDef::setup(|d| {
+                    d.set_options(&["Parametric", "Two Color"]);
+                    d.set_default(1);
+                }),
+                ae::ParamFlag::SUPERVISE,
+                ae::ParamUIFlags::empty(),
+            )?;
+            params.add_with_flags(
+                Params::TwoColorSpace,
+                "Interpolation Color Space",
+                PopupDef::setup(|d| {
+                    d.set_options(&[
+                        "OKLab",
+                        "OKLCH (Shortest Hue)",
+                        "CAM16-UCS J'a'b'",
+                        "CAM16-UCS J'M'h' (Shortest Hue)",
+                    ]);
+                    d.set_default(1);
+                }),
+                ae::ParamFlag::empty(),
+                ae::ParamUIFlags::DISABLED | ae::ParamUIFlags::INVISIBLE,
+            )?;
+            params.add_with_flags(
+                Params::StartColor,
+                "Start Color",
+                ColorDef::setup(|d| {
+                    d.set_default(Pixel8 {
+                        alpha: 255,
+                        red: 0,
+                        green: 0,
+                        blue: 0,
+                    });
+                }),
+                ae::ParamFlag::empty(),
+                ae::ParamUIFlags::DISABLED | ae::ParamUIFlags::INVISIBLE,
+            )?;
+            params.add_with_flags(
+                Params::EndColor,
+                "End Color",
+                ColorDef::setup(|d| {
+                    d.set_default(Pixel8 {
+                        alpha: 255,
+                        red: 255,
+                        green: 255,
+                        blue: 255,
+                    });
+                }),
+                ae::ParamFlag::empty(),
+                ae::ParamUIFlags::DISABLED | ae::ParamUIFlags::INVISIBLE,
+            )?;
+            Ok(())
+        },
+    )?;
+
+    params.add_group(
+        Params::TransformStart,
+        Params::TransformEnd,
+        "Transform",
+        false,
+        |params| {
+            params.add(
+                Params::Skew,
+                "Skew (%)",
+                FloatSliderDef::setup(|d| {
+                    d.set_valid_min(-1000.0);
+                    d.set_valid_max(1000.0);
+                    d.set_slider_min(-100.0);
+                    d.set_slider_max(100.0);
+                    d.set_default(0.0);
+                    d.set_precision(2);
                 }),
             )?;
             Ok(())

--- a/plugins/rainbow-generate/src/params.rs
+++ b/plugins/rainbow-generate/src/params.rs
@@ -1,0 +1,484 @@
+use ae::Error;
+use ae::pf::*;
+use after_effects as ae;
+
+#[derive(Eq, PartialEq, Hash, Clone, Copy, Debug)]
+pub(crate) enum Params {
+    GeometryStart,
+    Shape,
+    CoordinateMode,
+    PointA,
+    PointB,
+    Center,
+    Angle,
+    Length,
+    Aspect,
+    ShapeExponent,
+    SpiralTurns,
+    RayCount,
+    GeometryEnd,
+    RainbowStart,
+    ColorModel,
+    SplitRangeEnds,
+    HueScale,
+    HueOffset,
+    Component2Scale,
+    Component2Offset,
+    Component3Scale,
+    Component3Offset,
+    StartHue,
+    StartComponent2,
+    StartComponent3,
+    EndHue,
+    EndComponent2,
+    EndComponent3,
+    Extend,
+    ClampGamut,
+    RainbowEnd,
+    EasingStart,
+    Easing,
+    BezierX1,
+    BezierY1,
+    BezierX2,
+    BezierY2,
+    EasingEnd,
+    OutputStart,
+    Mix,
+    PreserveInputAlpha,
+    OutputEnd,
+}
+
+pub(crate) fn setup(params: &mut ae::Parameters<Params>) -> Result<(), Error> {
+    params.add_group(
+        Params::GeometryStart,
+        Params::GeometryEnd,
+        "Geometry",
+        false,
+        |params| {
+            params.add_with_flags(
+                Params::Shape,
+                "Shape",
+                PopupDef::setup(|d| {
+                    d.set_options(&[
+                        "Linear",
+                        "Radial (L2)",
+                        "Diamond (L1)",
+                        "Conic",
+                        "Box (L-infinity)",
+                        "Minkowski (Lp)",
+                        "Reflected Linear",
+                        "Spiral",
+                        "Starburst",
+                    ]);
+                    d.set_default(1);
+                }),
+                ae::ParamFlag::SUPERVISE,
+                ae::ParamUIFlags::empty(),
+            )?;
+            params.add_with_flags(
+                Params::CoordinateMode,
+                "Coordinates",
+                PopupDef::setup(|d| {
+                    d.set_options(&["Two Points", "Parametric"]);
+                    d.set_default(1);
+                }),
+                ae::ParamFlag::SUPERVISE,
+                ae::ParamUIFlags::empty(),
+            )?;
+            params.add(
+                Params::PointA,
+                "Start Point",
+                PointDef::setup(|d| {
+                    d.set_default((25.0, 50.0));
+                }),
+            )?;
+            params.add(
+                Params::PointB,
+                "End Point",
+                PointDef::setup(|d| {
+                    d.set_default((75.0, 50.0));
+                }),
+            )?;
+            params.add_with_flags(
+                Params::Center,
+                "Center",
+                PointDef::setup(|d| {
+                    d.set_default((50.0, 50.0));
+                }),
+                ae::ParamFlag::empty(),
+                ae::ParamUIFlags::INVISIBLE,
+            )?;
+            params.add_with_flags(
+                Params::Angle,
+                "Angle",
+                AngleDef::setup(|d| {
+                    d.set_default(0.0);
+                }),
+                ae::ParamFlag::empty(),
+                ae::ParamUIFlags::INVISIBLE,
+            )?;
+            params.add_with_flags(
+                Params::Length,
+                "Length / Radius (px)",
+                FloatSliderDef::setup(|d| {
+                    d.set_valid_min(0.01);
+                    d.set_valid_max(32768.0);
+                    d.set_slider_min(1.0);
+                    d.set_slider_max(2048.0);
+                    d.set_default(500.0);
+                    d.set_precision(2);
+                }),
+                ae::ParamFlag::empty(),
+                ae::ParamUIFlags::INVISIBLE,
+            )?;
+            params.add_with_flags(
+                Params::Aspect,
+                "Aspect (-Vertical/+Horizontal)",
+                FloatSliderDef::setup(|d| {
+                    d.set_valid_min(-1.0);
+                    d.set_valid_max(1.0);
+                    d.set_slider_min(-1.0);
+                    d.set_slider_max(1.0);
+                    d.set_default(0.0);
+                    d.set_precision(3);
+                }),
+                ae::ParamFlag::empty(),
+                ae::ParamUIFlags::DISABLED | ae::ParamUIFlags::INVISIBLE,
+            )?;
+            params.add_with_flags(
+                Params::ShapeExponent,
+                "Minkowski Exponent (p)",
+                FloatSliderDef::setup(|d| {
+                    d.set_valid_min(0.25);
+                    d.set_valid_max(64.0);
+                    d.set_slider_min(0.5);
+                    d.set_slider_max(16.0);
+                    d.set_default(2.0);
+                    d.set_precision(3);
+                }),
+                ae::ParamFlag::empty(),
+                ae::ParamUIFlags::DISABLED | ae::ParamUIFlags::INVISIBLE,
+            )?;
+            params.add_with_flags(
+                Params::SpiralTurns,
+                "Spiral Turns",
+                FloatSliderDef::setup(|d| {
+                    d.set_valid_min(-128.0);
+                    d.set_valid_max(128.0);
+                    d.set_slider_min(-16.0);
+                    d.set_slider_max(16.0);
+                    d.set_default(3.0);
+                    d.set_precision(2);
+                }),
+                ae::ParamFlag::empty(),
+                ae::ParamUIFlags::DISABLED | ae::ParamUIFlags::INVISIBLE,
+            )?;
+            params.add_with_flags(
+                Params::RayCount,
+                "Ray Count",
+                FloatSliderDef::setup(|d| {
+                    d.set_valid_min(1.0);
+                    d.set_valid_max(512.0);
+                    d.set_slider_min(1.0);
+                    d.set_slider_max(64.0);
+                    d.set_default(12.0);
+                    d.set_precision(0);
+                }),
+                ae::ParamFlag::empty(),
+                ae::ParamUIFlags::DISABLED | ae::ParamUIFlags::INVISIBLE,
+            )?;
+            Ok(())
+        },
+    )?;
+
+    params.add_group(
+        Params::RainbowStart,
+        Params::RainbowEnd,
+        "Parametric Rainbow",
+        false,
+        |params| {
+            params.add_with_flags(
+                Params::ColorModel,
+                "Color Model",
+                PopupDef::setup(|d| {
+                    // Keep the first three entries stable for existing projects.
+                    d.set_options(&[
+                        "OKLCH",
+                        "HSV",
+                        "HSL",
+                        "CIELCh(ab)",
+                        "CIELCh(uv)",
+                        "JzCzHz",
+                        "IPT ICh",
+                    ]);
+                    d.set_default(1);
+                }),
+                ae::ParamFlag::SUPERVISE,
+                ae::ParamUIFlags::empty(),
+            )?;
+            params.add_with_flags(
+                Params::SplitRangeEnds,
+                "Split Range Start / End",
+                CheckBoxDef::setup(|d| {
+                    d.set_default(false);
+                }),
+                ae::ParamFlag::SUPERVISE,
+                ae::ParamUIFlags::empty(),
+            )?;
+
+            for (id, name, valid_min, valid_max, slider_min, slider_max, default) in [
+                (
+                    Params::HueScale,
+                    "Hue Scale (%)",
+                    -1600.0,
+                    1600.0,
+                    -400.0,
+                    400.0,
+                    100.0,
+                ),
+                (
+                    Params::HueOffset,
+                    "Hue Offset (deg)",
+                    -3600.0,
+                    3600.0,
+                    -720.0,
+                    720.0,
+                    0.0,
+                ),
+                (
+                    Params::Component2Scale,
+                    "Chroma Scale (%)",
+                    -400.0,
+                    400.0,
+                    -200.0,
+                    200.0,
+                    0.0,
+                ),
+                (
+                    Params::Component2Offset,
+                    "Chroma Offset (%)",
+                    -400.0,
+                    400.0,
+                    0.0,
+                    200.0,
+                    100.0,
+                ),
+                (
+                    Params::Component3Scale,
+                    "Lightness Scale (%)",
+                    -400.0,
+                    400.0,
+                    -200.0,
+                    200.0,
+                    0.0,
+                ),
+                (
+                    Params::Component3Offset,
+                    "Lightness Offset (%)",
+                    -400.0,
+                    400.0,
+                    0.0,
+                    200.0,
+                    75.0,
+                ),
+            ] {
+                params.add(
+                    id,
+                    name,
+                    FloatSliderDef::setup(|d| {
+                        d.set_valid_min(valid_min);
+                        d.set_valid_max(valid_max);
+                        d.set_slider_min(slider_min);
+                        d.set_slider_max(slider_max);
+                        d.set_default(default);
+                        d.set_precision(2);
+                    }),
+                )?;
+            }
+
+            for (id, name, valid_min, valid_max, slider_min, slider_max, default) in [
+                (
+                    Params::StartHue,
+                    "Start Hue (deg)",
+                    -3600.0,
+                    3600.0,
+                    -720.0,
+                    720.0,
+                    0.0,
+                ),
+                (
+                    Params::StartComponent2,
+                    "Start Chroma (%)",
+                    -400.0,
+                    400.0,
+                    0.0,
+                    200.0,
+                    100.0,
+                ),
+                (
+                    Params::StartComponent3,
+                    "Start Lightness (%)",
+                    -400.0,
+                    400.0,
+                    0.0,
+                    200.0,
+                    75.0,
+                ),
+                (
+                    Params::EndHue,
+                    "End Hue (deg)",
+                    -3600.0,
+                    3600.0,
+                    -720.0,
+                    720.0,
+                    360.0,
+                ),
+                (
+                    Params::EndComponent2,
+                    "End Chroma (%)",
+                    -400.0,
+                    400.0,
+                    0.0,
+                    200.0,
+                    100.0,
+                ),
+                (
+                    Params::EndComponent3,
+                    "End Lightness (%)",
+                    -400.0,
+                    400.0,
+                    0.0,
+                    200.0,
+                    75.0,
+                ),
+            ] {
+                params.add_with_flags(
+                    id,
+                    name,
+                    FloatSliderDef::setup(|d| {
+                        d.set_valid_min(valid_min);
+                        d.set_valid_max(valid_max);
+                        d.set_slider_min(slider_min);
+                        d.set_slider_max(slider_max);
+                        d.set_default(default);
+                        d.set_precision(2);
+                    }),
+                    ae::ParamFlag::empty(),
+                    ae::ParamUIFlags::DISABLED | ae::ParamUIFlags::INVISIBLE,
+                )?;
+            }
+
+            params.add(
+                Params::Extend,
+                "Extend",
+                PopupDef::setup(|d| {
+                    d.set_options(&["Clamp", "Repeat", "Mirror"]);
+                    d.set_default(1);
+                }),
+            )?;
+            params.add(
+                Params::ClampGamut,
+                "Clamp to Display Gamut",
+                CheckBoxDef::setup(|d| {
+                    d.set_default(true);
+                }),
+            )?;
+            Ok(())
+        },
+    )?;
+
+    params.add_group(
+        Params::EasingStart,
+        Params::EasingEnd,
+        "Easing",
+        false,
+        |params| {
+            params.add_with_flags(
+                Params::Easing,
+                "Preset",
+                PopupDef::setup(|d| {
+                    d.set_options(&[
+                        "Linear",
+                        "Ease In",
+                        "Ease Out",
+                        "Ease In-Out",
+                        "Smoothstep",
+                        "Smootherstep",
+                        "Custom Cubic Bezier",
+                    ]);
+                    d.set_default(1);
+                }),
+                ae::ParamFlag::SUPERVISE,
+                ae::ParamUIFlags::empty(),
+            )?;
+            for (id, name, default) in [
+                (Params::BezierX1, "Bezier X1", 0.25),
+                (Params::BezierY1, "Bezier Y1", 0.1),
+                (Params::BezierX2, "Bezier X2", 0.25),
+                (Params::BezierY2, "Bezier Y2", 1.0),
+            ] {
+                params.add_with_flags(
+                    id,
+                    name,
+                    FloatSliderDef::setup(|d| {
+                        d.set_valid_min(if matches!(id, Params::BezierX1 | Params::BezierX2) {
+                            0.0
+                        } else {
+                            -4.0
+                        });
+                        d.set_valid_max(if matches!(id, Params::BezierX1 | Params::BezierX2) {
+                            1.0
+                        } else {
+                            4.0
+                        });
+                        d.set_slider_min(if matches!(id, Params::BezierX1 | Params::BezierX2) {
+                            0.0
+                        } else {
+                            -2.0
+                        });
+                        d.set_slider_max(if matches!(id, Params::BezierX1 | Params::BezierX2) {
+                            1.0
+                        } else {
+                            2.0
+                        });
+                        d.set_default(default);
+                        d.set_precision(3);
+                    }),
+                    ae::ParamFlag::empty(),
+                    ae::ParamUIFlags::INVISIBLE,
+                )?;
+            }
+            Ok(())
+        },
+    )?;
+
+    params.add_group(
+        Params::OutputStart,
+        Params::OutputEnd,
+        "Output",
+        false,
+        |params| {
+            params.add(
+                Params::Mix,
+                "Mix (%)",
+                FloatSliderDef::setup(|d| {
+                    d.set_valid_min(0.0);
+                    d.set_valid_max(100.0);
+                    d.set_slider_min(0.0);
+                    d.set_slider_max(100.0);
+                    d.set_default(100.0);
+                    d.set_precision(1);
+                }),
+            )?;
+            params.add(
+                Params::PreserveInputAlpha,
+                "Preserve Input Alpha",
+                CheckBoxDef::setup(|d| {
+                    d.set_default(false);
+                }),
+            )?;
+            Ok(())
+        },
+    )?;
+    Ok(())
+}

--- a/plugins/space-convert/Cargo.toml
+++ b/plugins/space-convert/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "space_convert"
+description = "Converts images between Cartesian, curvilinear coordinate, Radon, and channel-aware line Hough representations."
+version = "0.2.0"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib"]
+
+[features]
+default = []
+catch-panics = []
+
+[dependencies]
+after-effects = { workspace = true }
+utils = { path = "../../crates/utils" }
+
+
+[dev-dependencies]
+pipl = { workspace = true }
+
+[build-dependencies]
+chrono.workspace = true
+pipl.workspace = true
+winres = "0.1.12"
+
+[lints]
+workspace = true

--- a/plugins/space-convert/Cargo.toml
+++ b/plugins/space-convert/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "space_convert"
 description = "Converts images between Cartesian, curvilinear coordinate, Radon, and channel-aware line Hough representations."
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 
 [lib]

--- a/plugins/space-convert/Justfile
+++ b/plugins/space-convert/Justfile
@@ -1,0 +1,12 @@
+# Read package.name from Cargo.toml for build naming.
+CrateName := if os() == "windows" {
+    `$inPackage = $false; foreach ($line in Get-Content -Path Cargo.toml) { if ($line -match '^\s*\[package\]\s*$') { $inPackage = $true; continue }; if ($line -match '^\s*\[.+\]\s*$') { if ($inPackage) { break } }; if ($inPackage -and $line -match '^\s*name\s*=\s*"([^"]+)"') { $matches[1]; break } }`
+} else {
+    `awk -F'"' 'BEGIN{in_pkg=0} /^[[:space:]]*\[package\][[:space:]]*$/{in_pkg=1;next} /^[[:space:]]*\[/{if(in_pkg)exit} in_pkg && /^[[:space:]]*name[[:space:]]*=/ {print $2; exit}' Cargo.toml`
+}
+
+PluginName       := "AOD_SpaceConvert"
+BundleIdentifier := "com.aodaruma." + PluginName
+BinaryName       := snakecase(CrateName)
+
+import "../../AdobePlugin.just"

--- a/plugins/space-convert/README.md
+++ b/plugins/space-convert/README.md
@@ -1,0 +1,42 @@
+# space-convert ( AOD_SpaceConvert )
+
+Converts images between Cartesian, curvilinear coordinate, Radon, and line Hough representations.
+
+## Modes
+
+- **Polar / Log-Polar**: angle is horizontal and radius is vertical.
+- **Spiral Polar**: polar coordinates with a parametric radial twist. `Spiral Turns` may be
+  positive or negative and remains analytically invertible.
+- **Square-Disc**: concentric square/disc mapping with an analytic coordinate map. The default
+  `Auto (Full Coverage)` radius uses the canvas-inscribed disc so the mapped square is not clipped.
+- **Elliptic Coordinates**: confocal ellipse/hyperbola coordinates. `Focus / Radius` controls the
+  focal distance.
+- **Parabolic Coordinates**: an analytic complex-square coordinate map using signed parabolic axes.
+- **Bipolar Coordinates**: two-focus coordinates with adjustable focus distance and finite
+  coordinate extent.
+- **Radon**: angle is horizontal and signed detector distance is vertical. Forward projections are
+  path-length normalized; inverse applies the corresponding finite Ram-Lak/FBP normalization.
+- **Line Hough**: line-evidence accumulator in the same layout. `Luminance` preserves the original
+  behavior; `RGBA` transforms all four channels independently; `Red`, `Green`, `Blue`, and `Alpha`
+  provide single-channel grayscale analysis and reconstruction views.
+
+Spatial geometry is evaluated in full-resolution square-pixel coordinates. Pixel aspect ratio and
+independent horizontal/vertical downsampling are accounted for, so custom and log radii, circular
+maps, Radon lines, and Hough edge thresholds remain stable across render resolutions. Custom Center
+is localized against the checked-out world's origin when preceding effects expand the bounds.
+
+Coordinate modes use inverse-mapped sampling, so repeated conversion loses information through
+resampling. `Radon` inverse uses finite Ram-Lak filtered backprojection and `Line Hough` inverse uses
+normalized backprojection. Both are labelled **Inverse (Approximate)** in the UI and are not exact
+reconstruction methods.
+
+`Angle Samples`, `Detector Samples`, and `Samples per Ray` explicitly trade analysis quality for CPU
+cost. At extreme combinations the effective ray count, filter radius, and inverse working resolution
+are reduced to a fixed safe work budget. The analysis buffer is resampled to the layer dimensions for
+display.
+
+This is the After Effects plugin **AOD_SpaceConvert**, which provides the **AOD_SpaceConvert.aex** plugin file for Adobe After Effects.
+
+## Building the Plugin
+
+See the [main README](../../README.md) for instructions on how to build the plugin.

--- a/plugins/space-convert/README.md
+++ b/plugins/space-convert/README.md
@@ -30,6 +30,20 @@ resampling. `Radon` inverse uses finite Ram-Lak filtered backprojection and `Lin
 normalized backprojection. Both are labelled **Inverse (Approximate)** in the UI and are not exact
 reconstruction methods.
 
+## Post Transform
+
+The appended **Post Transform** group transforms the result of the selected space conversion. It
+uses the familiar AE controls `Anchor Point`, `Position`, uniform or separated `Scale`, `Rotation`,
+`Skew`, and `Skew Axis`. Enabling `Separate Dimensions` dynamically replaces the single scale
+control with `Scale X` and `Scale Y`.
+
+Rendering inverse-maps each output pixel through the post transform before evaluating the selected
+space equation. Coordinate modes therefore continue their analytic equations beyond the visible
+output rectangle where the equation has a valid extension; they do not tile or mirror a bounded
+intermediate image. Forward Radon and Line Hough likewise evaluate the inverse-mapped angle and
+detector distance directly on their analysis lattice. Inverse projection modes apply the same
+mapping before backprojection. The identity defaults take the original rendering path unchanged.
+
 `Angle Samples`, `Detector Samples`, and `Samples per Ray` explicitly trade analysis quality for CPU
 cost. At extreme combinations the effective ray count, filter radius, and inverse working resolution
 are reduced to a fixed safe work budget. The analysis buffer is resampled to the layer dimensions for

--- a/plugins/space-convert/build.rs
+++ b/plugins/space-convert/build.rs
@@ -1,0 +1,95 @@
+use chrono::Datelike;
+use pipl::*;
+
+const PF_PLUG_IN_VERSION: u16 = 13;
+const PF_PLUG_IN_SUBVERS: u16 = 28;
+
+#[cfg(target_os = "windows")]
+fn embed_binary_safe_pipl(pipl: &[u8]) {
+    let out_dir = std::path::PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR is set"));
+    let pipl_path = out_dir.join("space_convert.pipl");
+    std::fs::write(&pipl_path, pipl).expect("write binary PiPL resource");
+
+    let escaped_path = pipl_path.to_string_lossy().replace('\\', "\\\\");
+    let mut resource = winres::WindowsResource::new();
+    resource.append_rc_content(&format!("16000 PiPL DISCARDABLE \"{escaped_path}\""));
+    resource.compile().expect("compile binary PiPL resource");
+}
+
+#[rustfmt::skip]
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(does_dialog)");
+    println!("cargo::rustc-check-cfg=cfg(threaded_rendering)");
+
+    let current_year = chrono::Local::now().year();
+    println!("cargo:rustc-env=BUILD_YEAR={}", current_year);
+
+    let pkg_version = env!("CARGO_PKG_VERSION");
+    let version_parts: Vec<&str> = pkg_version.split('.').collect();
+    if version_parts.len() != 3 {
+        panic!("CARGO_PKG_VERSION must be in the format 'major.minor.patch'");
+    }
+    let major: u32 = version_parts[0].parse().expect("Invalid major version");
+    let minor: u32 = version_parts[1].parse().expect("Invalid minor version");
+    let patch: u32 = version_parts[2].parse().expect("Invalid patch version");
+
+    // Determine the stage based on building whether debug or release
+    /*
+    // pipl load error occured when stage = Stage::Release in pipl == v0.1.1, so temporarily fixed to Develop
+    let stage = if cfg!(debug_assertions) {
+        Stage::Develop
+    } else {
+        Stage::Release
+    };
+    */
+    let stage = Stage::Develop;
+
+    // --------------------------------------------------
+    // Build the plugin with PiPL
+    let properties = || vec![
+        Property::Kind(PIPLType::AEEffect),
+        Property::Name("AOD_SpaceConvert"),
+        Property::Category("Aodaruma"),
+
+        #[cfg(target_os = "windows")]
+        Property::CodeWin64X86("EffectMain"),
+        #[cfg(target_os = "macos")]
+        Property::CodeMacIntel64("EffectMain"),
+        #[cfg(target_os = "macos")]
+        Property::CodeMacARM64("EffectMain"),
+
+        Property::AE_PiPL_Version { major: 2, minor: 0 },
+        Property::AE_Effect_Spec_Version { major: PF_PLUG_IN_VERSION, minor: PF_PLUG_IN_SUBVERS },
+        Property::AE_Effect_Version {
+            version: major,
+            subversion: minor,
+            bugversion: patch,
+            stage,
+            build: 1,
+        },
+        Property::AE_Effect_Info_Flags(0),
+        Property::AE_Effect_Global_OutFlags(
+            // set up from https://docs.rs/pipl/latest/pipl/struct.OutFlags.html
+            OutFlags::UseOutputExtent
+            | OutFlags::DeepColorAware
+            | OutFlags::SendUpdateParamsUI
+            ,
+        ),
+        Property::AE_Effect_Global_OutFlags_2(
+            // set up from https://docs.rs/pipl/latest/pipl/struct.OutFlags2.html
+            OutFlags2::FloatColorAware
+            | OutFlags2::SupportsSmartRender
+            | OutFlags2::ParamGroupStartCollapsedFlag
+            | OutFlags2::RevealsZeroAlpha
+            // | OutFlags2::SupportsGpuRenderF32
+            ,
+        ),
+        Property::AE_Effect_Match_Name("SpaceConvert"),
+        Property::AE_Reserved_Info(8),
+        Property::AE_Effect_Support_URL("https://github.com/Aodaruma/aod-AE-plugin"),
+    ];
+
+    pipl::plugin_build(properties());
+    #[cfg(target_os = "windows")]
+    embed_binary_safe_pipl(&pipl::build_pipl(properties()).expect("build PiPL"));
+}

--- a/plugins/space-convert/src/lib.rs
+++ b/plugins/space-convert/src/lib.rs
@@ -46,6 +46,19 @@ enum Params {
     CoordinateExtent,
     HoughChannels,
     SpaceSpecificEnd,
+    // Post-transform parameters are deliberately append-only. Reordering any
+    // parameter above this point would break projects saved by earlier builds.
+    PostTransformStart,
+    PostAnchorPoint,
+    PostPosition,
+    PostSeparateScale,
+    PostScale,
+    PostScaleX,
+    PostScaleY,
+    PostRotation,
+    PostSkew,
+    PostSkewAxis,
+    PostTransformEnd,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -126,6 +139,103 @@ enum HoughChannels {
     Alpha,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct Matrix2 {
+    m00: f32,
+    m01: f32,
+    m10: f32,
+    m11: f32,
+}
+
+impl Matrix2 {
+    fn rotation(angle: f32) -> Self {
+        let (sin, cos) = angle.sin_cos();
+        Self {
+            m00: cos,
+            m01: -sin,
+            m10: sin,
+            m11: cos,
+        }
+    }
+
+    const fn scale(x: f32, y: f32) -> Self {
+        Self {
+            m00: x,
+            m01: 0.0,
+            m10: 0.0,
+            m11: y,
+        }
+    }
+
+    fn shear_x(angle: f32) -> Self {
+        Self {
+            m00: 1.0,
+            m01: angle.tan(),
+            m10: 0.0,
+            m11: 1.0,
+        }
+    }
+
+    const fn mul(self, rhs: Self) -> Self {
+        Self {
+            m00: self.m00 * rhs.m00 + self.m01 * rhs.m10,
+            m01: self.m00 * rhs.m01 + self.m01 * rhs.m11,
+            m10: self.m10 * rhs.m00 + self.m11 * rhs.m10,
+            m11: self.m10 * rhs.m01 + self.m11 * rhs.m11,
+        }
+    }
+
+    fn transform(self, point: (f32, f32)) -> (f32, f32) {
+        (
+            self.m00 * point.0 + self.m01 * point.1,
+            self.m10 * point.0 + self.m11 * point.1,
+        )
+    }
+
+    fn inverse(self) -> Option<Self> {
+        let determinant = self.m00 * self.m11 - self.m01 * self.m10;
+        if !determinant.is_finite() || determinant.abs() <= 1.0e-8 {
+            return None;
+        }
+        let reciprocal = determinant.recip();
+        Some(Self {
+            m00: self.m11 * reciprocal,
+            m01: -self.m01 * reciprocal,
+            m10: -self.m10 * reciprocal,
+            m11: self.m00 * reciprocal,
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct PostTransform {
+    anchor: (f32, f32),
+    position: (f32, f32),
+    scale: (f32, f32),
+    rotation: f32,
+    skew: f32,
+    skew_axis: f32,
+}
+
+impl PostTransform {
+    fn is_identity(self) -> bool {
+        self.anchor.0 == self.position.0
+            && self.anchor.1 == self.position.1
+            && self.scale.0 == 1.0
+            && self.scale.1 == 1.0
+            && self.rotation == 0.0
+            && self.skew == 0.0
+    }
+
+    fn matrix(self) -> Matrix2 {
+        let scale = Matrix2::scale(self.scale.0, self.scale.1);
+        let skew = Matrix2::rotation(self.skew_axis)
+            .mul(Matrix2::shear_x(self.skew))
+            .mul(Matrix2::rotation(-self.skew_axis));
+        Matrix2::rotation(self.rotation).mul(skew).mul(scale)
+    }
+}
+
 impl HoughChannels {
     fn from_popup(value: i32) -> Self {
         match value {
@@ -169,6 +279,7 @@ struct Settings {
     focus_ratio: f32,
     coordinate_extent: f32,
     hough_channels: HoughChannels,
+    post_transform: PostTransform,
 }
 
 #[derive(Default)]
@@ -509,6 +620,63 @@ impl AdobePluginGlobal for Plugin {
                 Ok(())
             },
         )?;
+
+        params.add_group(
+            Params::PostTransformStart,
+            Params::PostTransformEnd,
+            "Post Transform",
+            true,
+            |params| {
+                params.add(
+                    Params::PostAnchorPoint,
+                    "Anchor Point",
+                    PointDef::setup(|d| {
+                        d.set_default((50.0, 50.0));
+                    }),
+                )?;
+                params.add(
+                    Params::PostPosition,
+                    "Position",
+                    PointDef::setup(|d| {
+                        d.set_default((50.0, 50.0));
+                    }),
+                )?;
+                params.add_with_flags(
+                    Params::PostSeparateScale,
+                    "Separate Dimensions",
+                    CheckBoxDef::setup(|d| {
+                        d.set_default(false);
+                    }),
+                    ae::ParamFlag::SUPERVISE,
+                    ae::ParamUIFlags::empty(),
+                )?;
+                add_post_scale_slider(params, Params::PostScale, "Scale", true)?;
+                add_post_scale_slider(params, Params::PostScaleX, "Scale X", false)?;
+                add_post_scale_slider(params, Params::PostScaleY, "Scale Y", false)?;
+                params.add(
+                    Params::PostRotation,
+                    "Rotation",
+                    AngleDef::setup(|d| {
+                        d.set_default(0.0);
+                    }),
+                )?;
+                params.add(
+                    Params::PostSkew,
+                    "Skew",
+                    AngleDef::setup(|d| {
+                        d.set_default(0.0);
+                    }),
+                )?;
+                params.add(
+                    Params::PostSkewAxis,
+                    "Skew Axis",
+                    AngleDef::setup(|d| {
+                        d.set_default(0.0);
+                    }),
+                )?;
+                Ok(())
+            },
+        )?;
         Ok(())
     }
 
@@ -587,7 +755,11 @@ impl AdobePluginGlobal for Plugin {
             ae::Command::UserChangedParam { param_index } => {
                 if matches!(
                     params.type_at(param_index),
-                    Params::Space | Params::Direction | Params::CenterMode | Params::RadiusMode
+                    Params::Space
+                        | Params::Direction
+                        | Params::CenterMode
+                        | Params::RadiusMode
+                        | Params::PostSeparateScale
                 ) {
                     out_data.set_out_flag(OutFlags::RefreshUi, true);
                 }
@@ -662,6 +834,16 @@ impl Plugin {
             Params::HoughChannels,
             space == Space::LineHough,
         )?;
+        let separate_scale = params
+            .get(Params::PostSeparateScale)?
+            .as_checkbox()?
+            .value();
+        self.set_param_visible(in_data, params, Params::PostScale, !separate_scale)?;
+        self.set_param_visible(in_data, params, Params::PostScaleX, separate_scale)?;
+        self.set_param_visible(in_data, params, Params::PostScaleY, separate_scale)?;
+        Self::set_param_enabled(params, Params::PostScale, !separate_scale)?;
+        Self::set_param_enabled(params, Params::PostScaleX, separate_scale)?;
+        Self::set_param_enabled(params, Params::PostScaleY, separate_scale)?;
         Ok(())
     }
 
@@ -707,6 +889,14 @@ impl Plugin {
         Ok(())
     }
 
+    fn set_param_enabled(
+        params: &mut Parameters<Params>,
+        id: Params,
+        enabled: bool,
+    ) -> Result<(), Error> {
+        Self::set_param_ui_flag(params, id, ParamUIFlags::DISABLED, !enabled)
+    }
+
     fn do_render(
         &self,
         in_data: InData,
@@ -725,6 +915,10 @@ impl Plugin {
         if settings.center_mode == CenterMode::Custom {
             settings.center = point_in_checkout_world(settings.center, in_layer.origin());
         }
+        settings.post_transform.anchor =
+            point_in_checkout_world(settings.post_transform.anchor, out_layer.origin());
+        settings.post_transform.position =
+            point_in_checkout_world(settings.post_transform.position, out_layer.origin());
 
         let source = read_layer(&in_layer);
         let output = if settings.space.is_integral() {
@@ -773,9 +967,63 @@ fn add_integer_slider(
     Ok(())
 }
 
+fn add_post_scale_slider(
+    params: &mut Parameters<Params>,
+    id: Params,
+    name: &str,
+    visible: bool,
+) -> Result<(), Error> {
+    let mut ui_flags = ParamUIFlags::empty();
+    if !visible {
+        ui_flags |= ParamUIFlags::INVISIBLE | ParamUIFlags::DISABLED;
+    }
+    params.add_with_flags(
+        id,
+        name,
+        FloatSliderDef::setup(|d| {
+            d.set_valid_min(-10000.0);
+            d.set_valid_max(10000.0);
+            d.set_slider_min(-1000.0);
+            d.set_slider_max(1000.0);
+            d.set_default(100.0);
+            d.set_precision(2);
+        }),
+        ParamFlag::empty(),
+        ui_flags,
+    )?;
+    Ok(())
+}
+
 fn read_settings(params: &Parameters<Params>, in_data: InData) -> Result<Settings, Error> {
     let popup = |id| params.get(id)?.as_popup().map(|p| p.value());
     let slider = |id| params.get(id)?.as_float_slider().map(|p| p.value() as f32);
+    let angle = |id| {
+        params
+            .get(id)?
+            .as_angle()?
+            .float_value()
+            .map(|value| finite_or(value as f32, 0.0).to_radians())
+    };
+    let point = |id| {
+        params
+            .get(id)?
+            .as_point()
+            .map(|point| point.value())
+            .map(|(x, y)| (finite_or(x, 0.0), finite_or(y, 0.0)))
+    };
+    let separate_scale = params
+        .get(Params::PostSeparateScale)?
+        .as_checkbox()?
+        .value();
+    let post_scale = if separate_scale {
+        (
+            finite_or(slider(Params::PostScaleX)?, 100.0) * 0.01,
+            finite_or(slider(Params::PostScaleY)?, 100.0) * 0.01,
+        )
+    } else {
+        let uniform = finite_or(slider(Params::PostScale)?, 100.0) * 0.01;
+        (uniform, uniform)
+    };
     Ok(Settings {
         space: Space::from_popup(popup(Params::Space)?),
         direction: Direction::from_popup(popup(Params::Direction)?),
@@ -819,7 +1067,19 @@ fn read_settings(params: &Parameters<Params>, in_data: InData) -> Result<Setting
         focus_ratio: slider(Params::FocusRatio)?.clamp(0.001, 0.999),
         coordinate_extent: slider(Params::CoordinateExtent)?.clamp(0.05, 20.0),
         hough_channels: HoughChannels::from_popup(popup(Params::HoughChannels)?),
+        post_transform: PostTransform {
+            anchor: point(Params::PostAnchorPoint)?,
+            position: point(Params::PostPosition)?,
+            scale: post_scale,
+            rotation: angle(Params::PostRotation)?,
+            skew: angle(Params::PostSkew)?,
+            skew_axis: angle(Params::PostSkewAxis)?,
+        },
     })
+}
+
+fn finite_or(value: f32, fallback: f32) -> f32 {
+    if value.is_finite() { value } else { fallback }
 }
 
 fn render_pixel_scale(in_data: InData) -> (f32, f32) {
@@ -849,6 +1109,40 @@ fn square_pixel_scale(pixel_aspect: f32, downsample_x: f32, downsample_y: f32) -
 
 fn point_in_checkout_world(point: (f32, f32), origin: ae::Point) -> (f32, f32) {
     (point.0 - origin.h as f32, point.1 - origin.v as f32)
+}
+
+fn inverse_post_transform_point(
+    destination: (f32, f32),
+    post_transform: PostTransform,
+    pixel_scale: (f32, f32),
+    inverse: Matrix2,
+) -> (f32, f32) {
+    let destination_physical = (
+        (destination.0 - post_transform.position.0) * pixel_scale.0,
+        (destination.1 - post_transform.position.1) * pixel_scale.1,
+    );
+    let source_physical = inverse.transform(destination_physical);
+    (
+        post_transform.anchor.0 + source_physical.0 / pixel_scale.0,
+        post_transform.anchor.1 + source_physical.1 / pixel_scale.1,
+    )
+}
+
+#[cfg(test)]
+fn forward_post_transform_point(
+    source: (f32, f32),
+    post_transform: PostTransform,
+    pixel_scale: (f32, f32),
+) -> (f32, f32) {
+    let source_physical = (
+        (source.0 - post_transform.anchor.0) * pixel_scale.0,
+        (source.1 - post_transform.anchor.1) * pixel_scale.1,
+    );
+    let destination_physical = post_transform.matrix().transform(source_physical);
+    (
+        post_transform.position.0 + destination_physical.0 / pixel_scale.0,
+        post_transform.position.1 + destination_physical.1 / pixel_scale.1,
+    )
 }
 
 fn resolve_geometry(width: usize, height: usize, settings: Settings) -> ((f32, f32), f32) {
@@ -902,27 +1196,108 @@ fn render_coordinates(
     settings: Settings,
 ) -> Vec<PixelF32> {
     let (center, radius) = resolve_geometry(out_width, out_height, settings);
+    let post_identity = settings.post_transform.is_identity();
+    let post_inverse = if post_identity {
+        None
+    } else {
+        settings.post_transform.matrix().inverse()
+    };
+    if !post_identity && post_inverse.is_none() {
+        return vec![TRANSPARENT; out_width * out_height];
+    }
+    let (forward_polar_trigonometry, forward_polar_radii) = if matches!(
+        (settings.space, settings.direction),
+        (Space::Polar | Space::LogPolar, Direction::Forward)
+    ) && post_identity
+    {
+        let trigonometry = (0..out_width)
+            .map(|x| {
+                let theta = settings.angle_offset + normalized_index(x, out_width) * TAU;
+                (theta.cos(), theta.sin())
+            })
+            .collect::<Vec<_>>();
+        let radii = (0..out_height)
+            .map(|y| {
+                let v = normalized_index(y, out_height);
+                if settings.space == Space::LogPolar {
+                    let min_radius = settings.log_min_radius.min(radius * 0.999).max(0.001);
+                    min_radius * (radius / min_radius).powf(v)
+                } else {
+                    v * radius
+                }
+            })
+            .collect::<Vec<_>>();
+        (trigonometry, radii)
+    } else {
+        (Vec::new(), Vec::new())
+    };
+    let (inverse_polar_dx, inverse_polar_dy) = if matches!(
+        (settings.space, settings.direction),
+        (
+            Space::Polar | Space::LogPolar | Space::SpiralPolar,
+            Direction::Inverse
+        )
+    ) && post_identity
+    {
+        let dx = (0..out_width)
+            .map(|x| (x as f32 - center.0) * settings.pixel_scale.0)
+            .collect::<Vec<_>>();
+        let dy = (0..out_height)
+            .map(|y| (y as f32 - center.1) * settings.pixel_scale.1)
+            .collect::<Vec<_>>();
+        (dx, dy)
+    } else {
+        (Vec::new(), Vec::new())
+    };
+    let (inverse_log_min_radius, inverse_log_radius_range) =
+        if settings.space == Space::LogPolar && settings.direction == Direction::Inverse {
+            let min_radius = settings.log_min_radius.min(radius * 0.999).max(0.001);
+            (min_radius, (radius / min_radius).ln())
+        } else {
+            (0.0, 0.0)
+        };
     let mut output = vec![TRANSPARENT; out_width * out_height];
     for y in 0..out_height {
-        let v = normalized_index(y, out_height);
         for x in 0..out_width {
-            let u = normalized_index(x, out_width);
+            let (post_x, post_y) = if post_identity {
+                (x as f32, y as f32)
+            } else {
+                inverse_post_transform_point(
+                    (x as f32, y as f32),
+                    settings.post_transform,
+                    settings.pixel_scale,
+                    post_inverse.expect("non-identity transform was checked for invertibility"),
+                )
+            };
+            let u = normalized_coordinate(post_x, out_width);
+            let v = normalized_coordinate(post_y, out_height);
             let coordinate = match (settings.space, settings.direction) {
                 (Space::Polar, Direction::Forward) => {
-                    let theta = settings.angle_offset + u * TAU;
-                    let r = v * radius;
+                    let ((cos, sin), r) = if post_identity {
+                        (forward_polar_trigonometry[x], forward_polar_radii[y])
+                    } else {
+                        let theta = settings.angle_offset + u * TAU;
+                        ((theta.cos(), theta.sin()), v * radius)
+                    };
                     Some((
-                        center.0 + r * theta.cos() / settings.pixel_scale.0,
-                        center.1 + r * theta.sin() / settings.pixel_scale.1,
+                        center.0 + r * cos / settings.pixel_scale.0,
+                        center.1 + r * sin / settings.pixel_scale.1,
                     ))
                 }
                 (Space::LogPolar, Direction::Forward) => {
-                    let theta = settings.angle_offset + u * TAU;
-                    let min_radius = settings.log_min_radius.min(radius * 0.999).max(0.001);
-                    let r = min_radius * (radius / min_radius).powf(v);
+                    let ((cos, sin), r) = if post_identity {
+                        (forward_polar_trigonometry[x], forward_polar_radii[y])
+                    } else {
+                        let theta = settings.angle_offset + u * TAU;
+                        let min_radius = settings.log_min_radius.min(radius * 0.999).max(0.001);
+                        (
+                            (theta.cos(), theta.sin()),
+                            min_radius * (radius / min_radius).powf(v),
+                        )
+                    };
                     Some((
-                        center.0 + r * theta.cos() / settings.pixel_scale.0,
-                        center.1 + r * theta.sin() / settings.pixel_scale.1,
+                        center.0 + r * cos / settings.pixel_scale.0,
+                        center.1 + r * sin / settings.pixel_scale.1,
                     ))
                 }
                 (Space::SpiralPolar, Direction::Forward) => {
@@ -934,8 +1309,14 @@ fn render_coordinates(
                     ))
                 }
                 (Space::Polar | Space::LogPolar | Space::SpiralPolar, Direction::Inverse) => {
-                    let dx = (x as f32 - center.0) * settings.pixel_scale.0;
-                    let dy = (y as f32 - center.1) * settings.pixel_scale.1;
+                    let (dx, dy) = if post_identity {
+                        (inverse_polar_dx[x], inverse_polar_dy[y])
+                    } else {
+                        (
+                            (post_x - center.0) * settings.pixel_scale.0,
+                            (post_y - center.1) * settings.pixel_scale.1,
+                        )
+                    };
                     let r = dx.hypot(dy);
                     if r > radius {
                         None
@@ -950,11 +1331,10 @@ fn render_coordinates(
                             .rem_euclid(TAU)
                             / TAU;
                         let radius_v = if settings.space == Space::LogPolar {
-                            let min_radius = settings.log_min_radius.min(radius * 0.999).max(0.001);
-                            if r < min_radius {
+                            if r < inverse_log_min_radius {
                                 return_coordinate_none()
                             } else {
-                                (r / min_radius).ln() / (radius / min_radius).ln()
+                                (r / inverse_log_min_radius).ln() / inverse_log_radius_range
                             }
                         } else {
                             r / radius
@@ -970,8 +1350,8 @@ fn render_coordinates(
                     }
                 }
                 (Space::SquareDisc, Direction::Forward) => {
-                    let dx = (x as f32 - center.0) * settings.pixel_scale.0 / radius;
-                    let dy = (y as f32 - center.1) * settings.pixel_scale.1 / radius;
+                    let dx = (post_x - center.0) * settings.pixel_scale.0 / radius;
+                    let dy = (post_y - center.1) * settings.pixel_scale.1 / radius;
                     if dx * dx + dy * dy > 1.0 {
                         None
                     } else {
@@ -1002,8 +1382,8 @@ fn render_coordinates(
                     ))
                 }
                 (Space::Elliptic, Direction::Inverse) => {
-                    let dx = (x as f32 - center.0) * settings.pixel_scale.0;
-                    let dy = (y as f32 - center.1) * settings.pixel_scale.1;
+                    let dx = (post_x - center.0) * settings.pixel_scale.0;
+                    let dy = (post_y - center.1) * settings.pixel_scale.1;
                     let focus = (radius * settings.focus_ratio).max(1.0e-6);
                     let d_positive = (dx - focus).hypot(dy);
                     let d_negative = (dx + focus).hypot(dy);
@@ -1036,8 +1416,8 @@ fn render_coordinates(
                     ))
                 }
                 (Space::Parabolic, Direction::Inverse) => {
-                    let dx = (x as f32 - center.0) * settings.pixel_scale.0;
-                    let dy = (y as f32 - center.1) * settings.pixel_scale.1;
+                    let dx = (post_x - center.0) * settings.pixel_scale.0;
+                    let dy = (post_y - center.1) * settings.pixel_scale.1;
                     let radial = dx.hypot(dy);
                     let sigma = (radial + dx).max(0.0).sqrt();
                     let tau_magnitude = (radial - dx).max(0.0).sqrt();
@@ -1078,8 +1458,8 @@ fn render_coordinates(
                     }
                 }
                 (Space::Bipolar, Direction::Inverse) => {
-                    let dx = (x as f32 - center.0) * settings.pixel_scale.0;
-                    let dy = (y as f32 - center.1) * settings.pixel_scale.1;
+                    let dx = (post_x - center.0) * settings.pixel_scale.0;
+                    let dy = (post_y - center.1) * settings.pixel_scale.1;
                     let focus = (radius * settings.focus_ratio).max(1.0e-6);
                     let numerator = (dx + focus) * (dx + focus) + dy * dy;
                     let denominator = (dx - focus) * (dx - focus) + dy * dy;
@@ -1135,8 +1515,18 @@ fn render_integral(
     settings: Settings,
 ) -> Vec<PixelF32> {
     let analysis = match (settings.space, settings.direction) {
+        (Space::Radon, Direction::Forward) if !settings.post_transform.is_identity() => {
+            forward_radon_post_transformed(
+                source, src_width, src_height, out_width, out_height, settings,
+            )
+        }
         (Space::Radon, Direction::Forward) => {
             forward_radon(source, src_width, src_height, settings)
+        }
+        (Space::LineHough, Direction::Forward) if !settings.post_transform.is_identity() => {
+            forward_hough_post_transformed(
+                source, src_width, src_height, out_width, out_height, settings,
+            )
         }
         (Space::LineHough, Direction::Forward) => {
             forward_hough(source, src_width, src_height, settings)
@@ -1177,6 +1567,206 @@ fn effective_ray_samples(settings: Settings) -> usize {
     settings.ray_samples.min(budgeted)
 }
 
+struct ProjectionGeometry {
+    trigonometry: Vec<(f32, f32)>,
+    detector_rhos: Vec<f32>,
+    ray_positions: Vec<f32>,
+}
+
+fn projection_trigonometry(angle_offset: f32, angle_samples: usize) -> Vec<(f32, f32)> {
+    (0..angle_samples)
+        .map(|angle| {
+            let theta = angle_offset + angle as f32 * PI / angle_samples as f32;
+            (theta.cos(), theta.sin())
+        })
+        .collect()
+}
+
+impl ProjectionGeometry {
+    fn new(
+        angle_offset: f32,
+        angle_samples: usize,
+        detector_samples: usize,
+        ray_samples: usize,
+        radius: f32,
+    ) -> Self {
+        let trigonometry = projection_trigonometry(angle_offset, angle_samples);
+        let detector_rhos = (0..detector_samples)
+            .map(|detector| detector_rho(detector, detector_samples, radius))
+            .collect();
+        let ray_positions = (0..ray_samples)
+            .map(|ray| detector_rho(ray, ray_samples, radius))
+            .collect();
+        Self {
+            trigonometry,
+            detector_rhos,
+            ray_positions,
+        }
+    }
+}
+
+fn transformed_projection_coordinate(
+    angle_index: usize,
+    detector_index: usize,
+    out_width: usize,
+    out_height: usize,
+    settings: Settings,
+    inverse: Matrix2,
+) -> (f32, f32) {
+    let destination = (
+        resize_coordinate(angle_index, settings.angle_samples, out_width),
+        resize_coordinate(detector_index, settings.detector_samples, out_height),
+    );
+    let source = inverse_post_transform_point(
+        destination,
+        settings.post_transform,
+        settings.pixel_scale,
+        inverse,
+    );
+    (
+        settings.angle_offset + normalized_coordinate(source.0, out_width) * PI,
+        normalized_coordinate(source.1, out_height),
+    )
+}
+
+fn forward_radon_post_transformed(
+    source: &[PixelF32],
+    width: usize,
+    height: usize,
+    out_width: usize,
+    out_height: usize,
+    settings: Settings,
+) -> Vec<PixelF32> {
+    let Some(inverse) = settings.post_transform.matrix().inverse() else {
+        return vec![TRANSPARENT; settings.angle_samples * settings.detector_samples];
+    };
+    let (center, radius) = resolve_geometry(width, height, settings);
+    let ray_samples = effective_ray_samples(settings);
+    let ray_positions = (0..ray_samples)
+        .map(|ray| detector_rho(ray, ray_samples, radius))
+        .collect::<Vec<_>>();
+    let mut result = vec![TRANSPARENT; settings.angle_samples * settings.detector_samples];
+    for detector in 0..settings.detector_samples {
+        for angle in 0..settings.angle_samples {
+            let (theta, detector_v) = transformed_projection_coordinate(
+                angle, detector, out_width, out_height, settings, inverse,
+            );
+            let rho = (detector_v * 2.0 - 1.0) * radius;
+            let (sin, cos) = theta.sin_cos();
+            let mut sum = TRANSPARENT;
+            for (ray, &t) in ray_positions.iter().enumerate() {
+                let pixel = sample_bilinear(
+                    source,
+                    width,
+                    height,
+                    center.0 + (rho * cos - t * sin) / settings.pixel_scale.0,
+                    center.1 + (rho * sin + t * cos) / settings.pixel_scale.1,
+                    SampleEdge::Transparent,
+                );
+                let endpoint_weight = if ray == 0 || ray + 1 == ray_samples {
+                    0.5
+                } else {
+                    1.0
+                };
+                sum = add_pixel(sum, scale_pixel(pixel, endpoint_weight));
+            }
+            result[detector * settings.angle_samples + angle] =
+                scale_pixel(sum, 1.0 / ray_samples.saturating_sub(1).max(1) as f32);
+        }
+    }
+    result
+}
+
+fn forward_hough_post_transformed(
+    source: &[PixelF32],
+    width: usize,
+    height: usize,
+    out_width: usize,
+    out_height: usize,
+    settings: Settings,
+) -> Vec<PixelF32> {
+    let Some(inverse) = settings.post_transform.matrix().inverse() else {
+        return vec![TRANSPARENT; settings.angle_samples * settings.detector_samples];
+    };
+    let (center, radius) = resolve_geometry(width, height, settings);
+    let ray_samples = effective_ray_samples(settings);
+    let ray_positions = (0..ray_samples)
+        .map(|ray| detector_rho(ray, ray_samples, radius))
+        .collect::<Vec<_>>();
+    let edges = sobel_edge_channels(
+        source,
+        width,
+        height,
+        settings.pixel_scale,
+        settings.hough_channels,
+    );
+    let mut votes = vec![[0.0_f32; 4]; settings.angle_samples * settings.detector_samples];
+    let mut maximum = [0.0_f32; 4];
+    let alpha_fallback = if source.is_empty() {
+        0.0
+    } else {
+        source.iter().map(|pixel| pixel.alpha).sum::<f32>() / source.len() as f32
+    };
+    for detector in 0..settings.detector_samples {
+        for angle in 0..settings.angle_samples {
+            let (theta, detector_v) = transformed_projection_coordinate(
+                angle, detector, out_width, out_height, settings, inverse,
+            );
+            let rho = (detector_v * 2.0 - 1.0) * radius;
+            let (sin, cos) = theta.sin_cos();
+            let mut sum = [0.0_f32; 4];
+            for &t in &ray_positions {
+                let magnitude = sample_channel_bilinear(
+                    &edges,
+                    width,
+                    height,
+                    center.0 + (rho * cos - t * sin) / settings.pixel_scale.0,
+                    center.1 + (rho * sin + t * cos) / settings.pixel_scale.1,
+                );
+                for channel in 0..4 {
+                    if magnitude[channel] >= settings.hough_threshold {
+                        sum[channel] += if settings.weighted_hough {
+                            magnitude[channel]
+                        } else {
+                            1.0
+                        };
+                    }
+                }
+            }
+            let vote = sum.map(|value| value / ray_samples as f32);
+            votes[detector * settings.angle_samples + angle] = vote;
+            for channel in 0..4 {
+                maximum[channel] = maximum[channel].max(vote[channel]);
+            }
+        }
+    }
+    votes
+        .into_iter()
+        .map(|value| {
+            let normalized = [
+                value[0] / maximum[0].max(1.0e-8),
+                value[1] / maximum[1].max(1.0e-8),
+                value[2] / maximum[2].max(1.0e-8),
+                if maximum[3] <= 1.0e-8 {
+                    alpha_fallback
+                } else {
+                    value[3] / maximum[3]
+                },
+            ];
+            if settings.hough_channels.is_rgba() {
+                PixelF32 {
+                    alpha: normalized[3],
+                    red: normalized[0],
+                    green: normalized[1],
+                    blue: normalized[2],
+                }
+            } else {
+                gray_pixel(normalized[0])
+            }
+        })
+        .collect()
+}
+
 fn forward_radon(
     source: &[PixelF32],
     width: usize,
@@ -1185,16 +1775,21 @@ fn forward_radon(
 ) -> Vec<PixelF32> {
     let (center, radius) = resolve_geometry(width, height, settings);
     let ray_samples = effective_ray_samples(settings);
+    let geometry = ProjectionGeometry::new(
+        settings.angle_offset,
+        settings.angle_samples,
+        settings.detector_samples,
+        ray_samples,
+        radius,
+    );
     let mut result = vec![TRANSPARENT; settings.angle_samples * settings.detector_samples];
     for detector in 0..settings.detector_samples {
-        let rho = detector_rho(detector, settings.detector_samples, radius);
+        let rho = geometry.detector_rhos[detector];
         for angle in 0..settings.angle_samples {
-            let theta = settings.angle_offset + angle as f32 * PI / settings.angle_samples as f32;
-            let cos = theta.cos();
-            let sin = theta.sin();
+            let (cos, sin) = geometry.trigonometry[angle];
             let mut sum = TRANSPARENT;
             for ray in 0..ray_samples {
-                let t = detector_rho(ray, ray_samples, radius);
+                let t = geometry.ray_positions[ray];
                 let pixel = sample_bilinear(
                     source,
                     width,
@@ -1225,6 +1820,13 @@ fn forward_hough(
 ) -> Vec<PixelF32> {
     let (center, radius) = resolve_geometry(width, height, settings);
     let ray_samples = effective_ray_samples(settings);
+    let geometry = ProjectionGeometry::new(
+        settings.angle_offset,
+        settings.angle_samples,
+        settings.detector_samples,
+        ray_samples,
+        radius,
+    );
     let edges = sobel_edge_channels(
         source,
         width,
@@ -1240,14 +1842,12 @@ fn forward_hough(
         source.iter().map(|pixel| pixel.alpha).sum::<f32>() / source.len() as f32
     };
     for detector in 0..settings.detector_samples {
-        let rho = detector_rho(detector, settings.detector_samples, radius);
+        let rho = geometry.detector_rhos[detector];
         for angle in 0..settings.angle_samples {
-            let theta = settings.angle_offset + angle as f32 * PI / settings.angle_samples as f32;
-            let cos = theta.cos();
-            let sin = theta.sin();
+            let (cos, sin) = geometry.trigonometry[angle];
             let mut sum = [0.0_f32; 4];
             for ray in 0..ray_samples {
-                let t = detector_rho(ray, ray_samples, radius);
+                let t = geometry.ray_positions[ray];
                 let magnitude = sample_channel_bilinear(
                     &edges,
                     width,
@@ -1441,6 +2041,10 @@ fn scaled_geometry_settings(mut settings: Settings, scale_x: f32, scale_y: f32) 
         settings.center.0 *= scale_x;
         settings.center.1 *= scale_y;
     }
+    settings.post_transform.anchor.0 *= scale_x;
+    settings.post_transform.anchor.1 *= scale_y;
+    settings.post_transform.position.0 *= scale_x;
+    settings.post_transform.position.1 *= scale_y;
     settings.pixel_scale.0 /= scale_x.max(1.0e-6);
     settings.pixel_scale.1 /= scale_y.max(1.0e-6);
     settings
@@ -1457,16 +2061,35 @@ fn backproject(
     normalize: bool,
 ) -> Vec<PixelF32> {
     let (center, radius) = resolve_geometry(width, height, settings);
+    let trigonometry = projection_trigonometry(settings.angle_offset, angles);
+    let post_identity = settings.post_transform.is_identity();
+    let post_inverse = if post_identity {
+        None
+    } else {
+        settings.post_transform.matrix().inverse()
+    };
+    if !post_identity && post_inverse.is_none() {
+        return vec![TRANSPARENT; width * height];
+    }
     let mut result = vec![TRANSPARENT; width * height];
     let mut maximum = 0.0_f32;
     for y in 0..height {
         for x in 0..width {
-            let dx = (x as f32 - center.0) * settings.pixel_scale.0;
-            let dy = (y as f32 - center.1) * settings.pixel_scale.1;
+            let (post_x, post_y) = if post_identity {
+                (x as f32, y as f32)
+            } else {
+                inverse_post_transform_point(
+                    (x as f32, y as f32),
+                    settings.post_transform,
+                    settings.pixel_scale,
+                    post_inverse.expect("non-identity transform was checked for invertibility"),
+                )
+            };
+            let dx = (post_x - center.0) * settings.pixel_scale.0;
+            let dy = (post_y - center.1) * settings.pixel_scale.1;
             let mut sum = TRANSPARENT;
-            for angle in 0..angles {
-                let theta = settings.angle_offset + angle as f32 * PI / angles as f32;
-                let rho = dx * theta.cos() + dy * theta.sin();
+            for (angle, &(cos, sin)) in trigonometry.iter().enumerate() {
+                let rho = dx * cos + dy * sin;
                 let detector = rho_to_detector(rho, detectors, radius);
                 sum = add_pixel(
                     sum,
@@ -1507,6 +2130,9 @@ fn ram_lak_filter(
     radius: usize,
 ) -> Vec<PixelF32> {
     let mut result = vec![TRANSPARENT; sinogram.len()];
+    let coefficients = (-(radius as isize)..=(radius as isize))
+        .map(ram_lak_coefficient)
+        .collect::<Vec<_>>();
     for detector in 0..detectors {
         for angle in 0..angles {
             let mut sum = TRANSPARENT;
@@ -1515,7 +2141,7 @@ fn ram_lak_filter(
                 if !(0..detectors as isize).contains(&source_detector) {
                     continue;
                 }
-                let coefficient = ram_lak_coefficient(offset);
+                let coefficient = coefficients[(offset + radius as isize) as usize];
                 sum = add_pixel(
                     sum,
                     scale_pixel(
@@ -1588,11 +2214,16 @@ fn sobel_edge_channels(
     mode: HoughChannels,
 ) -> Vec<[f32; 4]> {
     let mut result = vec![[0.0; 4]; width * height];
+    if width == 0 || height == 0 {
+        return result;
+    }
+    let components = (0..width * height)
+        .map(|index| analysis_components(source.get(index).copied().unwrap_or(TRANSPARENT), mode))
+        .collect::<Vec<_>>();
     let get = |x: i64, y: i64| {
-        analysis_components(
-            sample_nearest(source, width, height, x as f32, y as f32, SampleEdge::Clamp),
-            mode,
-        )
+        let x = x.clamp(0, width as i64 - 1) as usize;
+        let y = y.clamp(0, height as i64 - 1) as usize;
+        components[y * width + x]
     };
     for y in 0..height {
         for x in 0..width {
@@ -1736,6 +2367,14 @@ fn normalized_index(index: usize, length: usize) -> f32 {
     }
 }
 
+fn normalized_coordinate(coordinate: f32, length: usize) -> f32 {
+    if length <= 1 {
+        0.0
+    } else {
+        coordinate / (length - 1) as f32
+    }
+}
+
 fn detector_rho(index: usize, count: usize, radius: f32) -> f32 {
     (normalized_index(index, count) * 2.0 - 1.0) * radius
 }
@@ -1786,6 +2425,372 @@ fn finish_pixel(mut pixel: PixelF32, settings: Settings) -> PixelF32 {
 mod tests {
     use super::*;
 
+    fn assert_pixels_bits_eq(actual: &[PixelF32], expected: &[PixelF32]) {
+        assert_eq!(actual.len(), expected.len());
+        for (index, (actual, expected)) in actual.iter().zip(expected).enumerate() {
+            assert_eq!(
+                actual.alpha.to_bits(),
+                expected.alpha.to_bits(),
+                "pixel {index} alpha"
+            );
+            assert_eq!(
+                actual.red.to_bits(),
+                expected.red.to_bits(),
+                "pixel {index} red"
+            );
+            assert_eq!(
+                actual.green.to_bits(),
+                expected.green.to_bits(),
+                "pixel {index} green"
+            );
+            assert_eq!(
+                actual.blue.to_bits(),
+                expected.blue.to_bits(),
+                "pixel {index} blue"
+            );
+        }
+    }
+
+    fn render_polar_reference(
+        source: &[PixelF32],
+        src_width: usize,
+        src_height: usize,
+        out_width: usize,
+        out_height: usize,
+        settings: Settings,
+    ) -> Vec<PixelF32> {
+        let (center, radius) = resolve_geometry(out_width, out_height, settings);
+        let mut output = vec![TRANSPARENT; out_width * out_height];
+        for y in 0..out_height {
+            let v = normalized_index(y, out_height);
+            for x in 0..out_width {
+                let u = normalized_index(x, out_width);
+                let coordinate = match (settings.space, settings.direction) {
+                    (Space::Polar, Direction::Forward) => {
+                        let theta = settings.angle_offset + u * TAU;
+                        let r = v * radius;
+                        Some((
+                            center.0 + r * theta.cos() / settings.pixel_scale.0,
+                            center.1 + r * theta.sin() / settings.pixel_scale.1,
+                        ))
+                    }
+                    (Space::LogPolar, Direction::Forward) => {
+                        let theta = settings.angle_offset + u * TAU;
+                        let min_radius = settings.log_min_radius.min(radius * 0.999).max(0.001);
+                        let r = min_radius * (radius / min_radius).powf(v);
+                        Some((
+                            center.0 + r * theta.cos() / settings.pixel_scale.0,
+                            center.1 + r * theta.sin() / settings.pixel_scale.1,
+                        ))
+                    }
+                    (Space::SpiralPolar, Direction::Forward) => {
+                        let theta = settings.angle_offset + (u + v * settings.spiral_turns) * TAU;
+                        let r = v * radius;
+                        Some((
+                            center.0 + r * theta.cos() / settings.pixel_scale.0,
+                            center.1 + r * theta.sin() / settings.pixel_scale.1,
+                        ))
+                    }
+                    (Space::Polar | Space::LogPolar | Space::SpiralPolar, Direction::Inverse) => {
+                        let dx = (x as f32 - center.0) * settings.pixel_scale.0;
+                        let dy = (y as f32 - center.1) * settings.pixel_scale.1;
+                        let r = dx.hypot(dy);
+                        if r > radius {
+                            None
+                        } else {
+                            let radial_position = r / radius;
+                            let spiral_phase = if settings.space == Space::SpiralPolar {
+                                radial_position * settings.spiral_turns * TAU
+                            } else {
+                                0.0
+                            };
+                            let angle_u = (dy.atan2(dx) - settings.angle_offset - spiral_phase)
+                                .rem_euclid(TAU)
+                                / TAU;
+                            let radius_v = if settings.space == Space::LogPolar {
+                                let min_radius =
+                                    settings.log_min_radius.min(radius * 0.999).max(0.001);
+                                if r < min_radius {
+                                    return_coordinate_none()
+                                } else {
+                                    (r / min_radius).ln() / (radius / min_radius).ln()
+                                }
+                            } else {
+                                r / radius
+                            };
+                            if radius_v.is_finite() {
+                                Some((
+                                    angle_u * src_width.saturating_sub(1) as f32,
+                                    radius_v * src_height.saturating_sub(1) as f32,
+                                ))
+                            } else {
+                                None
+                            }
+                        }
+                    }
+                    _ => unreachable!(),
+                };
+                let pixel = coordinate
+                    .map(|(sx, sy)| {
+                        sample(
+                            source,
+                            src_width,
+                            src_height,
+                            sx,
+                            sy,
+                            settings.interpolation,
+                            settings.edge,
+                        )
+                    })
+                    .unwrap_or(TRANSPARENT);
+                output[y * out_width + x] = finish_pixel(pixel, settings);
+            }
+        }
+        output
+    }
+
+    fn sobel_edge_channels_reference(
+        source: &[PixelF32],
+        width: usize,
+        height: usize,
+        pixel_scale: (f32, f32),
+        mode: HoughChannels,
+    ) -> Vec<[f32; 4]> {
+        let mut result = vec![[0.0; 4]; width * height];
+        let get = |x: i64, y: i64| {
+            analysis_components(
+                sample_nearest(source, width, height, x as f32, y as f32, SampleEdge::Clamp),
+                mode,
+            )
+        };
+        for y in 0..height {
+            for x in 0..width {
+                let x = x as i64;
+                let y = y as i64;
+                let p00 = get(x - 1, y - 1);
+                let p10 = get(x, y - 1);
+                let p20 = get(x + 1, y - 1);
+                let p01 = get(x - 1, y);
+                let p21 = get(x + 1, y);
+                let p02 = get(x - 1, y + 1);
+                let p12 = get(x, y + 1);
+                let p22 = get(x + 1, y + 1);
+                let mut magnitude = [0.0; 4];
+                for channel in 0..4 {
+                    let gx = (-p00[channel] + p20[channel] - 2.0 * p01[channel]
+                        + 2.0 * p21[channel]
+                        - p02[channel]
+                        + p22[channel])
+                        / pixel_scale.0.max(1.0e-6);
+                    let gy = (-p00[channel] - 2.0 * p10[channel] - p20[channel]
+                        + p02[channel]
+                        + 2.0 * p12[channel]
+                        + p22[channel])
+                        / pixel_scale.1.max(1.0e-6);
+                    magnitude[channel] = (gx.hypot(gy) * 0.25).clamp(0.0, 1.0);
+                }
+                result[y as usize * width + x as usize] = magnitude;
+            }
+        }
+        result
+    }
+
+    fn forward_radon_reference(
+        source: &[PixelF32],
+        width: usize,
+        height: usize,
+        settings: Settings,
+    ) -> Vec<PixelF32> {
+        let (center, radius) = resolve_geometry(width, height, settings);
+        let ray_samples = effective_ray_samples(settings);
+        let mut result = vec![TRANSPARENT; settings.angle_samples * settings.detector_samples];
+        for detector in 0..settings.detector_samples {
+            let rho = detector_rho(detector, settings.detector_samples, radius);
+            for angle in 0..settings.angle_samples {
+                let theta =
+                    settings.angle_offset + angle as f32 * PI / settings.angle_samples as f32;
+                let cos = theta.cos();
+                let sin = theta.sin();
+                let mut sum = TRANSPARENT;
+                for ray in 0..ray_samples {
+                    let t = detector_rho(ray, ray_samples, radius);
+                    let pixel = sample_bilinear(
+                        source,
+                        width,
+                        height,
+                        center.0 + (rho * cos - t * sin) / settings.pixel_scale.0,
+                        center.1 + (rho * sin + t * cos) / settings.pixel_scale.1,
+                        SampleEdge::Transparent,
+                    );
+                    let endpoint_weight = if ray == 0 || ray + 1 == ray_samples {
+                        0.5
+                    } else {
+                        1.0
+                    };
+                    sum = add_pixel(sum, scale_pixel(pixel, endpoint_weight));
+                }
+                result[detector * settings.angle_samples + angle] =
+                    scale_pixel(sum, 1.0 / ray_samples.saturating_sub(1).max(1) as f32);
+            }
+        }
+        result
+    }
+
+    fn forward_hough_reference(
+        source: &[PixelF32],
+        width: usize,
+        height: usize,
+        settings: Settings,
+    ) -> Vec<PixelF32> {
+        let (center, radius) = resolve_geometry(width, height, settings);
+        let ray_samples = effective_ray_samples(settings);
+        let edges = sobel_edge_channels_reference(
+            source,
+            width,
+            height,
+            settings.pixel_scale,
+            settings.hough_channels,
+        );
+        let mut votes = vec![[0.0_f32; 4]; settings.angle_samples * settings.detector_samples];
+        let mut maximum = [0.0_f32; 4];
+        let alpha_fallback = if source.is_empty() {
+            0.0
+        } else {
+            source.iter().map(|pixel| pixel.alpha).sum::<f32>() / source.len() as f32
+        };
+        for detector in 0..settings.detector_samples {
+            let rho = detector_rho(detector, settings.detector_samples, radius);
+            for angle in 0..settings.angle_samples {
+                let theta =
+                    settings.angle_offset + angle as f32 * PI / settings.angle_samples as f32;
+                let cos = theta.cos();
+                let sin = theta.sin();
+                let mut sum = [0.0_f32; 4];
+                for ray in 0..ray_samples {
+                    let t = detector_rho(ray, ray_samples, radius);
+                    let magnitude = sample_channel_bilinear(
+                        &edges,
+                        width,
+                        height,
+                        center.0 + (rho * cos - t * sin) / settings.pixel_scale.0,
+                        center.1 + (rho * sin + t * cos) / settings.pixel_scale.1,
+                    );
+                    for channel in 0..4 {
+                        if magnitude[channel] >= settings.hough_threshold {
+                            sum[channel] += if settings.weighted_hough {
+                                magnitude[channel]
+                            } else {
+                                1.0
+                            };
+                        }
+                    }
+                }
+                let vote = sum.map(|value| value / ray_samples as f32);
+                votes[detector * settings.angle_samples + angle] = vote;
+                for channel in 0..4 {
+                    maximum[channel] = maximum[channel].max(vote[channel]);
+                }
+            }
+        }
+        votes
+            .into_iter()
+            .map(|value| {
+                let normalized = [
+                    value[0] / maximum[0].max(1.0e-8),
+                    value[1] / maximum[1].max(1.0e-8),
+                    value[2] / maximum[2].max(1.0e-8),
+                    if maximum[3] <= 1.0e-8 {
+                        alpha_fallback
+                    } else {
+                        value[3] / maximum[3]
+                    },
+                ];
+                if settings.hough_channels.is_rgba() {
+                    PixelF32 {
+                        alpha: normalized[3],
+                        red: normalized[0],
+                        green: normalized[1],
+                        blue: normalized[2],
+                    }
+                } else {
+                    gray_pixel(normalized[0])
+                }
+            })
+            .collect()
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn backproject_reference(
+        sinogram: &[PixelF32],
+        angles: usize,
+        detectors: usize,
+        width: usize,
+        height: usize,
+        settings: Settings,
+        normalize: bool,
+    ) -> Vec<PixelF32> {
+        let (center, radius) = resolve_geometry(width, height, settings);
+        let mut result = vec![TRANSPARENT; width * height];
+        let mut maximum = 0.0_f32;
+        for y in 0..height {
+            for x in 0..width {
+                let dx = (x as f32 - center.0) * settings.pixel_scale.0;
+                let dy = (y as f32 - center.1) * settings.pixel_scale.1;
+                let mut sum = TRANSPARENT;
+                for angle in 0..angles {
+                    let theta = settings.angle_offset + angle as f32 * PI / angles as f32;
+                    let rho = dx * theta.cos() + dy * theta.sin();
+                    let detector = rho_to_detector(rho, detectors, radius);
+                    sum = add_pixel(
+                        sum,
+                        sample_sinogram_detector(sinogram, angles, detectors, angle, detector),
+                    );
+                }
+                let pixel = scale_pixel(sum, PI / angles as f32);
+                maximum = maximum.max(pixel.red.max(pixel.green).max(pixel.blue).abs());
+                result[y * width + x] = pixel;
+            }
+        }
+        if normalize {
+            let scale = 1.0 / maximum.max(1.0e-8);
+            for pixel in &mut result {
+                *pixel = scale_pixel(*pixel, scale);
+                pixel.alpha = 1.0;
+            }
+        }
+        result
+    }
+
+    fn ram_lak_filter_reference(
+        sinogram: &[PixelF32],
+        angles: usize,
+        detectors: usize,
+        radius: usize,
+    ) -> Vec<PixelF32> {
+        let mut result = vec![TRANSPARENT; sinogram.len()];
+        for detector in 0..detectors {
+            for angle in 0..angles {
+                let mut sum = TRANSPARENT;
+                for offset in -(radius as isize)..=(radius as isize) {
+                    let source_detector = detector as isize + offset;
+                    if !(0..detectors as isize).contains(&source_detector) {
+                        continue;
+                    }
+                    let coefficient = ram_lak_coefficient(offset);
+                    sum = add_pixel(
+                        sum,
+                        scale_pixel(
+                            sinogram[source_detector as usize * angles + angle],
+                            coefficient,
+                        ),
+                    );
+                }
+                result[detector * angles + angle] = sum;
+            }
+        }
+        result
+    }
+
     fn test_settings(space: Space) -> Settings {
         Settings {
             space,
@@ -1812,7 +2817,314 @@ mod tests {
             focus_ratio: 0.5,
             coordinate_extent: 3.0,
             hough_channels: HoughChannels::Luminance,
+            post_transform: PostTransform {
+                anchor: (4.0, 3.0),
+                position: (4.0, 3.0),
+                scale: (1.0, 1.0),
+                rotation: 0.0,
+                skew: 0.0,
+                skew_axis: 0.0,
+            },
         }
+    }
+
+    fn representative_pixels(width: usize, height: usize) -> Vec<PixelF32> {
+        (0..width * height)
+            .map(|index| {
+                let x = index % width;
+                let y = index / width;
+                PixelF32 {
+                    alpha: 0.35 + ((x * 7 + y * 3) % 11) as f32 / 17.0,
+                    red: ((x * 5 + y * 2) % 13) as f32 / 12.0,
+                    green: ((x * 3 + y * 7) % 17) as f32 / 16.0,
+                    blue: ((x * 11 + y * 5) % 19) as f32 / 18.0,
+                }
+            })
+            .collect()
+    }
+
+    #[test]
+    fn post_transform_inverse_undoes_full_affine_mapping() {
+        let post_transform = PostTransform {
+            anchor: (47.0, 31.0),
+            position: (123.0, -18.0),
+            scale: (-1.25, 0.65),
+            rotation: 37.0_f32.to_radians(),
+            skew: -21.0_f32.to_radians(),
+            skew_axis: 14.0_f32.to_radians(),
+        };
+        let pixel_scale = (2.4, 3.0);
+        let inverse = post_transform
+            .matrix()
+            .inverse()
+            .expect("non-zero scale must be invertible");
+        for source in [(0.0, 0.0), (47.0, 31.0), (103.0, -18.0)] {
+            let destination = forward_post_transform_point(source, post_transform, pixel_scale);
+            let rebuilt =
+                inverse_post_transform_point(destination, post_transform, pixel_scale, inverse);
+            assert!((rebuilt.0 - source.0).abs() < 1.0e-4);
+            assert!((rebuilt.1 - source.1).abs() < 1.0e-4);
+        }
+    }
+
+    #[test]
+    fn identity_post_transform_is_bitwise_compatible_in_every_space() {
+        let width = 9;
+        let height = 7;
+        let source = representative_pixels(width, height);
+        for space in [
+            Space::Polar,
+            Space::LogPolar,
+            Space::SquareDisc,
+            Space::SpiralPolar,
+            Space::Elliptic,
+            Space::Parabolic,
+            Space::Bipolar,
+            Space::Radon,
+            Space::LineHough,
+        ] {
+            for direction in [Direction::Forward, Direction::Inverse] {
+                let mut baseline_settings = test_settings(space);
+                baseline_settings.direction = direction;
+                baseline_settings.angle_samples = width;
+                baseline_settings.detector_samples = height;
+                baseline_settings.ray_samples = 9;
+                baseline_settings.filter_radius = 3;
+                let baseline = if space.is_integral() {
+                    render_integral(&source, width, height, width, height, baseline_settings)
+                } else {
+                    render_coordinates(&source, width, height, width, height, baseline_settings)
+                };
+
+                let moved_identity = Settings {
+                    post_transform: PostTransform {
+                        anchor: (812.5, -209.25),
+                        position: (812.5, -209.25),
+                        ..baseline_settings.post_transform
+                    },
+                    ..baseline_settings
+                };
+                let actual = if space.is_integral() {
+                    render_integral(&source, width, height, width, height, moved_identity)
+                } else {
+                    render_coordinates(&source, width, height, width, height, moved_identity)
+                };
+                assert_pixels_bits_eq(&actual, &baseline);
+            }
+        }
+    }
+
+    #[test]
+    fn post_translation_is_composed_before_each_coordinate_formula() {
+        let width = 9;
+        let height = 7;
+        let source = representative_pixels(width, height);
+        for space in [
+            Space::Polar,
+            Space::LogPolar,
+            Space::SquareDisc,
+            Space::SpiralPolar,
+            Space::Elliptic,
+            Space::Parabolic,
+            Space::Bipolar,
+        ] {
+            for direction in [Direction::Forward, Direction::Inverse] {
+                let baseline_settings = Settings {
+                    direction,
+                    ..test_settings(space)
+                };
+                let baseline =
+                    render_coordinates(&source, width, height, width, height, baseline_settings);
+                let translated_settings = Settings {
+                    post_transform: PostTransform {
+                        position: (
+                            baseline_settings.post_transform.position.0 + 1.0,
+                            baseline_settings.post_transform.position.1,
+                        ),
+                        ..baseline_settings.post_transform
+                    },
+                    ..baseline_settings
+                };
+                let translated =
+                    render_coordinates(&source, width, height, width, height, translated_settings);
+                for y in 0..height {
+                    for x in 1..width {
+                        assert_pixels_bits_eq(
+                            &translated[y * width + x..=y * width + x],
+                            &baseline[y * width + x - 1..=y * width + x - 1],
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn transformed_radon_evaluates_unclamped_projection_coordinates() {
+        let width = 9;
+        let height = 7;
+        let settings = Settings {
+            angle_samples: width,
+            detector_samples: height,
+            ray_samples: 9,
+            post_transform: PostTransform {
+                position: (13.0, 3.0),
+                ..test_settings(Space::Radon).post_transform
+            },
+            ..test_settings(Space::Radon)
+        };
+        let inverse = settings
+            .post_transform
+            .matrix()
+            .inverse()
+            .expect("translation is invertible");
+        let (theta, detector_v) =
+            transformed_projection_coordinate(0, 0, width, height, settings, inverse);
+        // A nine-pixel right translation maps the first output sample to x=-9.
+        // The angle remains outside the nominal [0, PI] interval instead of
+        // being clamped or tiled from a finite accumulator image.
+        assert!((theta - (-9.0 / 8.0 * PI)).abs() < 1.0e-6);
+        assert_eq!(detector_v.to_bits(), 0.0_f32.to_bits());
+
+        let source = representative_pixels(width, height);
+        let transformed =
+            forward_radon_post_transformed(&source, width, height, width, height, settings);
+        assert_eq!(transformed.len(), width * height);
+        assert!(transformed.iter().all(|pixel| {
+            pixel.alpha.is_finite()
+                && pixel.red.is_finite()
+                && pixel.green.is_finite()
+                && pixel.blue.is_finite()
+        }));
+    }
+
+    #[test]
+    fn polar_coordinate_caches_match_reference_bitwise() {
+        let width = 11;
+        let height = 9;
+        let source = representative_pixels(width, height);
+        for space in [Space::Polar, Space::LogPolar, Space::SpiralPolar] {
+            for direction in [Direction::Forward, Direction::Inverse] {
+                let settings = Settings {
+                    direction,
+                    center_mode: CenterMode::Custom,
+                    center: (4.25, 3.75),
+                    radius_mode: RadiusMode::Custom,
+                    radius: 5.125,
+                    log_min_radius: 0.625,
+                    angle_offset: 0.371,
+                    pixel_scale: (1.125, 0.875),
+                    ..test_settings(space)
+                };
+                let actual = render_coordinates(&source, width, height, width, height, settings);
+                let expected =
+                    render_polar_reference(&source, width, height, width, height, settings);
+                assert_pixels_bits_eq(&actual, &expected);
+            }
+        }
+    }
+
+    #[test]
+    fn projection_geometry_caches_match_reference_bitwise() {
+        let width = 9;
+        let height = 7;
+        let source = representative_pixels(width, height);
+        let settings = Settings {
+            angle_samples: 13,
+            detector_samples: 11,
+            ray_samples: 15,
+            angle_offset: -0.217,
+            center_mode: CenterMode::Custom,
+            center: (3.75, 2.625),
+            radius_mode: RadiusMode::Custom,
+            radius: 4.875,
+            pixel_scale: (1.25, 0.8),
+            ..test_settings(Space::Radon)
+        };
+
+        let actual_sinogram = forward_radon(&source, width, height, settings);
+        let expected_sinogram = forward_radon_reference(&source, width, height, settings);
+        assert_pixels_bits_eq(&actual_sinogram, &expected_sinogram);
+
+        let actual_backprojection = backproject(
+            &actual_sinogram,
+            settings.angle_samples,
+            settings.detector_samples,
+            width,
+            height,
+            settings,
+            false,
+        );
+        let expected_backprojection = backproject_reference(
+            &expected_sinogram,
+            settings.angle_samples,
+            settings.detector_samples,
+            width,
+            height,
+            settings,
+            false,
+        );
+        assert_pixels_bits_eq(&actual_backprojection, &expected_backprojection);
+
+        let actual_filtered = ram_lak_filter(
+            &actual_sinogram,
+            settings.angle_samples,
+            settings.detector_samples,
+            5,
+        );
+        let expected_filtered = ram_lak_filter_reference(
+            &expected_sinogram,
+            settings.angle_samples,
+            settings.detector_samples,
+            5,
+        );
+        assert_pixels_bits_eq(&actual_filtered, &expected_filtered);
+    }
+
+    #[test]
+    fn rgba_hough_and_sobel_cache_match_reference_bitwise() {
+        let width = 9;
+        let height = 7;
+        let source = representative_pixels(width, height);
+        let settings = Settings {
+            angle_samples: 13,
+            detector_samples: 11,
+            ray_samples: 15,
+            angle_offset: 0.413,
+            hough_threshold: 0.08,
+            hough_channels: HoughChannels::Rgba,
+            pixel_scale: (1.125, 0.75),
+            ..test_settings(Space::LineHough)
+        };
+
+        for mode in [
+            HoughChannels::Luminance,
+            HoughChannels::Rgba,
+            HoughChannels::Red,
+            HoughChannels::Green,
+            HoughChannels::Blue,
+            HoughChannels::Alpha,
+        ] {
+            let actual_edges =
+                sobel_edge_channels(&source, width, height, settings.pixel_scale, mode);
+            let expected_edges =
+                sobel_edge_channels_reference(&source, width, height, settings.pixel_scale, mode);
+            assert_eq!(actual_edges.len(), expected_edges.len());
+            for (index, (actual, expected)) in actual_edges.iter().zip(&expected_edges).enumerate()
+            {
+                for channel in 0..4 {
+                    assert_eq!(
+                        actual[channel].to_bits(),
+                        expected[channel].to_bits(),
+                        "mode {mode:?}, edge {index}, channel {channel}"
+                    );
+                }
+            }
+        }
+
+        let actual = forward_hough(&source, width, height, settings);
+        let expected = forward_hough_reference(&source, width, height, settings);
+        assert_pixels_bits_eq(&actual, &expected);
     }
 
     #[test]

--- a/plugins/space-convert/src/lib.rs
+++ b/plugins/space-convert/src/lib.rs
@@ -1,0 +1,2084 @@
+#![allow(clippy::drop_non_drop, clippy::question_mark)]
+
+use after_effects as ae;
+use std::env;
+use std::f32::consts::{FRAC_PI_4, PI, TAU};
+
+use ae::pf::*;
+use utils::ToPixel;
+use utils::image::{
+    SampleEdge, TRANSPARENT, luma, read_layer, sample_bilinear, sample_nearest, sanitize_pixel,
+};
+
+const PLUGIN_DESCRIPTION: &str = "Converts images between Cartesian, polar, spiral, elliptic, parabolic, bipolar, Radon, and line Hough representations.";
+const MAX_INTEGRAL_SAMPLE_EVALUATIONS: usize = 12_000_000;
+
+#[derive(Eq, PartialEq, Hash, Clone, Copy, Debug)]
+enum Params {
+    TransformStart,
+    Space,
+    Direction,
+    CenterMode,
+    Center,
+    RadiusMode,
+    Radius,
+    LogMinRadius,
+    AngleOffset,
+    TransformEnd,
+    AnalysisStart,
+    AngleSamples,
+    DetectorSamples,
+    RaySamples,
+    HoughThreshold,
+    WeightedHough,
+    FilterRadius,
+    AnalysisEnd,
+    SamplingStart,
+    Interpolation,
+    Edge,
+    OutputGain,
+    OutputBias,
+    ClampOutput,
+    SamplingEnd,
+    SpaceSpecificStart,
+    SpiralTurns,
+    FocusRatio,
+    CoordinateExtent,
+    HoughChannels,
+    SpaceSpecificEnd,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Space {
+    Polar,
+    LogPolar,
+    SquareDisc,
+    Radon,
+    LineHough,
+    SpiralPolar,
+    Elliptic,
+    Parabolic,
+    Bipolar,
+}
+
+impl Space {
+    fn from_popup(value: i32) -> Self {
+        match value {
+            2 => Self::LogPolar,
+            3 => Self::SquareDisc,
+            4 => Self::Radon,
+            5 => Self::LineHough,
+            6 => Self::SpiralPolar,
+            7 => Self::Elliptic,
+            8 => Self::Parabolic,
+            9 => Self::Bipolar,
+            _ => Self::Polar,
+        }
+    }
+
+    fn is_integral(self) -> bool {
+        matches!(self, Self::Radon | Self::LineHough)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Direction {
+    Forward,
+    Inverse,
+}
+
+impl Direction {
+    fn from_popup(value: i32) -> Self {
+        if value == 2 {
+            Self::Inverse
+        } else {
+            Self::Forward
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CenterMode {
+    LayerCenter,
+    Custom,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RadiusMode {
+    Auto,
+    Inscribed,
+    Custom,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Interpolation {
+    Nearest,
+    Bilinear,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum HoughChannels {
+    Luminance,
+    Rgba,
+    Red,
+    Green,
+    Blue,
+    Alpha,
+}
+
+impl HoughChannels {
+    fn from_popup(value: i32) -> Self {
+        match value {
+            2 => Self::Rgba,
+            3 => Self::Red,
+            4 => Self::Green,
+            5 => Self::Blue,
+            6 => Self::Alpha,
+            _ => Self::Luminance,
+        }
+    }
+
+    fn is_rgba(self) -> bool {
+        self == Self::Rgba
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Settings {
+    space: Space,
+    direction: Direction,
+    center_mode: CenterMode,
+    center: (f32, f32),
+    radius_mode: RadiusMode,
+    radius: f32,
+    log_min_radius: f32,
+    angle_offset: f32,
+    angle_samples: usize,
+    detector_samples: usize,
+    ray_samples: usize,
+    hough_threshold: f32,
+    weighted_hough: bool,
+    filter_radius: usize,
+    interpolation: Interpolation,
+    edge: SampleEdge,
+    output_gain: f32,
+    output_bias: f32,
+    clamp_output: bool,
+    pixel_scale: (f32, f32),
+    spiral_turns: f32,
+    focus_ratio: f32,
+    coordinate_extent: f32,
+    hough_channels: HoughChannels,
+}
+
+#[derive(Default)]
+struct Plugin {
+    aegp_id: Option<ae::aegp::PluginId>,
+}
+
+struct LayerCheckoutGuard<const N: usize> {
+    callbacks: SmartRenderCallbacks,
+    checkout_ids: [u32; N],
+    count: usize,
+}
+
+impl<const N: usize> LayerCheckoutGuard<N> {
+    fn new(callbacks: SmartRenderCallbacks) -> Self {
+        Self {
+            callbacks,
+            checkout_ids: [0; N],
+            count: 0,
+        }
+    }
+
+    fn checkout(&mut self, checkout_id: u32) -> Result<Option<Layer>, Error> {
+        assert!(self.count < N, "layer checkout guard capacity exceeded");
+        let layer = self.callbacks.checkout_layer_pixels(checkout_id)?;
+        self.checkout_ids[self.count] = checkout_id;
+        self.count += 1;
+        Ok(layer)
+    }
+
+    fn checkin_all(&mut self) -> Result<(), Error> {
+        let mut first_error = None;
+        while self.count > 0 {
+            self.count -= 1;
+            if let Err(error) = self
+                .callbacks
+                .checkin_layer_pixels(self.checkout_ids[self.count])
+                && first_error.is_none()
+            {
+                first_error = Some(error);
+            }
+        }
+        first_error.map_or(Ok(()), Err)
+    }
+}
+
+impl<const N: usize> Drop for LayerCheckoutGuard<N> {
+    fn drop(&mut self) {
+        let _ = self.checkin_all();
+    }
+}
+
+ae::define_effect!(Plugin, (), Params);
+
+impl AdobePluginGlobal for Plugin {
+    fn params_setup(
+        &self,
+        params: &mut ae::Parameters<Params>,
+        _in_data: InData,
+        _: OutData,
+    ) -> Result<(), Error> {
+        let supervise = || {
+            ae::ParamFlag::SUPERVISE
+                | ae::ParamFlag::CANNOT_TIME_VARY
+                | ae::ParamFlag::CANNOT_INTERP
+        };
+
+        params.add_group(
+            Params::TransformStart,
+            Params::TransformEnd,
+            "Transform",
+            false,
+            |params| {
+                params.add_with_flags(
+                    Params::Space,
+                    "Space",
+                    PopupDef::setup(|d| {
+                        d.set_options(&[
+                            "Polar",
+                            "Log-Polar",
+                            "Square-Disc",
+                            "Radon",
+                            "Line Hough",
+                            "Spiral Polar",
+                            "Elliptic Coordinates",
+                            "Parabolic Coordinates",
+                            "Bipolar Coordinates",
+                        ]);
+                        d.set_default(1);
+                    }),
+                    supervise(),
+                    ae::ParamUIFlags::empty(),
+                )?;
+                params.add_with_flags(
+                    Params::Direction,
+                    "Direction",
+                    PopupDef::setup(|d| {
+                        d.set_options(&["Forward", "Inverse (Approximate)"]);
+                        d.set_default(1);
+                    }),
+                    supervise(),
+                    ae::ParamUIFlags::empty(),
+                )?;
+                params.add_with_flags(
+                    Params::CenterMode,
+                    "Center",
+                    PopupDef::setup(|d| {
+                        d.set_options(&["Layer Center", "Custom"]);
+                        d.set_default(1);
+                    }),
+                    supervise(),
+                    ae::ParamUIFlags::empty(),
+                )?;
+                params.add(
+                    Params::Center,
+                    "Custom Center",
+                    PointDef::setup(|d| {
+                        d.set_default((0.0, 0.0));
+                    }),
+                )?;
+                params.add_with_flags(
+                    Params::RadiusMode,
+                    "Radius",
+                    PopupDef::setup(|d| {
+                        d.set_options(&["Auto (Full Coverage)", "Inscribed", "Custom"]);
+                        d.set_default(1);
+                    }),
+                    supervise(),
+                    ae::ParamUIFlags::empty(),
+                )?;
+                params.add(
+                    Params::Radius,
+                    "Custom Radius",
+                    FloatSliderDef::setup(|d| {
+                        d.set_valid_min(0.01);
+                        d.set_valid_max(100000.0);
+                        d.set_slider_min(1.0);
+                        d.set_slider_max(4000.0);
+                        d.set_default(500.0);
+                        d.set_precision(2);
+                    }),
+                )?;
+                params.add(
+                    Params::LogMinRadius,
+                    "Log Minimum Radius",
+                    FloatSliderDef::setup(|d| {
+                        d.set_valid_min(0.001);
+                        d.set_valid_max(10000.0);
+                        d.set_slider_min(0.1);
+                        d.set_slider_max(100.0);
+                        d.set_default(1.0);
+                        d.set_precision(3);
+                    }),
+                )?;
+                params.add(
+                    Params::AngleOffset,
+                    "Angle Offset",
+                    AngleDef::setup(|d| {
+                        d.set_default(0.0);
+                    }),
+                )?;
+                Ok(())
+            },
+        )?;
+
+        params.add_group(
+            Params::AnalysisStart,
+            Params::AnalysisEnd,
+            "Analysis Quality",
+            true,
+            |params| {
+                add_integer_slider(
+                    params,
+                    Params::AngleSamples,
+                    "Angle Samples",
+                    8.0,
+                    720.0,
+                    180.0,
+                )?;
+                add_integer_slider(
+                    params,
+                    Params::DetectorSamples,
+                    "Detector Samples",
+                    16.0,
+                    2048.0,
+                    256.0,
+                )?;
+                add_integer_slider(
+                    params,
+                    Params::RaySamples,
+                    "Samples per Ray",
+                    8.0,
+                    2048.0,
+                    256.0,
+                )?;
+                params.add(
+                    Params::HoughThreshold,
+                    "Edge Threshold",
+                    FloatSliderDef::setup(|d| {
+                        d.set_valid_min(0.0);
+                        d.set_valid_max(1.0);
+                        d.set_slider_min(0.0);
+                        d.set_slider_max(1.0);
+                        d.set_default(0.15);
+                        d.set_precision(3);
+                    }),
+                )?;
+                params.add(
+                    Params::WeightedHough,
+                    "Weighted Votes",
+                    CheckBoxDef::setup(|d| {
+                        d.set_default(true);
+                    }),
+                )?;
+                add_integer_slider(
+                    params,
+                    Params::FilterRadius,
+                    "Ram-Lak Radius",
+                    1.0,
+                    127.0,
+                    31.0,
+                )?;
+                Ok(())
+            },
+        )?;
+
+        params.add_group(
+            Params::SamplingStart,
+            Params::SamplingEnd,
+            "Sampling / Output",
+            true,
+            |params| {
+                params.add(
+                    Params::Interpolation,
+                    "Interpolation",
+                    PopupDef::setup(|d| {
+                        d.set_options(&["Nearest", "Bilinear"]);
+                        d.set_default(2);
+                    }),
+                )?;
+                params.add(
+                    Params::Edge,
+                    "Edge",
+                    PopupDef::setup(|d| {
+                        d.set_options(&["Transparent", "Clamp", "Tile", "Mirror"]);
+                        d.set_default(1);
+                    }),
+                )?;
+                params.add(
+                    Params::OutputGain,
+                    "Output Gain",
+                    FloatSliderDef::setup(|d| {
+                        d.set_valid_min(-100.0);
+                        d.set_valid_max(100.0);
+                        d.set_slider_min(0.0);
+                        d.set_slider_max(4.0);
+                        d.set_default(1.0);
+                        d.set_precision(3);
+                    }),
+                )?;
+                params.add(
+                    Params::OutputBias,
+                    "Output Bias",
+                    FloatSliderDef::setup(|d| {
+                        d.set_valid_min(-100.0);
+                        d.set_valid_max(100.0);
+                        d.set_slider_min(-1.0);
+                        d.set_slider_max(1.0);
+                        d.set_default(0.0);
+                        d.set_precision(3);
+                    }),
+                )?;
+                params.add(
+                    Params::ClampOutput,
+                    "Clamp Output",
+                    CheckBoxDef::setup(|d| {
+                        d.set_default(true);
+                    }),
+                )?;
+                Ok(())
+            },
+        )?;
+
+        // Appended after the original parameter block to preserve the indices used by
+        // projects created with the first release.
+        params.add_group(
+            Params::SpaceSpecificStart,
+            Params::SpaceSpecificEnd,
+            "Space-specific",
+            true,
+            |params| {
+                params.add(
+                    Params::SpiralTurns,
+                    "Spiral Turns",
+                    FloatSliderDef::setup(|d| {
+                        d.set_valid_min(-100.0);
+                        d.set_valid_max(100.0);
+                        d.set_slider_min(-12.0);
+                        d.set_slider_max(12.0);
+                        d.set_default(1.0);
+                        d.set_precision(3);
+                    }),
+                )?;
+                params.add(
+                    Params::FocusRatio,
+                    "Focus / Radius",
+                    FloatSliderDef::setup(|d| {
+                        d.set_valid_min(0.001);
+                        d.set_valid_max(0.999);
+                        d.set_slider_min(0.05);
+                        d.set_slider_max(0.95);
+                        d.set_default(0.5);
+                        d.set_precision(3);
+                    }),
+                )?;
+                params.add(
+                    Params::CoordinateExtent,
+                    "Coordinate Extent",
+                    FloatSliderDef::setup(|d| {
+                        d.set_valid_min(0.05);
+                        d.set_valid_max(20.0);
+                        d.set_slider_min(0.25);
+                        d.set_slider_max(8.0);
+                        d.set_default(3.0);
+                        d.set_precision(3);
+                    }),
+                )?;
+                params.add_with_flags(
+                    Params::HoughChannels,
+                    "Line Hough Channels",
+                    PopupDef::setup(|d| {
+                        d.set_options(&["Luminance", "RGBA", "Red", "Green", "Blue", "Alpha"]);
+                        d.set_default(1);
+                    }),
+                    supervise(),
+                    ae::ParamUIFlags::empty(),
+                )?;
+                Ok(())
+            },
+        )?;
+        Ok(())
+    }
+
+    fn handle_command(
+        &mut self,
+        cmd: ae::Command,
+        in_data: InData,
+        mut out_data: OutData,
+        params: &mut ae::Parameters<Params>,
+    ) -> Result<(), ae::Error> {
+        match cmd {
+            ae::Command::About => out_data.set_return_msg(
+                format!(
+                    "AOD_SpaceConvert - {version}\r\r{PLUGIN_DESCRIPTION}\rCopyright (c) 2026-{year} Aodaruma",
+                    version = env!("CARGO_PKG_VERSION"),
+                    year = env!("BUILD_YEAR")
+                )
+                .as_str(),
+            ),
+            ae::Command::GlobalSetup => {
+                out_data.set_out_flag(OutFlags::SendUpdateParamsUi, true);
+                out_data.set_out_flag2(OutFlags2::SupportsSmartRender, true);
+                out_data.set_out_flag2(OutFlags2::ParamGroupStartCollapsedFlag, true);
+                out_data.set_out_flag2(OutFlags2::RevealsZeroAlpha, true);
+                if let Ok(suite) = ae::aegp::suites::Utility::new()
+                    && let Ok(plugin_id) = suite.register_with_aegp("AOD_SpaceConvert")
+                {
+                    self.aegp_id = Some(plugin_id);
+                }
+            }
+            ae::Command::Render { in_layer, out_layer } => {
+                self.do_render(in_data, in_layer, out_layer, params)?;
+            }
+            ae::Command::SmartPreRender { mut extra } => {
+                let request = extra.output_request();
+                let callbacks = extra.callbacks();
+                let query = callbacks.checkout_layer(
+                    0,
+                    1000,
+                    &request,
+                    in_data.current_time(),
+                    in_data.time_step(),
+                    in_data.time_scale(),
+                )?;
+                let mut full_request = request;
+                full_request.rect = query.max_result_rect;
+                let result = callbacks.checkout_layer(
+                    0,
+                    0,
+                    &full_request,
+                    in_data.current_time(),
+                    in_data.time_step(),
+                    in_data.time_scale(),
+                )?;
+                let full_rect: ae::Rect = result.max_result_rect.into();
+                let _ = extra.union_result_rect(full_rect);
+                let _ = extra.union_max_result_rect(full_rect);
+                extra.set_returns_extra_pixels(true);
+            }
+            ae::Command::SmartRender { extra } => {
+                let cb = extra.callbacks();
+                let mut checkouts = LayerCheckoutGuard::<1>::new(cb);
+                let render_result = (|| -> Result<(), Error> {
+                    let input = checkouts.checkout(0)?;
+                    let output = cb.checkout_output()?;
+                    if let (Some(input), Some(output)) = (input, output) {
+                        self.do_render(in_data, input, output, params)
+                    } else {
+                        Ok(())
+                    }
+                })();
+                let checkin_result = checkouts.checkin_all();
+                render_result?;
+                checkin_result?;
+            }
+            ae::Command::UserChangedParam { param_index } => {
+                if matches!(
+                    params.type_at(param_index),
+                    Params::Space | Params::Direction | Params::CenterMode | Params::RadiusMode
+                ) {
+                    out_data.set_out_flag(OutFlags::RefreshUi, true);
+                }
+            }
+            ae::Command::UpdateParamsUi => {
+                let mut cloned = params.cloned();
+                self.update_params_ui(in_data, &mut cloned)?;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+}
+
+impl Plugin {
+    fn update_params_ui(
+        &self,
+        in_data: InData,
+        params: &mut Parameters<Params>,
+    ) -> Result<(), Error> {
+        let space = Space::from_popup(params.get(Params::Space)?.as_popup()?.value());
+        let direction = Direction::from_popup(params.get(Params::Direction)?.as_popup()?.value());
+        let custom_center = params.get(Params::CenterMode)?.as_popup()?.value() == 2;
+        let custom_radius = params.get(Params::RadiusMode)?.as_popup()?.value() == 3;
+        let integral = space.is_integral();
+        let hough_forward = space == Space::LineHough && direction == Direction::Forward;
+        let radon_inverse = space == Space::Radon && direction == Direction::Inverse;
+
+        self.set_param_visible(in_data, params, Params::Center, custom_center)?;
+        self.set_param_visible(in_data, params, Params::Radius, custom_radius)?;
+        self.set_param_visible(
+            in_data,
+            params,
+            Params::LogMinRadius,
+            space == Space::LogPolar,
+        )?;
+        for id in [Params::AngleSamples, Params::DetectorSamples] {
+            self.set_param_visible(in_data, params, id, integral)?;
+        }
+        self.set_param_visible(
+            in_data,
+            params,
+            Params::RaySamples,
+            integral && direction == Direction::Forward,
+        )?;
+        self.set_param_visible(in_data, params, Params::HoughThreshold, hough_forward)?;
+        self.set_param_visible(in_data, params, Params::WeightedHough, hough_forward)?;
+        self.set_param_visible(in_data, params, Params::FilterRadius, radon_inverse)?;
+        self.set_param_visible(in_data, params, Params::Interpolation, !integral)?;
+        self.set_param_visible(in_data, params, Params::Edge, !integral)?;
+        self.set_param_visible(
+            in_data,
+            params,
+            Params::SpiralTurns,
+            space == Space::SpiralPolar,
+        )?;
+        self.set_param_visible(
+            in_data,
+            params,
+            Params::FocusRatio,
+            matches!(space, Space::Elliptic | Space::Bipolar),
+        )?;
+        self.set_param_visible(
+            in_data,
+            params,
+            Params::CoordinateExtent,
+            space == Space::Bipolar,
+        )?;
+        self.set_param_visible(
+            in_data,
+            params,
+            Params::HoughChannels,
+            space == Space::LineHough,
+        )?;
+        Ok(())
+    }
+
+    fn set_param_visible(
+        &self,
+        in_data: InData,
+        params: &mut Parameters<Params>,
+        id: Params,
+        visible: bool,
+    ) -> Result<(), Error> {
+        if in_data.is_premiere() {
+            return Self::set_param_ui_flag(params, id, ParamUIFlags::INVISIBLE, !visible);
+        }
+        if let Some(plugin_id) = self.aegp_id {
+            let effect = in_data.effect();
+            if let Some(index) = params.index(id)
+                && let Ok(effect_ref) = effect.aegp_effect(plugin_id)
+                && let Ok(stream) = effect_ref.new_stream_by_index(plugin_id, index as i32)
+            {
+                return stream.set_dynamic_stream_flag(
+                    ae::aegp::DynamicStreamFlags::Hidden,
+                    false,
+                    !visible,
+                );
+            }
+        }
+        Self::set_param_ui_flag(params, id, ParamUIFlags::INVISIBLE, !visible)
+    }
+
+    fn set_param_ui_flag(
+        params: &mut Parameters<Params>,
+        id: Params,
+        flag: ParamUIFlags,
+        status: bool,
+    ) -> Result<(), Error> {
+        let current = (params.get(id)?.ui_flags().bits() & flag.bits()) != 0;
+        if current == status {
+            return Ok(());
+        }
+        let mut param = params.get_mut(id)?;
+        param.set_ui_flag(flag, status);
+        param.update_param_ui()?;
+        Ok(())
+    }
+
+    fn do_render(
+        &self,
+        in_data: InData,
+        in_layer: Layer,
+        mut out_layer: Layer,
+        params: &mut Parameters<Params>,
+    ) -> Result<(), Error> {
+        let mut settings = read_settings(params, in_data)?;
+        let src_width = in_layer.width();
+        let src_height = in_layer.height();
+        let out_width = out_layer.width();
+        let out_height = out_layer.height();
+        if src_width == 0 || src_height == 0 || out_width == 0 || out_height == 0 {
+            return Ok(());
+        }
+        if settings.center_mode == CenterMode::Custom {
+            settings.center = point_in_checkout_world(settings.center, in_layer.origin());
+        }
+
+        let source = read_layer(&in_layer);
+        let output = if settings.space.is_integral() {
+            render_integral(
+                &source, src_width, src_height, out_width, out_height, settings,
+            )
+        } else {
+            render_coordinates(
+                &source, src_width, src_height, out_width, out_height, settings,
+            )
+        };
+        let out_world_type = out_layer.world_type();
+        out_layer.iterate(0, out_height as i32, None, |x, y, mut dst| {
+            let pixel = output[y as usize * out_width + x as usize];
+            match out_world_type {
+                ae::aegp::WorldType::U8 => dst.set_from_u8(pixel.to_pixel8()),
+                ae::aegp::WorldType::U15 => dst.set_from_u16(pixel.to_pixel16()),
+                ae::aegp::WorldType::F32 | ae::aegp::WorldType::None => dst.set_from_f32(pixel),
+            }
+            Ok(())
+        })?;
+        Ok(())
+    }
+}
+
+fn add_integer_slider(
+    params: &mut Parameters<Params>,
+    id: Params,
+    name: &str,
+    min: f32,
+    max: f32,
+    default: f64,
+) -> Result<(), Error> {
+    params.add(
+        id,
+        name,
+        FloatSliderDef::setup(|d| {
+            d.set_valid_min(min);
+            d.set_valid_max(max);
+            d.set_slider_min(min);
+            d.set_slider_max(max);
+            d.set_default(default);
+            d.set_precision(0);
+        }),
+    )?;
+    Ok(())
+}
+
+fn read_settings(params: &Parameters<Params>, in_data: InData) -> Result<Settings, Error> {
+    let popup = |id| params.get(id)?.as_popup().map(|p| p.value());
+    let slider = |id| params.get(id)?.as_float_slider().map(|p| p.value() as f32);
+    Ok(Settings {
+        space: Space::from_popup(popup(Params::Space)?),
+        direction: Direction::from_popup(popup(Params::Direction)?),
+        center_mode: if popup(Params::CenterMode)? == 2 {
+            CenterMode::Custom
+        } else {
+            CenterMode::LayerCenter
+        },
+        center: params.get(Params::Center)?.as_point()?.value(),
+        radius_mode: match popup(Params::RadiusMode)? {
+            2 => RadiusMode::Inscribed,
+            3 => RadiusMode::Custom,
+            _ => RadiusMode::Auto,
+        },
+        radius: slider(Params::Radius)?.max(0.01),
+        log_min_radius: slider(Params::LogMinRadius)?.max(0.001),
+        angle_offset: (params.get(Params::AngleOffset)?.as_angle()?.float_value()? as f32)
+            .to_radians(),
+        angle_samples: slider(Params::AngleSamples)?.round().clamp(8.0, 720.0) as usize,
+        detector_samples: slider(Params::DetectorSamples)?.round().clamp(16.0, 2048.0) as usize,
+        ray_samples: slider(Params::RaySamples)?.round().clamp(8.0, 2048.0) as usize,
+        hough_threshold: slider(Params::HoughThreshold)?.clamp(0.0, 1.0),
+        weighted_hough: params.get(Params::WeightedHough)?.as_checkbox()?.value(),
+        filter_radius: slider(Params::FilterRadius)?.round().clamp(1.0, 127.0) as usize,
+        interpolation: if popup(Params::Interpolation)? == 1 {
+            Interpolation::Nearest
+        } else {
+            Interpolation::Bilinear
+        },
+        edge: match popup(Params::Edge)? {
+            2 => SampleEdge::Clamp,
+            3 => SampleEdge::Tile,
+            4 => SampleEdge::Mirror,
+            _ => SampleEdge::Transparent,
+        },
+        output_gain: slider(Params::OutputGain)?,
+        output_bias: slider(Params::OutputBias)?,
+        clamp_output: params.get(Params::ClampOutput)?.as_checkbox()?.value(),
+        pixel_scale: render_pixel_scale(in_data),
+        spiral_turns: slider(Params::SpiralTurns)?,
+        focus_ratio: slider(Params::FocusRatio)?.clamp(0.001, 0.999),
+        coordinate_extent: slider(Params::CoordinateExtent)?.clamp(0.05, 20.0),
+        hough_channels: HoughChannels::from_popup(popup(Params::HoughChannels)?),
+    })
+}
+
+fn render_pixel_scale(in_data: InData) -> (f32, f32) {
+    square_pixel_scale(
+        rational_or_one(in_data.pixel_aspect_ratio()),
+        rational_or_one(in_data.downsample_x()),
+        rational_or_one(in_data.downsample_y()),
+    )
+}
+
+fn rational_or_one(value: RationalScale) -> f32 {
+    if value.num > 0 && value.den > 0 {
+        let ratio = value.num as f32 / value.den as f32;
+        if ratio.is_finite() && ratio > 0.0 {
+            return ratio;
+        }
+    }
+    1.0
+}
+
+fn square_pixel_scale(pixel_aspect: f32, downsample_x: f32, downsample_y: f32) -> (f32, f32) {
+    (
+        pixel_aspect.max(1.0e-6) / downsample_x.max(1.0e-6),
+        1.0 / downsample_y.max(1.0e-6),
+    )
+}
+
+fn point_in_checkout_world(point: (f32, f32), origin: ae::Point) -> (f32, f32) {
+    (point.0 - origin.h as f32, point.1 - origin.v as f32)
+}
+
+fn resolve_geometry(width: usize, height: usize, settings: Settings) -> ((f32, f32), f32) {
+    let center = match settings.center_mode {
+        CenterMode::LayerCenter => ((width as f32 - 1.0) * 0.5, (height as f32 - 1.0) * 0.5),
+        CenterMode::Custom => settings.center,
+    };
+    let left = center.0.abs() * settings.pixel_scale.0;
+    let right = (width as f32 - 1.0 - center.0).abs() * settings.pixel_scale.0;
+    let top = center.1.abs() * settings.pixel_scale.1;
+    let bottom = (height as f32 - 1.0 - center.1).abs() * settings.pixel_scale.1;
+    let radius = match settings.radius_mode {
+        RadiusMode::Auto if settings.space == Space::SquareDisc => {
+            left.min(right).min(top).min(bottom)
+        }
+        RadiusMode::Auto => [
+            left.hypot(top),
+            left.hypot(bottom),
+            right.hypot(top),
+            right.hypot(bottom),
+        ]
+        .into_iter()
+        .fold(0.0, f32::max),
+        RadiusMode::Inscribed => left.min(right).min(top).min(bottom),
+        RadiusMode::Custom => settings.radius,
+    };
+    (center, radius.max(0.001))
+}
+
+fn sample(
+    pixels: &[PixelF32],
+    width: usize,
+    height: usize,
+    x: f32,
+    y: f32,
+    interpolation: Interpolation,
+    edge: SampleEdge,
+) -> PixelF32 {
+    match interpolation {
+        Interpolation::Nearest => sample_nearest(pixels, width, height, x, y, edge),
+        Interpolation::Bilinear => sample_bilinear(pixels, width, height, x, y, edge),
+    }
+}
+
+fn render_coordinates(
+    source: &[PixelF32],
+    src_width: usize,
+    src_height: usize,
+    out_width: usize,
+    out_height: usize,
+    settings: Settings,
+) -> Vec<PixelF32> {
+    let (center, radius) = resolve_geometry(out_width, out_height, settings);
+    let mut output = vec![TRANSPARENT; out_width * out_height];
+    for y in 0..out_height {
+        let v = normalized_index(y, out_height);
+        for x in 0..out_width {
+            let u = normalized_index(x, out_width);
+            let coordinate = match (settings.space, settings.direction) {
+                (Space::Polar, Direction::Forward) => {
+                    let theta = settings.angle_offset + u * TAU;
+                    let r = v * radius;
+                    Some((
+                        center.0 + r * theta.cos() / settings.pixel_scale.0,
+                        center.1 + r * theta.sin() / settings.pixel_scale.1,
+                    ))
+                }
+                (Space::LogPolar, Direction::Forward) => {
+                    let theta = settings.angle_offset + u * TAU;
+                    let min_radius = settings.log_min_radius.min(radius * 0.999).max(0.001);
+                    let r = min_radius * (radius / min_radius).powf(v);
+                    Some((
+                        center.0 + r * theta.cos() / settings.pixel_scale.0,
+                        center.1 + r * theta.sin() / settings.pixel_scale.1,
+                    ))
+                }
+                (Space::SpiralPolar, Direction::Forward) => {
+                    let theta = settings.angle_offset + (u + v * settings.spiral_turns) * TAU;
+                    let r = v * radius;
+                    Some((
+                        center.0 + r * theta.cos() / settings.pixel_scale.0,
+                        center.1 + r * theta.sin() / settings.pixel_scale.1,
+                    ))
+                }
+                (Space::Polar | Space::LogPolar | Space::SpiralPolar, Direction::Inverse) => {
+                    let dx = (x as f32 - center.0) * settings.pixel_scale.0;
+                    let dy = (y as f32 - center.1) * settings.pixel_scale.1;
+                    let r = dx.hypot(dy);
+                    if r > radius {
+                        None
+                    } else {
+                        let radial_position = r / radius;
+                        let spiral_phase = if settings.space == Space::SpiralPolar {
+                            radial_position * settings.spiral_turns * TAU
+                        } else {
+                            0.0
+                        };
+                        let angle_u = (dy.atan2(dx) - settings.angle_offset - spiral_phase)
+                            .rem_euclid(TAU)
+                            / TAU;
+                        let radius_v = if settings.space == Space::LogPolar {
+                            let min_radius = settings.log_min_radius.min(radius * 0.999).max(0.001);
+                            if r < min_radius {
+                                return_coordinate_none()
+                            } else {
+                                (r / min_radius).ln() / (radius / min_radius).ln()
+                            }
+                        } else {
+                            r / radius
+                        };
+                        if radius_v.is_finite() {
+                            Some((
+                                angle_u * (src_width.saturating_sub(1) as f32),
+                                radius_v * (src_height.saturating_sub(1) as f32),
+                            ))
+                        } else {
+                            None
+                        }
+                    }
+                }
+                (Space::SquareDisc, Direction::Forward) => {
+                    let dx = (x as f32 - center.0) * settings.pixel_scale.0 / radius;
+                    let dy = (y as f32 - center.1) * settings.pixel_scale.1 / radius;
+                    if dx * dx + dy * dy > 1.0 {
+                        None
+                    } else {
+                        let (sx, sy) = disc_to_square(dx, dy);
+                        Some((
+                            (sx * 0.5 + 0.5) * src_width.saturating_sub(1) as f32,
+                            (sy * 0.5 + 0.5) * src_height.saturating_sub(1) as f32,
+                        ))
+                    }
+                }
+                (Space::SquareDisc, Direction::Inverse) => {
+                    let sx = u * 2.0 - 1.0;
+                    let sy = v * 2.0 - 1.0;
+                    let (dx, dy) = square_to_disc(sx, sy);
+                    Some((
+                        center.0 + dx * radius / settings.pixel_scale.0,
+                        center.1 + dy * radius / settings.pixel_scale.1,
+                    ))
+                }
+                (Space::Elliptic, Direction::Forward) => {
+                    let focus = (radius * settings.focus_ratio).max(1.0e-6);
+                    let mu_max = (radius / focus).max(1.0).acosh().max(1.0e-6);
+                    let mu = v * mu_max;
+                    let nu = settings.angle_offset + u * TAU;
+                    Some((
+                        center.0 + focus * mu.cosh() * nu.cos() / settings.pixel_scale.0,
+                        center.1 + focus * mu.sinh() * nu.sin() / settings.pixel_scale.1,
+                    ))
+                }
+                (Space::Elliptic, Direction::Inverse) => {
+                    let dx = (x as f32 - center.0) * settings.pixel_scale.0;
+                    let dy = (y as f32 - center.1) * settings.pixel_scale.1;
+                    let focus = (radius * settings.focus_ratio).max(1.0e-6);
+                    let d_positive = (dx - focus).hypot(dy);
+                    let d_negative = (dx + focus).hypot(dy);
+                    let mu = ((d_positive + d_negative) / (2.0 * focus)).max(1.0).acosh();
+                    let mu_max = (radius / focus).max(1.0).acosh().max(1.0e-6);
+                    if mu > mu_max + 1.0e-5 {
+                        None
+                    } else {
+                        let cosine = ((d_negative - d_positive) / (2.0 * focus)).clamp(-1.0, 1.0);
+                        let mut nu = cosine.acos();
+                        if dy < 0.0 {
+                            nu = TAU - nu;
+                        }
+                        let angle_u = (nu - settings.angle_offset).rem_euclid(TAU) / TAU;
+                        Some((
+                            angle_u * src_width.saturating_sub(1) as f32,
+                            (mu / mu_max) * src_height.saturating_sub(1) as f32,
+                        ))
+                    }
+                }
+                (Space::Parabolic, Direction::Forward) => {
+                    let coordinate_radius = (2.0 * radius).sqrt();
+                    let tau = (u * 2.0 - 1.0) * coordinate_radius;
+                    let sigma = v * coordinate_radius;
+                    let dx = 0.5 * (sigma * sigma - tau * tau);
+                    let dy = sigma * tau;
+                    Some((
+                        center.0 + dx / settings.pixel_scale.0,
+                        center.1 + dy / settings.pixel_scale.1,
+                    ))
+                }
+                (Space::Parabolic, Direction::Inverse) => {
+                    let dx = (x as f32 - center.0) * settings.pixel_scale.0;
+                    let dy = (y as f32 - center.1) * settings.pixel_scale.1;
+                    let radial = dx.hypot(dy);
+                    let sigma = (radial + dx).max(0.0).sqrt();
+                    let tau_magnitude = (radial - dx).max(0.0).sqrt();
+                    // The negative X axis is the parabolic branch cut. Choose
+                    // the positive branch at exactly y=0 so it stays mapped
+                    // instead of collapsing to the origin.
+                    let tau = if dy < 0.0 {
+                        -tau_magnitude
+                    } else {
+                        tau_magnitude
+                    };
+                    let coordinate_radius = (2.0 * radius).sqrt().max(1.0e-6);
+                    let source_u = tau / (2.0 * coordinate_radius) + 0.5;
+                    let source_v = sigma / coordinate_radius;
+                    if !(0.0..=1.0).contains(&source_u) || !(0.0..=1.0).contains(&source_v) {
+                        None
+                    } else {
+                        Some((
+                            source_u * src_width.saturating_sub(1) as f32,
+                            source_v * src_height.saturating_sub(1) as f32,
+                        ))
+                    }
+                }
+                (Space::Bipolar, Direction::Forward) => {
+                    let focus = (radius * settings.focus_ratio).max(1.0e-6);
+                    let tau = (u * 2.0 - 1.0) * settings.coordinate_extent;
+                    let sigma = (v * 2.0 - 1.0) * PI + settings.angle_offset;
+                    let denominator = tau.cosh() - sigma.cos();
+                    if denominator.abs() < 1.0e-6 {
+                        None
+                    } else {
+                        let dx = focus * tau.sinh() / denominator;
+                        let dy = focus * sigma.sin() / denominator;
+                        Some((
+                            center.0 + dx / settings.pixel_scale.0,
+                            center.1 + dy / settings.pixel_scale.1,
+                        ))
+                    }
+                }
+                (Space::Bipolar, Direction::Inverse) => {
+                    let dx = (x as f32 - center.0) * settings.pixel_scale.0;
+                    let dy = (y as f32 - center.1) * settings.pixel_scale.1;
+                    let focus = (radius * settings.focus_ratio).max(1.0e-6);
+                    let numerator = (dx + focus) * (dx + focus) + dy * dy;
+                    let denominator = (dx - focus) * (dx - focus) + dy * dy;
+                    if numerator <= 1.0e-12 || denominator <= 1.0e-12 {
+                        None
+                    } else {
+                        let tau = 0.5 * (numerator / denominator).ln();
+                        let sigma = (2.0 * focus * dy).atan2(dx * dx + dy * dy - focus * focus);
+                        let source_u = tau / (2.0 * settings.coordinate_extent) + 0.5;
+                        let source_v = (sigma - settings.angle_offset).rem_euclid(TAU) / TAU;
+                        if !(0.0..=1.0).contains(&source_u) {
+                            None
+                        } else {
+                            Some((
+                                source_u * src_width.saturating_sub(1) as f32,
+                                source_v * src_height.saturating_sub(1) as f32,
+                            ))
+                        }
+                    }
+                }
+                _ => None,
+            };
+            let pixel = coordinate
+                .map(|(sx, sy)| {
+                    sample(
+                        source,
+                        src_width,
+                        src_height,
+                        sx,
+                        sy,
+                        settings.interpolation,
+                        settings.edge,
+                    )
+                })
+                .unwrap_or(TRANSPARENT);
+            output[y * out_width + x] = finish_pixel(pixel, settings);
+        }
+    }
+    output
+}
+
+#[inline]
+fn return_coordinate_none() -> f32 {
+    f32::NAN
+}
+
+fn render_integral(
+    source: &[PixelF32],
+    src_width: usize,
+    src_height: usize,
+    out_width: usize,
+    out_height: usize,
+    settings: Settings,
+) -> Vec<PixelF32> {
+    let analysis = match (settings.space, settings.direction) {
+        (Space::Radon, Direction::Forward) => {
+            forward_radon(source, src_width, src_height, settings)
+        }
+        (Space::LineHough, Direction::Forward) => {
+            forward_hough(source, src_width, src_height, settings)
+        }
+        (Space::Radon, Direction::Inverse) => inverse_radon(
+            source, src_width, src_height, out_width, out_height, settings,
+        ),
+        (Space::LineHough, Direction::Inverse) => inverse_hough(
+            source, src_width, src_height, out_width, out_height, settings,
+        ),
+        _ => vec![TRANSPARENT; out_width * out_height],
+    };
+
+    if settings.direction == Direction::Inverse {
+        return analysis
+            .into_iter()
+            .map(|pixel| finish_pixel(pixel, settings))
+            .collect();
+    }
+    resize_image(
+        &analysis,
+        settings.angle_samples,
+        settings.detector_samples,
+        out_width,
+        out_height,
+    )
+    .into_iter()
+    .map(|pixel| finish_pixel(pixel, settings))
+    .collect()
+}
+
+fn effective_ray_samples(settings: Settings) -> usize {
+    let projection_count = settings
+        .angle_samples
+        .saturating_mul(settings.detector_samples)
+        .max(1);
+    let budgeted = (MAX_INTEGRAL_SAMPLE_EVALUATIONS / projection_count).max(8);
+    settings.ray_samples.min(budgeted)
+}
+
+fn forward_radon(
+    source: &[PixelF32],
+    width: usize,
+    height: usize,
+    settings: Settings,
+) -> Vec<PixelF32> {
+    let (center, radius) = resolve_geometry(width, height, settings);
+    let ray_samples = effective_ray_samples(settings);
+    let mut result = vec![TRANSPARENT; settings.angle_samples * settings.detector_samples];
+    for detector in 0..settings.detector_samples {
+        let rho = detector_rho(detector, settings.detector_samples, radius);
+        for angle in 0..settings.angle_samples {
+            let theta = settings.angle_offset + angle as f32 * PI / settings.angle_samples as f32;
+            let cos = theta.cos();
+            let sin = theta.sin();
+            let mut sum = TRANSPARENT;
+            for ray in 0..ray_samples {
+                let t = detector_rho(ray, ray_samples, radius);
+                let pixel = sample_bilinear(
+                    source,
+                    width,
+                    height,
+                    center.0 + (rho * cos - t * sin) / settings.pixel_scale.0,
+                    center.1 + (rho * sin + t * cos) / settings.pixel_scale.1,
+                    SampleEdge::Transparent,
+                );
+                let endpoint_weight = if ray == 0 || ray + 1 == ray_samples {
+                    0.5
+                } else {
+                    1.0
+                };
+                sum = add_pixel(sum, scale_pixel(pixel, endpoint_weight));
+            }
+            result[detector * settings.angle_samples + angle] =
+                scale_pixel(sum, 1.0 / ray_samples.saturating_sub(1).max(1) as f32);
+        }
+    }
+    result
+}
+
+fn forward_hough(
+    source: &[PixelF32],
+    width: usize,
+    height: usize,
+    settings: Settings,
+) -> Vec<PixelF32> {
+    let (center, radius) = resolve_geometry(width, height, settings);
+    let ray_samples = effective_ray_samples(settings);
+    let edges = sobel_edge_channels(
+        source,
+        width,
+        height,
+        settings.pixel_scale,
+        settings.hough_channels,
+    );
+    let mut votes = vec![[0.0_f32; 4]; settings.angle_samples * settings.detector_samples];
+    let mut maximum = [0.0_f32; 4];
+    let alpha_fallback = if source.is_empty() {
+        0.0
+    } else {
+        source.iter().map(|pixel| pixel.alpha).sum::<f32>() / source.len() as f32
+    };
+    for detector in 0..settings.detector_samples {
+        let rho = detector_rho(detector, settings.detector_samples, radius);
+        for angle in 0..settings.angle_samples {
+            let theta = settings.angle_offset + angle as f32 * PI / settings.angle_samples as f32;
+            let cos = theta.cos();
+            let sin = theta.sin();
+            let mut sum = [0.0_f32; 4];
+            for ray in 0..ray_samples {
+                let t = detector_rho(ray, ray_samples, radius);
+                let magnitude = sample_channel_bilinear(
+                    &edges,
+                    width,
+                    height,
+                    center.0 + (rho * cos - t * sin) / settings.pixel_scale.0,
+                    center.1 + (rho * sin + t * cos) / settings.pixel_scale.1,
+                );
+                for channel in 0..4 {
+                    if magnitude[channel] >= settings.hough_threshold {
+                        sum[channel] += if settings.weighted_hough {
+                            magnitude[channel]
+                        } else {
+                            1.0
+                        };
+                    }
+                }
+            }
+            let vote = sum.map(|value| value / ray_samples as f32);
+            votes[detector * settings.angle_samples + angle] = vote;
+            for channel in 0..4 {
+                maximum[channel] = maximum[channel].max(vote[channel]);
+            }
+        }
+    }
+    votes
+        .into_iter()
+        .map(|value| {
+            let normalized = [
+                value[0] / maximum[0].max(1.0e-8),
+                value[1] / maximum[1].max(1.0e-8),
+                value[2] / maximum[2].max(1.0e-8),
+                if maximum[3] <= 1.0e-8 {
+                    alpha_fallback
+                } else {
+                    value[3] / maximum[3]
+                },
+            ];
+            if settings.hough_channels.is_rgba() {
+                PixelF32 {
+                    alpha: normalized[3],
+                    red: normalized[0],
+                    green: normalized[1],
+                    blue: normalized[2],
+                }
+            } else {
+                gray_pixel(normalized[0])
+            }
+        })
+        .collect()
+}
+
+fn inverse_radon(
+    source: &[PixelF32],
+    src_width: usize,
+    src_height: usize,
+    out_width: usize,
+    out_height: usize,
+    settings: Settings,
+) -> Vec<PixelF32> {
+    let sinogram = resize_image(
+        source,
+        src_width,
+        src_height,
+        settings.angle_samples,
+        settings.detector_samples,
+    );
+    let (analysis_width, analysis_height) = reconstruction_dimensions(
+        out_width,
+        out_height,
+        settings.detector_samples,
+        settings.angle_samples,
+    );
+    let analysis_settings = scaled_geometry_settings(
+        settings,
+        analysis_width as f32 / out_width.max(1) as f32,
+        analysis_height as f32 / out_height.max(1) as f32,
+    );
+    let filter_radius = effective_filter_radius(
+        settings.angle_samples,
+        settings.detector_samples,
+        settings.filter_radius,
+    );
+    let filtered = ram_lak_filter(
+        &sinogram,
+        settings.angle_samples,
+        settings.detector_samples,
+        filter_radius,
+    );
+    let mut reconstruction = backproject(
+        &filtered,
+        settings.angle_samples,
+        settings.detector_samples,
+        analysis_width,
+        analysis_height,
+        analysis_settings,
+        false,
+    );
+    let (_, analysis_radius) = resolve_geometry(analysis_width, analysis_height, analysis_settings);
+    let normalization = fbp_normalization(settings.detector_samples, analysis_radius);
+    for pixel in &mut reconstruction {
+        *pixel = scale_pixel(*pixel, normalization);
+    }
+    resize_image(
+        &reconstruction,
+        analysis_width,
+        analysis_height,
+        out_width,
+        out_height,
+    )
+}
+
+fn inverse_hough(
+    source: &[PixelF32],
+    src_width: usize,
+    src_height: usize,
+    out_width: usize,
+    out_height: usize,
+    settings: Settings,
+) -> Vec<PixelF32> {
+    let channel_source = analysis_channel_pixels(source, settings.hough_channels);
+    let accumulator = resize_image(
+        &channel_source,
+        src_width,
+        src_height,
+        settings.angle_samples,
+        settings.detector_samples,
+    );
+    let (analysis_width, analysis_height) = reconstruction_dimensions(
+        out_width,
+        out_height,
+        settings.detector_samples,
+        settings.angle_samples,
+    );
+    let analysis_settings = scaled_geometry_settings(
+        settings,
+        analysis_width as f32 / out_width.max(1) as f32,
+        analysis_height as f32 / out_height.max(1) as f32,
+    );
+    let reconstruction = backproject(
+        &accumulator,
+        settings.angle_samples,
+        settings.detector_samples,
+        analysis_width,
+        analysis_height,
+        analysis_settings,
+        true,
+    );
+    resize_image(
+        &reconstruction,
+        analysis_width,
+        analysis_height,
+        out_width,
+        out_height,
+    )
+}
+
+fn reconstruction_dimensions(
+    width: usize,
+    height: usize,
+    detector_samples: usize,
+    angle_samples: usize,
+) -> (usize, usize) {
+    let longest = width.max(height).max(1);
+    let analysis_longest = detector_samples.min(longest).max(1);
+    let scale = analysis_longest as f32 / longest as f32;
+    let mut dimensions = (
+        ((width as f32 * scale).round() as usize).max(1),
+        ((height as f32 * scale).round() as usize).max(1),
+    );
+    let pixel_budget = (MAX_INTEGRAL_SAMPLE_EVALUATIONS / angle_samples.max(1)).max(1);
+    let pixel_count = dimensions.0.saturating_mul(dimensions.1);
+    if pixel_count > pixel_budget {
+        let budget_scale = (pixel_budget as f64 / pixel_count as f64).sqrt() as f32;
+        dimensions.0 = ((dimensions.0 as f32 * budget_scale).floor() as usize).max(1);
+        dimensions.1 = ((dimensions.1 as f32 * budget_scale).floor() as usize).max(1);
+        while dimensions.0.saturating_mul(dimensions.1) > pixel_budget {
+            if dimensions.0 >= dimensions.1 && dimensions.0 > 1 {
+                dimensions.0 -= 1;
+            } else if dimensions.1 > 1 {
+                dimensions.1 -= 1;
+            } else {
+                break;
+            }
+        }
+    }
+    dimensions
+}
+
+fn scaled_geometry_settings(mut settings: Settings, scale_x: f32, scale_y: f32) -> Settings {
+    if settings.center_mode == CenterMode::Custom {
+        settings.center.0 *= scale_x;
+        settings.center.1 *= scale_y;
+    }
+    settings.pixel_scale.0 /= scale_x.max(1.0e-6);
+    settings.pixel_scale.1 /= scale_y.max(1.0e-6);
+    settings
+}
+
+#[allow(clippy::too_many_arguments)]
+fn backproject(
+    sinogram: &[PixelF32],
+    angles: usize,
+    detectors: usize,
+    width: usize,
+    height: usize,
+    settings: Settings,
+    normalize: bool,
+) -> Vec<PixelF32> {
+    let (center, radius) = resolve_geometry(width, height, settings);
+    let mut result = vec![TRANSPARENT; width * height];
+    let mut maximum = 0.0_f32;
+    for y in 0..height {
+        for x in 0..width {
+            let dx = (x as f32 - center.0) * settings.pixel_scale.0;
+            let dy = (y as f32 - center.1) * settings.pixel_scale.1;
+            let mut sum = TRANSPARENT;
+            for angle in 0..angles {
+                let theta = settings.angle_offset + angle as f32 * PI / angles as f32;
+                let rho = dx * theta.cos() + dy * theta.sin();
+                let detector = rho_to_detector(rho, detectors, radius);
+                sum = add_pixel(
+                    sum,
+                    sample_sinogram_detector(sinogram, angles, detectors, angle, detector),
+                );
+            }
+            let pixel = scale_pixel(sum, PI / angles as f32);
+            maximum = maximum.max(pixel.red.max(pixel.green).max(pixel.blue).abs());
+            result[y * width + x] = pixel;
+        }
+    }
+    if normalize {
+        let scale = 1.0 / maximum.max(1.0e-8);
+        for pixel in &mut result {
+            *pixel = scale_pixel(*pixel, scale);
+            pixel.alpha = 1.0;
+        }
+    }
+    result
+}
+
+fn effective_filter_radius(angles: usize, detectors: usize, requested: usize) -> usize {
+    let sample_count = angles.saturating_mul(detectors).max(1);
+    let tap_budget = (MAX_INTEGRAL_SAMPLE_EVALUATIONS / sample_count).max(3);
+    let budgeted_radius = tap_budget.saturating_sub(1) / 2;
+    requested.min(budgeted_radius.max(1))
+}
+
+fn fbp_normalization(detectors: usize, reconstruction_radius: f32) -> f32 {
+    let detector_intervals = detectors.saturating_sub(1).max(1) as f32;
+    detector_intervals * detector_intervals / (2.0 * reconstruction_radius.max(0.001))
+}
+
+fn ram_lak_filter(
+    sinogram: &[PixelF32],
+    angles: usize,
+    detectors: usize,
+    radius: usize,
+) -> Vec<PixelF32> {
+    let mut result = vec![TRANSPARENT; sinogram.len()];
+    for detector in 0..detectors {
+        for angle in 0..angles {
+            let mut sum = TRANSPARENT;
+            for offset in -(radius as isize)..=(radius as isize) {
+                let source_detector = detector as isize + offset;
+                if !(0..detectors as isize).contains(&source_detector) {
+                    continue;
+                }
+                let coefficient = ram_lak_coefficient(offset);
+                sum = add_pixel(
+                    sum,
+                    scale_pixel(
+                        sinogram[source_detector as usize * angles + angle],
+                        coefficient,
+                    ),
+                );
+            }
+            result[detector * angles + angle] = sum;
+        }
+    }
+    result
+}
+
+fn ram_lak_coefficient(index: isize) -> f32 {
+    if index == 0 {
+        0.25
+    } else if index % 2 == 0 {
+        0.0
+    } else {
+        -1.0 / (PI * PI * (index * index) as f32)
+    }
+}
+
+fn resize_image(
+    source: &[PixelF32],
+    src_width: usize,
+    src_height: usize,
+    width: usize,
+    height: usize,
+) -> Vec<PixelF32> {
+    let mut result = vec![TRANSPARENT; width * height];
+    for y in 0..height {
+        let sy = resize_coordinate(y, height, src_height);
+        for x in 0..width {
+            let sx = resize_coordinate(x, width, src_width);
+            result[y * width + x] =
+                sample_bilinear(source, src_width, src_height, sx, sy, SampleEdge::Clamp);
+        }
+    }
+    result
+}
+
+fn resize_coordinate(index: usize, destination: usize, source: usize) -> f32 {
+    if destination <= 1 || source <= 1 {
+        0.0
+    } else {
+        index as f32 * (source - 1) as f32 / (destination - 1) as f32
+    }
+}
+
+#[cfg(test)]
+fn sobel_edges(
+    source: &[PixelF32],
+    width: usize,
+    height: usize,
+    pixel_scale: (f32, f32),
+) -> Vec<f32> {
+    sobel_edge_channels(source, width, height, pixel_scale, HoughChannels::Luminance)
+        .into_iter()
+        .map(|channels| channels[0])
+        .collect()
+}
+
+fn sobel_edge_channels(
+    source: &[PixelF32],
+    width: usize,
+    height: usize,
+    pixel_scale: (f32, f32),
+    mode: HoughChannels,
+) -> Vec<[f32; 4]> {
+    let mut result = vec![[0.0; 4]; width * height];
+    let get = |x: i64, y: i64| {
+        analysis_components(
+            sample_nearest(source, width, height, x as f32, y as f32, SampleEdge::Clamp),
+            mode,
+        )
+    };
+    for y in 0..height {
+        for x in 0..width {
+            let x = x as i64;
+            let y = y as i64;
+            let p00 = get(x - 1, y - 1);
+            let p10 = get(x, y - 1);
+            let p20 = get(x + 1, y - 1);
+            let p01 = get(x - 1, y);
+            let p21 = get(x + 1, y);
+            let p02 = get(x - 1, y + 1);
+            let p12 = get(x, y + 1);
+            let p22 = get(x + 1, y + 1);
+            let mut magnitude = [0.0; 4];
+            for channel in 0..4 {
+                let gx = (-p00[channel] + p20[channel] - 2.0 * p01[channel] + 2.0 * p21[channel]
+                    - p02[channel]
+                    + p22[channel])
+                    / pixel_scale.0.max(1.0e-6);
+                let gy = (-p00[channel] - 2.0 * p10[channel] - p20[channel]
+                    + p02[channel]
+                    + 2.0 * p12[channel]
+                    + p22[channel])
+                    / pixel_scale.1.max(1.0e-6);
+                magnitude[channel] = (gx.hypot(gy) * 0.25).clamp(0.0, 1.0);
+            }
+            result[y as usize * width + x as usize] = magnitude;
+        }
+    }
+    result
+}
+
+fn analysis_components(pixel: PixelF32, mode: HoughChannels) -> [f32; 4] {
+    match mode {
+        HoughChannels::Rgba => [pixel.red, pixel.green, pixel.blue, pixel.alpha],
+        HoughChannels::Red => [pixel.red; 4],
+        HoughChannels::Green => [pixel.green; 4],
+        HoughChannels::Blue => [pixel.blue; 4],
+        HoughChannels::Alpha => [pixel.alpha; 4],
+        HoughChannels::Luminance => [luma(pixel); 4],
+    }
+}
+
+fn analysis_channel_pixels(source: &[PixelF32], mode: HoughChannels) -> Vec<PixelF32> {
+    if mode.is_rgba() {
+        return source.to_vec();
+    }
+    source
+        .iter()
+        .map(|pixel| gray_pixel(analysis_components(*pixel, mode)[0]))
+        .collect()
+}
+
+fn sample_channel_bilinear(
+    values: &[[f32; 4]],
+    width: usize,
+    height: usize,
+    x: f32,
+    y: f32,
+) -> [f32; 4] {
+    if x < 0.0
+        || y < 0.0
+        || x > width.saturating_sub(1) as f32
+        || y > height.saturating_sub(1) as f32
+    {
+        return [0.0; 4];
+    }
+    let x0 = x.floor() as usize;
+    let y0 = y.floor() as usize;
+    let x1 = (x0 + 1).min(width - 1);
+    let y1 = (y0 + 1).min(height - 1);
+    let tx = x - x0 as f32;
+    let ty = y - y0 as f32;
+    let mut result = [0.0; 4];
+    for channel in 0..4 {
+        let top =
+            values[y0 * width + x0][channel] * (1.0 - tx) + values[y0 * width + x1][channel] * tx;
+        let bottom =
+            values[y1 * width + x0][channel] * (1.0 - tx) + values[y1 * width + x1][channel] * tx;
+        result[channel] = top * (1.0 - ty) + bottom * ty;
+    }
+    result
+}
+
+fn sample_sinogram_detector(
+    pixels: &[PixelF32],
+    angles: usize,
+    detectors: usize,
+    angle: usize,
+    detector: f32,
+) -> PixelF32 {
+    if detector < 0.0 || detector > detectors.saturating_sub(1) as f32 {
+        return TRANSPARENT;
+    }
+    let d0 = detector.floor() as usize;
+    let d1 = (d0 + 1).min(detectors - 1);
+    let t = detector - d0 as f32;
+    lerp_pixel_local(pixels[d0 * angles + angle], pixels[d1 * angles + angle], t)
+}
+
+fn square_to_disc(x: f32, y: f32) -> (f32, f32) {
+    if x.abs() < 1.0e-8 && y.abs() < 1.0e-8 {
+        return (0.0, 0.0);
+    }
+    let (radius, theta) = if x.abs() > y.abs() {
+        (x, FRAC_PI_4 * y / x)
+    } else {
+        (y, PI * 0.5 - FRAC_PI_4 * x / y)
+    };
+    (radius * theta.cos(), radius * theta.sin())
+}
+
+fn disc_to_square(x: f32, y: f32) -> (f32, f32) {
+    let radius = x.hypot(y);
+    if radius < 1.0e-8 {
+        return (0.0, 0.0);
+    }
+    let mut phi = y.atan2(x);
+    if phi < -FRAC_PI_4 {
+        phi += TAU;
+    }
+    if phi < FRAC_PI_4 {
+        (radius, radius * phi / FRAC_PI_4)
+    } else if phi < 3.0 * FRAC_PI_4 {
+        let square_y = radius;
+        (square_y * (2.0 - phi / FRAC_PI_4), square_y)
+    } else if phi < 5.0 * FRAC_PI_4 {
+        let square_x = -radius;
+        (square_x, square_x * (phi - PI) / FRAC_PI_4)
+    } else {
+        let square_y = -radius;
+        (square_y * (2.0 - (phi - PI) / FRAC_PI_4), square_y)
+    }
+}
+
+fn normalized_index(index: usize, length: usize) -> f32 {
+    if length <= 1 {
+        0.0
+    } else {
+        index as f32 / (length - 1) as f32
+    }
+}
+
+fn detector_rho(index: usize, count: usize, radius: f32) -> f32 {
+    (normalized_index(index, count) * 2.0 - 1.0) * radius
+}
+
+fn rho_to_detector(rho: f32, detectors: usize, radius: f32) -> f32 {
+    (rho / radius * 0.5 + 0.5) * detectors.saturating_sub(1) as f32
+}
+
+fn add_pixel(a: PixelF32, b: PixelF32) -> PixelF32 {
+    PixelF32 {
+        alpha: a.alpha + b.alpha,
+        red: a.red + b.red,
+        green: a.green + b.green,
+        blue: a.blue + b.blue,
+    }
+}
+
+fn scale_pixel(pixel: PixelF32, scale: f32) -> PixelF32 {
+    PixelF32 {
+        alpha: pixel.alpha * scale,
+        red: pixel.red * scale,
+        green: pixel.green * scale,
+        blue: pixel.blue * scale,
+    }
+}
+
+fn lerp_pixel_local(a: PixelF32, b: PixelF32, t: f32) -> PixelF32 {
+    add_pixel(scale_pixel(a, 1.0 - t), scale_pixel(b, t))
+}
+
+fn gray_pixel(value: f32) -> PixelF32 {
+    PixelF32 {
+        alpha: 1.0,
+        red: value,
+        green: value,
+        blue: value,
+    }
+}
+
+fn finish_pixel(mut pixel: PixelF32, settings: Settings) -> PixelF32 {
+    pixel.red = pixel.red * settings.output_gain + settings.output_bias * pixel.alpha;
+    pixel.green = pixel.green * settings.output_gain + settings.output_bias * pixel.alpha;
+    pixel.blue = pixel.blue * settings.output_gain + settings.output_bias * pixel.alpha;
+    sanitize_pixel(pixel, settings.clamp_output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_settings(space: Space) -> Settings {
+        Settings {
+            space,
+            direction: Direction::Forward,
+            center_mode: CenterMode::LayerCenter,
+            center: (0.0, 0.0),
+            radius_mode: RadiusMode::Auto,
+            radius: 1.0,
+            log_min_radius: 1.0,
+            angle_offset: 0.0,
+            angle_samples: 90,
+            detector_samples: 48,
+            ray_samples: 64,
+            hough_threshold: 0.15,
+            weighted_hough: true,
+            filter_radius: 15,
+            interpolation: Interpolation::Bilinear,
+            edge: SampleEdge::Transparent,
+            output_gain: 1.0,
+            output_bias: 0.0,
+            clamp_output: false,
+            pixel_scale: (1.0, 1.0),
+            spiral_turns: 1.0,
+            focus_ratio: 0.5,
+            coordinate_extent: 3.0,
+            hough_channels: HoughChannels::Luminance,
+        }
+    }
+
+    #[test]
+    fn concentric_square_disc_round_trip() {
+        for point in [
+            (-1.0, -1.0),
+            (-0.8, 0.2),
+            (0.3, -0.7),
+            (1.0, 0.5),
+            (0.0, 0.0),
+        ] {
+            let disc = square_to_disc(point.0, point.1);
+            let square = disc_to_square(disc.0, disc.1);
+            assert!((square.0 - point.0).abs() < 1.0e-5);
+            assert!((square.1 - point.1).abs() < 1.0e-5);
+        }
+    }
+
+    #[test]
+    fn parabolic_inverse_keeps_negative_x_branch() {
+        let width = 9;
+        let height = 9;
+        let source: Vec<PixelF32> = (0..width * height)
+            .map(|index| {
+                let value = (index % width) as f32 / (width - 1) as f32;
+                PixelF32 {
+                    alpha: 1.0,
+                    red: value,
+                    green: value,
+                    blue: value,
+                }
+            })
+            .collect();
+        let output = render_coordinates(
+            &source,
+            width,
+            height,
+            width,
+            height,
+            Settings {
+                direction: Direction::Inverse,
+                ..test_settings(Space::Parabolic)
+            },
+        );
+        assert!(output[(height / 2) * width].red > 0.75);
+    }
+
+    #[test]
+    fn square_disc_auto_radius_stays_inside_canvas() {
+        let settings = test_settings(Space::SquareDisc);
+        let (center, radius) = resolve_geometry(16, 10, settings);
+        assert!((radius - 4.5).abs() < 1.0e-6);
+
+        for sx in [-1.0, -0.5, 0.0, 0.5, 1.0] {
+            for sy in [-1.0, -0.5, 0.0, 0.5, 1.0] {
+                let (dx, dy) = square_to_disc(sx, sy);
+                let x = center.0 + dx * radius / settings.pixel_scale.0;
+                let y = center.1 + dy * radius / settings.pixel_scale.1;
+                assert!((0.0..=15.0).contains(&x));
+                assert!((0.0..=9.0).contains(&y));
+            }
+        }
+    }
+
+    #[test]
+    fn pixel_geometry_accounts_for_par_and_downsample() {
+        assert_eq!(square_pixel_scale(2.0, 0.5, 0.25), (4.0, 4.0));
+    }
+
+    #[test]
+    fn extended_bounds_origin_localizes_custom_center() {
+        let local = point_in_checkout_world((50.0, 25.0), ae::Point { h: -20, v: 10 });
+        assert_eq!(local, (70.0, 15.0));
+        let local_positive = point_in_checkout_world((50.0, 25.0), ae::Point { h: 12, v: 8 });
+        assert_eq!(local_positive, (38.0, 17.0));
+    }
+
+    #[test]
+    fn physical_radius_is_resolution_invariant() {
+        let full_settings = test_settings(Space::Polar);
+        let (_, full_radius) = resolve_geometry(101, 51, full_settings);
+
+        let mut half_settings = full_settings;
+        half_settings.pixel_scale = (2.0, 2.0);
+        let (_, half_radius) = resolve_geometry(51, 26, half_settings);
+        assert!((full_radius - half_radius).abs() < 1.0e-5);
+
+        let mut custom = full_settings;
+        custom.center_mode = CenterMode::Custom;
+        custom.center = (50.0, 25.0);
+        custom.radius_mode = RadiusMode::Custom;
+        custom.radius = 80.0;
+        custom.log_min_radius = 4.0;
+        let scaled = scaled_geometry_settings(custom, 0.5, 0.5);
+        assert_eq!(scaled.center, (25.0, 12.5));
+        assert_eq!(scaled.pixel_scale, (2.0, 2.0));
+        assert_eq!(scaled.radius, 80.0);
+        assert_eq!(scaled.log_min_radius, 4.0);
+    }
+
+    #[test]
+    fn hough_edge_strength_is_resolution_invariant() {
+        let width = 7;
+        let height = 3;
+        let full: Vec<PixelF32> = (0..width * height)
+            .map(|index| gray_pixel((index % width) as f32 * 0.05))
+            .collect();
+        let half: Vec<PixelF32> = (0..width * height)
+            .map(|index| gray_pixel((index % width) as f32 * 0.1))
+            .collect();
+        let full_edges = sobel_edges(&full, width, height, (1.0, 1.0));
+        let half_edges = sobel_edges(&half, width, height, (2.0, 2.0));
+        assert!((full_edges[width + 3] - half_edges[width + 3]).abs() < 1.0e-6);
+    }
+
+    #[test]
+    fn line_hough_rgba_channels_are_analyzed_independently() {
+        let width = 7;
+        let height = 7;
+        let pixels: Vec<PixelF32> = (0..width * height)
+            .map(|index| {
+                let x = index % width;
+                let y = index / width;
+                PixelF32 {
+                    alpha: 1.0,
+                    red: if x >= 3 { 1.0 } else { 0.0 },
+                    green: if y >= 3 { 1.0 } else { 0.0 },
+                    blue: if x + y >= 7 { 1.0 } else { 0.0 },
+                }
+            })
+            .collect();
+        let rgba = sobel_edge_channels(&pixels, width, height, (1.0, 1.0), HoughChannels::Rgba);
+        assert!(rgba[width + 2][0] > rgba[width + 2][1]);
+        assert!(rgba[2 * width + 1][1] > rgba[2 * width + 1][0]);
+
+        let red = sobel_edge_channels(&pixels, width, height, (1.0, 1.0), HoughChannels::Red);
+        assert!(red.iter().all(|channels| {
+            channels
+                .windows(2)
+                .all(|pair| (pair[0] - pair[1]).abs() < 1.0e-7)
+        }));
+    }
+
+    #[test]
+    fn detector_coordinate_round_trip() {
+        let radius = 123.0;
+        for detector in [0, 1, 37, 255] {
+            let rho = detector_rho(detector, 256, radius);
+            let rebuilt = rho_to_detector(rho, 256, radius);
+            assert!((rebuilt - detector as f32).abs() < 1.0e-4);
+        }
+    }
+
+    #[test]
+    fn ram_lak_kernel_is_even_and_finite() {
+        for index in 1..32 {
+            let positive = ram_lak_coefficient(index);
+            let negative = ram_lak_coefficient(-index);
+            assert!(positive.is_finite());
+            assert!((positive - negative).abs() < 1.0e-8);
+        }
+    }
+
+    #[test]
+    fn inverse_analysis_resolution_preserves_aspect_ratio() {
+        let (width, height) = reconstruction_dimensions(1920, 1080, 256, 180);
+        assert_eq!(width, 256);
+        assert_eq!(height, 144);
+        let (small_width, small_height) = reconstruction_dimensions(100, 50, 256, 180);
+        assert_eq!((small_width, small_height), (100, 50));
+    }
+
+    #[test]
+    fn integral_quality_is_bounded_by_work_budget() {
+        let mut settings = test_settings(Space::Radon);
+        settings.angle_samples = 720;
+        settings.detector_samples = 2048;
+        settings.ray_samples = 2048;
+        settings.filter_radius = 127;
+
+        let rays = effective_ray_samples(settings);
+        assert!(
+            settings
+                .angle_samples
+                .saturating_mul(settings.detector_samples)
+                .saturating_mul(rays)
+                <= MAX_INTEGRAL_SAMPLE_EVALUATIONS
+        );
+
+        let filter_radius = effective_filter_radius(
+            settings.angle_samples,
+            settings.detector_samples,
+            settings.filter_radius,
+        );
+        let filter_taps = filter_radius * 2 + 1;
+        assert!(
+            settings
+                .angle_samples
+                .saturating_mul(settings.detector_samples)
+                .saturating_mul(filter_taps)
+                <= MAX_INTEGRAL_SAMPLE_EVALUATIONS
+        );
+
+        let dimensions = reconstruction_dimensions(
+            4096,
+            2160,
+            settings.detector_samples,
+            settings.angle_samples,
+        );
+        assert!(
+            dimensions
+                .0
+                .saturating_mul(dimensions.1)
+                .saturating_mul(settings.angle_samples)
+                <= MAX_INTEGRAL_SAMPLE_EVALUATIONS
+        );
+    }
+
+    #[test]
+    fn radon_fbp_round_trip_preserves_phantom_level() {
+        let width = 32;
+        let height = 32;
+        let mut phantom = vec![TRANSPARENT; width * height];
+        let center = ((width as f32 - 1.0) * 0.5, (height as f32 - 1.0) * 0.5);
+        for y in 0..height {
+            for x in 0..width {
+                if (x as f32 - center.0).hypot(y as f32 - center.1) <= 7.0 {
+                    phantom[y * width + x] = PixelF32 {
+                        alpha: 1.0,
+                        red: 1.0,
+                        green: 0.5,
+                        blue: 0.25,
+                    };
+                }
+            }
+        }
+
+        let settings = test_settings(Space::Radon);
+        let sinogram = forward_radon(&phantom, width, height, settings);
+        let reconstruction = inverse_radon(
+            &sinogram,
+            settings.angle_samples,
+            settings.detector_samples,
+            width,
+            height,
+            Settings {
+                direction: Direction::Inverse,
+                ..settings
+            },
+        );
+
+        let mut inside_sum = 0.0;
+        let mut inside_count = 0;
+        for y in 0..height {
+            for x in 0..width {
+                if (x as f32 - center.0).hypot(y as f32 - center.1) <= 4.0 {
+                    inside_sum += reconstruction[y * width + x].red;
+                    inside_count += 1;
+                }
+            }
+        }
+        let inside_mean = inside_sum / inside_count as f32;
+        assert!(
+            (0.8..=1.2).contains(&inside_mean),
+            "FBP level was {inside_mean}"
+        );
+        assert!(reconstruction[0].red.abs() < 0.35);
+    }
+}


### PR DESCRIPTION
Adds five image effects: AOD_SpaceConvert with coordinate, Radon, and per-channel Line Hough conversions; AOD_ImageTransform with advanced reconstruction filters and outside-image sampling; AOD_ImageCrypt with reversible and resilient visual-data transforms; AOD_GlassDisplace with procedural fractures, Snell-law refraction, BK7 Sellmeier spectral dispersion, and automatic spectral sampling; and AOD_RainbowGenerate with parametric geometry, easing, and OKLCH, HSV, HSL, CIELCh(ab), CIELCh(uv), JzCzHz, and IPT ICh rainbow models. Includes shared sampling utilities and 91 passing tests. The sequence-data flattening flag is intentionally not enabled.