### PR TITLE
FIX: Preserve Windows release-ci PowerShell state

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -24,13 +24,18 @@ release:
 
 [windows]
 release-ci:
-	$ErrorActionPreference = "Stop"
-	cargo build --workspace --release
-	$root = "{{justfile_directory()}}"
-	$justfiles = Get-ChildItem -Path (Join-Path $root "plugins") -Filter Justfile -Recurse
-	$env:NO_CARGO_BUILD = "1"
+	$ErrorActionPreference = "Stop"; \
+	cargo build --workspace --release; \
+	if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }; \
+	$root = "{{justfile_directory()}}"; \
+	$justfiles = Get-ChildItem -Path (Join-Path $root "plugins") -Filter Justfile -Recurse; \
+	if (-not $justfiles) { throw "No plugin Justfiles found under $root\plugins" }; \
+	$env:NO_CARGO_BUILD = "1"; \
 	try { \
-		$justfiles | ForEach-Object { just -f $_.FullName release } \
+		$justfiles | ForEach-Object { \
+			just -f $_.FullName release; \
+			if ($LASTEXITCODE -ne 0) { throw "Plugin release failed: $($_.FullName)" } \
+		} \
 	} finally { \
 		Remove-Item Env:NO_CARGO_BUILD -ErrorAction SilentlyContinue \
 	}


### PR DESCRIPTION
## Summary
- Run the Windows release-ci recipe in one PowerShell process so variables persist across steps
- Propagate cargo and per-plugin release failures via native exit codes
- Validate plugin Justfile discovery before packaging

## Validation
- NO_INSTALL=1 just release-ci
- cargo fmt --all -- --check
- cargo clippy --workspace
- CARGO_INCREMENTAL=0 cargo test

Sequence-related flags and warnings are unchanged.