### PR TITLE
FIX: Enable NormalGenerate Y flip by default

### DIFF
--- a/docs/catalog/anime.md
+++ b/docs/catalog/anime.md
@@ -138,7 +138,7 @@ Canny法で色や明度の境界を検出し、輪郭線画像を生成します
 ### パラメーター
 
 - `Method`: SDFまたはPoisson方式を選択します。
-- `Normal Strength`、`Invert`、`Flip Y`: 法線強度、凹凸反転、DirectX形式を設定します。
+- `Normal Strength`、`Invert`、`Flip Y`: 法線強度、凹凸反転、DirectX形式を設定します。`Flip Y`は既定で有効です。
 - `Alpha Threshold`、`Label Tolerance`、`Boundary Condition`: 領域と境界の解釈を設定します。
 - `Edge Softness`、`SDF Radius/Exponent`: SDF方式の形状を調整します。
 - `Poisson Iters`、`Divergence`、`Damping`、`Edge Feather`: Poisson方式の収束と滑らかさを調整します。

--- a/plugins/normal-generate/src/lib.rs
+++ b/plugins/normal-generate/src/lib.rs
@@ -88,7 +88,7 @@ impl AdobePluginGlobal for Plugin {
             Params::FlipY,
             "Flip Y (DirectX)",
             CheckBoxDef::setup(|d| {
-                d.set_default(false);
+                d.set_default(true);
             }),
         )?;
 


### PR DESCRIPTION
Enables Flip Y (DirectX) by default for newly applied AOD_NormalGenerate effects and documents the new default. Validation: cargo fmt --all -- --check; cargo test -p normal_generate; cargo clippy -p normal_generate --all-targets.